### PR TITLE
Fix lingering typos in markdown docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This [blog](https://idvork.in) contains my [evergreen notes](https://notes.andym
 
 ### No broken links
 
-- A script validates no broken links keeping everythign nice
+ - A script validates no broken links keeping everything nice
 
 ### Select a Random Page
 
@@ -141,7 +141,7 @@ just js-test-html
 - js.sh - Run the development server with live reload and excluding spurious Jekyll warnings
 - prettier - Opinionated consistent formatting, auto run on git commit
 - vim-toc-generator - Auto generate TOCs, auto run on save
-- checklinks.sh- Check for [broken links](https://github.com/idvorkin/LinqPadSnippets/blob/master/python/checklinks.sh) - Runs manaully from other repro
+- checklinks.sh- Check for [broken links](https://github.com/idvorkin/LinqPadSnippets/blob/master/python/checklinks.sh) - Runs manually from other repo
 
 ### Re-writing from scratch
 

--- a/_d/2016-05-09-lost-interview.md
+++ b/_d/2016-05-09-lost-interview.md
@@ -19,21 +19,21 @@ Just called him up (everything was ina phone book) and asked him for spare parts
 
 #### How did Xerox Park Die?
 
-When a product company like Pepsi gets big, for them a major change is changing a pepsi bottle, and they can only do that every few years. Thus success goes to the sales and marketting teams who become the leaders.
+When a product company like Pepsi gets big, for them a major change is changing a Pepsi bottle, and they can only do that every few years. Thus success goes to the sales and marketing teams who become the leaders.
 
 Thus in the decision making forums, product people are pushed out.
 
-Interestingly, in technology firms the same things happen when you get to be a monopoloy, like IBM Or Xerox, doesn't matter most of what you do, to move the neeedle it's sales and Marketting.
+Interestingly, in technology firms the same things happen when you get to be a monopoly, like IBM or Xerox; it doesn't matter most of what you do, to move the needle it's sales and marketing.
 
-So, at Xeros, all the decisiosn where made by sales and marketting people of copiers, adn thus Zeros park was killed.
+So, at Xerox, all the decisions were made by sales and marketing people of copiers, and thus Xerox PARC was killed.
 
 #### Value of the eco system?
 
-IBM product sucked, and if it was upto them it would have failed, but they had a brilliant approach, which was they had a bunch of people having a vested interest in thier success, and that network kept them succesful -- Think of the PC ecosystem or the wintel allience.
+IBM product sucked, and if it was up to them it would have failed, but they had a brilliant approach, which was they had a bunch of people having a vested interest in their success, and that network kept them successful -- think of the PC ecosystem or the Wintel alliance.
 
 #### Process vs Content
 
-When companies get biggger they want to replicate that sucess. The assume the 'magic' was the process so they instuitionalize the proecss in the hope that'll bring success. **People think the process is the content**
+When companies get bigger they want to replicate that success. They assume the 'magic' was the process, so they institutionalize the process in the hope that'll bring success. **People think the process is the content**
 
 Best people are the content, and are a pain in the but to manage, but it's worth it!
 
@@ -47,7 +47,7 @@ Old guy takes him out back to make a rock clean. A bunch of common rocks go in ,
 
 What does it mean when you say 'your work is shit'. Usually it means your work is shit. Sometimes it means 'I think you're work is shit, but I'm wrong', but most of the time it means your work isn't good enough.
 
-Good people, don't need their ego's babied. Most valuable thing you can do is tell them when they aren't living upto the teams need, but do it in a way that doesn't question their abilities. Very hard to do, and I do it in a very direct way.
+Good people don't need their egos babied. The most valuable thing you can do is tell them when they aren't living up to the team's need, but do it in a way that doesn't question their abilities. Very hard to do, and I do it in a very direct way.
 
 #### How adobe started
 

--- a/_d/2016-2-15-Seth-Godin-Notes.md
+++ b/_d/2016-2-15-Seth-Godin-Notes.md
@@ -42,7 +42,7 @@ Sources:
 ### Your tribe:
 
 - Who is your tribe?
-- Chooses you because you earn thier trust, and are worthy of thier attention.
+- Chooses you because you earn their trust, and are worthy of their attention.
 - Provide attention because there is tension
 - Doesn't care about perfection,
 - When you find your thing, and your tribe finds you, you tune to appeal, so long as it still appeals to your thing.
@@ -51,13 +51,13 @@ Sources:
   - Friend - Wants to know you, and see your art to make YOU happy. If you change your art, they're there for you.
   - Tribe - Wants your art, doesn't care about you, unless grows appreciate of your art.
   - Change yourt art: lose your tribe, keep your friends.
-- Once you've found your tribe, give them art they'll tell thier friends/family about.
+- Once you've found your tribe, give them art they'll tell their friends/family about.
 - Wants personal attention - wants to feel special.
 
 ### Connection:
 
 - People prefer selfies to signed books
-- Make experiances people want to tell thier friends/families about.
+- Make experiences people want to tell their friends/families about.
 - Give people a story they can tell others [TBD:Link - why is noone referring my project]
 - Story/Context is how people connect.
 - Perfection blocks connection, as not accessible. Rough feels good, and accessible.

--- a/_d/2016-8-1-Twelve-Tech-Forces.md
+++ b/_d/2016-8-1-Twelve-Tech-Forces.md
@@ -250,6 +250,6 @@ tbd
 
 tbd
 
-### Begining
+### Beginning
 
 tbd

--- a/_d/2018-02-10-you-do-want-your-favorite-app-to-be-a-service.md
+++ b/_d/2018-02-10-you-do-want-your-favorite-app-to-be-a-service.md
@@ -8,6 +8,6 @@ tags:
   - strategy
 ---
 
-When selling subscription software, a publisher needs to continue to prove the value of thier software, or users will not renew their contracts. This is very beneficial to the users and to the publisher.
+When selling subscription software, a publisher needs to continue to prove the value of their software, or users will not renew their contracts. This is very beneficial to the users and to the publisher.
 
-By contrast, if a publisher uses a one time purchase option for thier software, they can't get additional revenue from an existing customer (because app store physics don't support paid upgrades). This means once their existing user base is much larger then the additional users they are likely to aquire, they should (from an economics perspective, assuming they use the one-time app purchase business model) stop investing in the app, and focus on a new app.
+By contrast, if a publisher uses a one-time purchase option for their software, they can't get additional revenue from an existing customer (because app store physics don't support paid upgrades). This means once their existing user base is much larger than the additional users they are likely to acquire, they should (from an economics perspective, assuming they use the one-time app purchase business model) stop investing in the app, and focus on a new app.

--- a/_d/ai-journal.md
+++ b/_d/ai-journal.md
@@ -27,7 +27,7 @@ A journal of random explorations in AI. Keeping track of them so I don't get sup
     - [Awesome talks](#awesome-talks)
     - [Working through making Neural Nets](#working-through-making-neural-nets)
   - [2024-07-31](#2024-07-31)
-    - [Auto code editting (via Aider) - TOO Soon](#auto-code-editting-via-aider---too-soon)
+    - [Auto code editing (via Aider) - TOO Soon](#auto-code-editing-via-aider---too-soon)
   - [2024-07-30](#2024-07-30)
     - [Agenic Frameworks](#agenic-frameworks)
   - [2024-06-22](#2024-06-22)
@@ -230,7 +230,7 @@ See: <https://karpathy.ai/zero-to-hero.html>
 
 ### 2024-07-31
 
-#### Auto code editting (via Aider) - TOO Soon
+#### Auto code editing (via Aider) - TOO Soon
 
 OK, so, copilot tends to be just a code completion, which is pretty meh. Ideally it could do more complex changes, like find code that would be good to refactor then make those changes. [aider](https://aider.chat/) is supposed to that, but in my expereince, it just made stuff wrose and was slower then me making the cahnges myself. I guess I'll try again in a while.
 

--- a/_d/ar.md
+++ b/_d/ar.md
@@ -128,7 +128,7 @@ Google vs Apple.
 
 ### Virtual Boxing
 
-I accidently punched a hole in my TV.
+I accidentally punched a hole in my TV.
 
 ### Virtual Tennis
 

--- a/_d/bmu.md
+++ b/_d/bmu.md
@@ -120,7 +120,7 @@ More complex then it sounds, need to do this per customer segment:
 - How will they decide whether to buy your product or services?
 - How will they buy it?
 - How will you deliver it?
-- How will you follow up ot make sure you are succesful?
+- How will you follow up to make sure you are successful?
 
 ### Customer Relationships - How do you interact?
 

--- a/_d/lonely.md
+++ b/_d/lonely.md
@@ -38,7 +38,7 @@ Recent data shows the problem is deepening. Since 1990, the percentage of U.S. a
 
 I wonder if there's someone in Meta working on changing this.
 
-### Happiness spreads upto 3 degrees of seperation
+### Happiness spreads up to 3 degrees of separation
 
 <https://www.bmj.com/content/bmj/337/bmj.a2338.full.pdf>
 

--- a/_d/media-edit.md
+++ b/_d/media-edit.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: Media Editting
+title: Media Editing
 permalink: /media-edit
 ---
 
-Lets play with media editting. So far I've liked luma fusion for post:
+Lets play with media editing. So far I've liked luma fusion for post:
 
-## Text based media editting
+## Text based media editing
 
 - Loom lets you do this, it shows the words, and then you can trim the video using the words. Given everyone has great transcription now this will get much easier. Though maybe even easier with shotcut like tools.
 

--- a/_d/taxes.md
+++ b/_d/taxes.md
@@ -207,7 +207,7 @@ Below is tax rate by income in 2020.
 
 | Tax Rate | Married Filing Joiningly |
 | -------- | ------------------------ |
-| 15%      | Upto 488K                |
+| 15%      | Up to 488K               |
 | 20%      | Above 488K               |
 
 ### Washington State Capital Gains Tax

--- a/_d/time-off-2020-03.md
+++ b/_d/time-off-2020-03.md
@@ -51,7 +51,7 @@ In March 2020, I took a 2 month sabatical between leaving Amazon and joining Fac
     - [☑ Kids biking](#-kids-biking)
 - [Inspirations](#inspirations)
 - [iOS](#ios)
-    - [☐ Video Editting - Luma Fusion](#-video-editting---luma-fusion)
+    - [☐ Video Editing - Luma Fusion](#-video-editing---luma-fusion)
 - [Books](#books)
     - [☐ How will you measure your life](#-how-will-you-measure-your-life)
     - [☑ StoryBrand](#-storybrand)
@@ -225,7 +225,7 @@ Too early, waiting for someone to make fine tuning easier/web service
 
 ### iOS
 
-#### ☐ Video Editting - Luma Fusion
+#### ☐ Video Editing - Luma Fusion
 
 ### Books
 
@@ -286,7 +286,7 @@ Chapter 9
 
 #### ☑ StoryBrand
 
-Using the hero's path to createa marketting plan. Also, helpful to clarify what your "business" really is.
+Using the hero's path to create a marketing plan. Also, helpful to clarify what your "business" really is.
 
 Superb book. Very well written, and really speaks to the many, many, websites you see now a days.
 

--- a/_d/time-off-2022-07.md
+++ b/_d/time-off-2022-07.md
@@ -242,7 +242,7 @@ I guess if I do, I can take the time off.
 - Got a gym membership - cheaper then day passes
 - Tried a few. One had no showers,
 - Top metric is probably BP/sqft
-- Last one I went to had a saltwater pool and a cold plunge ,and everythign else. Was awesome. And massage chairs
+- Last one I went to had a saltwater pool and a cold plunge, and everything else. Was awesome. And massage chairs
 - Last day, found out pool was closed, grateful to have gotten to try it for several days.
 
 ### Rental Car

--- a/_d/y2024.md
+++ b/_d/y2024.md
@@ -149,7 +149,7 @@ Peter Attia's book that goes into the e
 
 Dogs of war and Bear head
 
-Interesting scifi series about using genetic engineering instead of robots for soldiers. As it's harder to "hack them". Book 2 gets much more interseting.
+Interesting scifi series about using genetic engineering instead of robots for soldiers. As it's harder to "hack them". Book 2 gets much more interesting.
 
 ## Stuff I'm really proud of:
 

--- a/_ig66/645.md
+++ b/_ig66/645.md
@@ -30,7 +30,7 @@ This year Zach won the election for VP, totally based on his speech - check it o
 
 ### Biking, exercise and Diet
 
-Exercise and Diet are thing I've found challenging my whole life, and being very much like me, Zach has as well. This summer he decided to lean into his healht and do something about it. He's looking at how to eat a healthier diet, and got an exercise bike so he can build his strength while enjoying YouTube on TV - I'm super proud of you for this kid. It's a tough journey, but it's critical.
+Exercise and diet are things I've found challenging my whole life, and being very much like me, Zach has as well. This summer he decided to lean into his health and do something about it. He's looking at how to eat a healthier diet, and got an exercise bike so he can build his strength while enjoying YouTube on TV - I'm super proud of you for this kid. It's a tough journey, but it's critical.
 
 ### Kayaking
 

--- a/_ig66/681.md
+++ b/_ig66/681.md
@@ -26,7 +26,7 @@ And here are some random photos to round out the mix. Zach has gotten into pocke
 
 {% include bi_table.html is="d_a_rings.jpg; i_heart.jpg; z_time.jpg;" %}
 
-Oh, and this long weekend I played with some AI programming. Pretty fun for my tech freinds:
+Oh, and this long weekend I played with some AI programming. Pretty fun for my tech friends:
 
 {% include youtube.html src="lq_7Vsq7p6M" %}
 {% include youtube.html src="i4snLCRyYIQ" %}

--- a/_posts/2015-11-28-essentialism.md
+++ b/_posts/2015-11-28-essentialism.md
@@ -22,7 +22,7 @@ This is a summary of [Essentialisim](http://www.amazon.com/gp/product/B00G1J1D28
 - Three critical questions:
   - How do I know when I'm done?
   - If I didn't own this, would I buy it?
-  - If I didn't have this opportunity what would I do to aquire it?
+  - If I didn't have this opportunity what would I do to acquire it?
 - Three key differences between essentialisim and most people.
   - I choose to **NOT** I have to
   - Only a few things matter **NOT** it's all important
@@ -278,8 +278,8 @@ The tricksters:
 ### 13) Edit: Invisible Art - Cut Early, Cut Often. &#x2611;
 
 - Making better is through subtracting
-- Best picture, usually nominited or wins best editting.
-- Editting is hard to see, since it's been removed.
+- Best picture, usually nominated or wins best editing.
+- Editing is hard to see, since it's been removed.
 - A great editor provides clarity by removing the non-essential.
 - Removes annoying distractions
 - Eliminate everything distracting (words/images/details)
@@ -334,7 +334,7 @@ The tricksters:
   - What is the worst case scenario
   - What would make the social effects of this be
   - What would the financial impacts be
-  - How can you invest to reduce risks or strengthen resilliance
+  - How can you invest to reduce risks or strengthen resilience
 
 ### 16) Subtract: Can only ship by cutting &#x2611;
 

--- a/_posts/2015-12-23-getting-to-yes-with-yourself.md
+++ b/_posts/2015-12-23-getting-to-yes-with-yourself.md
@@ -21,7 +21,7 @@ Before you can negotiate with others, you need to be in sync with yourself. This
 - [3) Reframe your picture &#x2610;](#3-reframe-your-picture-x2610)
 - [4) Stay in the zone &#x2610;](#4-stay-in-the-zone-x2610)
 - [5) Respect them even if &#x2610;](#5-respect-them-even-if-x2610)
-- [6) Give and Recieve &#x2610;](#6-give-and-recieve-x2610)
+- [6) Give and Receive &#x2610;](#6-give-and-receive-x2610)
 - [7) The 3 wins &#x2611;](#7-the-3-wins-x2611)
 
 <!-- vim-markdown-toc-end -->
@@ -127,12 +127,12 @@ _The ideas in this chapter are great, but I think connecting the concepts to inn
 
 ### 5) Respect them even if &#x2610;
 
-- Put yourself in thier shoes
+- Put yourself in their shoes
 - Expand your circle of respect
 - Respect them even if they reject you
 - From exclusion to inclusion
 
-### 6) Give and Recieve &#x2610;
+### 6) Give and Receive &#x2610;
 
 - Give for mutual gain
 - Give for pleasure and meaning

--- a/_posts/2016-03-03-the-manager-book-2.md
+++ b/_posts/2016-03-03-the-manager-book-2.md
@@ -958,7 +958,7 @@ I gave a talk on [lies we tell ourselves](https://docs.google.com/presentation/d
 
 Both helpful for a short period of time, and for a longer period of time, kuddos boards let the team get together and celebrate what they appreciate from their co-workers. This has many benefits:
 
-- People are appreciated for thier contributions
+- People are appreciated for their contributions
 - People are reminded how impactful their work is
 - Good behaviors are recognized and reinforced
 - The team bonds and grows
@@ -1558,7 +1558,7 @@ How to reduce pain and suffering. _Have no confusion, I rarely do these, but I w
   - Quickly course correct.
   - Include feedback you're getting.
   - Bonus point for including what you plan to do.
-- Block your calender at work, and tell your family you're working nights and weekends
+- Block your calendar at work, and tell your family you're working nights and weekends
   - Set expectation this will take 110% of your energy.
   - Ensure your family knows and can support you.
   - Remove all other stressors from your life at this time.

--- a/_posts/2018-11-25-what-makes-a-leader-great.md
+++ b/_posts/2018-11-25-what-makes-a-leader-great.md
@@ -41,7 +41,7 @@ quadrantChart
 
 - A passion for the work itself and for new challenges
 - Unflagging energy to improve
-- Resiliance - Optimism in the face of failure
+- Resilience - Optimism in the face of failure
 
 **Empathy:** Considering others’ feelings, especially when making decisions
 

--- a/_td/cloud-first-applications.md
+++ b/_td/cloud-first-applications.md
@@ -32,7 +32,7 @@ The world is now on the cloud, here are my random notes on the topic.
     - [Communication buses: Envoy](#communication-buses-envoy)
 - [New patterns](#new-patterns)
     - [Side cars](#side-cars)
-    - [Resiliance Patterns - Retry, Circuit-Breaker, Timeout, Fallback, Bulkhead, Cache.](#resiliance-patterns---retry-circuit-breaker-timeout-fallback-bulkhead-cache)
+    - [Resilience Patterns - Retry, Circuit-Breaker, Timeout, Fallback, Bulkhead, Cache.](#resilience-patterns---retry-circuit-breaker-timeout-fallback-bulkhead-cache)
 - [Functions as a Service FaaS](#functions-as-a-service-faas)
     - [Introduction](#introduction)
     - [FaaS Orchestration](#faas-orchestration)
@@ -121,9 +121,9 @@ Websockets allow you to simply implement server initiated push notifications to 
 
 This isn’t an apples to apples comparison. But the ideas are usually compared with these concepts.
 
-REST is a frequently used request/response protocol with easy API semantic and many years of supporting goops (caches, routing, api semantics, debugging tools, etc).
+REST is a frequently used request/response protocol with easy API semantics and many years of supporting gobs (caches, routing, API semantics, debugging tools, etc).
 
-WebSockets are frequently used when push notification or high data volumes are required, essential raw socket access ( sockets were the default network access from user mode and represented a TCP connection before the web ate teh world). Websockets do not define a common interface, so it’s up to the app developer to define these and as a result there are few tools to support this.
+WebSockets are frequently used when push notification or high data volumes are required, essentially raw socket access (sockets were the default network access from user mode and represented a TCP connection before the web ate the world). WebSockets do not define a common interface, so it’s up to the app developer to define these and as a result there are few tools to support this.
 
 I suspect a common pattern will be using WebSockets for a server initiated push notification requesting the client to call for current state.
 
@@ -156,11 +156,11 @@ Similar to Nginx or HA Proxy, or AWS ELB, terminate the https and redirect to th
 
 ### Side cars
 
-Package functionality into a seperately injected application: https://docs.microsoft.com/en-us/azure/architecture/patterns/sidecar
+Package functionality into a separately injected application: https://docs.microsoft.com/en-us/azure/architecture/patterns/sidecar
 
-### Resiliance Patterns - Retry, Circuit-Breaker, Timeout, Fallback, Bulkhead, Cache.
+### Resilience Patterns - Retry, Circuit-Breaker, Timeout, Fallback, Bulkhead, Cache.
 
-Distributed services fail, and resilliance patterns like mentioned above are critical. See [Polly](https://docs.google.wbb://github.com/App-vNext/Polly) as an example library implementing these concepts.
+Distributed services fail, and resilience patterns like mentioned above are critical. See [Polly](https://github.com/App-vNext/Polly) as an example library implementing these concepts.
 
 [Azure cloud patterns](https://docs.microsoft.com/en-us/azure/architecture/patterns/) also has many good patterns.
 

--- a/_td/hack-web.md
+++ b/_td/hack-web.md
@@ -110,7 +110,7 @@ Often there's a useful object, that's only available in the closure. You can alw
 
 ### Chrome local overrides
 
-Allows you to save a local copy of the source files for editting. To Use
+Allows you to save a local copy of the source files for editing. To use
 
 How to use:
 

--- a/_td/machine-learning.md
+++ b/_td/machine-learning.md
@@ -439,7 +439,7 @@ _Thanks Dan Massey for your recommendation to discuss these topics_
 
 ### Computer Vision
 
-See my explorations of [video editting](https://github.com/idvorkin/video-edit) and CV models.
+See my explorations of [video editing](https://github.com/idvorkin/video-edit) and CV models.
 
 ### Natural Language Processing (NLP)
 

--- a/_td/ring-video-download.md
+++ b/_td/ring-video-download.md
@@ -31,7 +31,7 @@ _[Copied from my GitHub techdiary](https://github.com/idvorkin/techdiary/blob/ma
 Erase video content that hasn't changed, so videos are actually interesting:
 https://stackoverflow.com/questions/13142541/extract-thumbnails-of-every-camera-change-on-a-video-file
 
-I'm exploring this in my [video editting](https://github.com/idvorkin/video-edit) project.
+I'm exploring this in my [video editing](https://github.com/idvorkin/video-edit) project.
 
 ## Notes
 

--- a/_td/sicp.md
+++ b/_td/sicp.md
@@ -137,7 +137,7 @@ Harder on brain, but more consistent
 
 ---
 
-LISP is prefix notion, (funciton args), the upside of this is you enver have to guess operator precedence. Everythign is consistent, makes self editting much easier.
+LISP is prefix notation (function args). The upside of this is you never have to guess operator precedence. Everything is consistent, making self editing much easier.
 
 Having everything in prefix notion makes it very consistent and easy to write code, just a bit tough on the brain.
 
@@ -264,9 +264,9 @@ p1.tail() # => 2
 
 (object class arg1 arg2)
 
-As long as that first object is a funciton you can do anything. What's the difference object.function, is really just (function.object) - yup that's interesting obseragion on on OO.
+As long as that first object is a function you can do anything. What's the difference? `object.function` is really just `(function object)` - yup that's an interesting observation on OO.
 
-So long as syntax is always (function arg1, arg2 arg3), if (method, object, arg arg) - isn't that interseting
+So long as syntax is always `(function arg1 arg2 arg3)`, if `(method object arg arg)` - isn't that interesting?
 
 ### Lazy vs Eager
 

--- a/_td/streaks.md
+++ b/_td/streaks.md
@@ -27,7 +27,7 @@ Turns out the apps streaks built this perfectly - and that's what i use. This co
 
 ### User can track mutiple streaks
 
-### User can say they did thier task to get a streak.
+### User can say they did their task to get a streak.
 
 ### User is prompted if they don't complete their streak by a certain time.
 

--- a/_td/system-design.md
+++ b/_td/system-design.md
@@ -178,7 +178,7 @@ the table
 
 | Type               | TPS | Notes          |
 | ------------------ | --- | -------------- |
-| Key Value (Dynamo) | 40K | Upto 5 Indexes |
+| Key Value (Dynamo) | 40K | Up to 5 Indexes |
 | SQL (Aurora)       | ??  |                |
 
 ## Use cases

--- a/_td/usbtech.md
+++ b/_td/usbtech.md
@@ -26,9 +26,9 @@ USB 2.0 (and 1.1 before it) are the ubiquitous legacy charging tech that just wo
 1. If you're obsessed you can measure using this USB A [multimeter](http://amzn.to/2C4ErcR).
 1. My multiport [USB car charger](http://amzn.to/2l9n3ZL)
 
-## It works fast USB charging (but rarely works - upto 100W)
+## It works fast USB charging (but rarely works - up to 100W)
 
-USB Power Delivery (PD) is the new charging standard on the block, and can charge at 10x faster then legacy chargers (upto 100W!!!). USB PD is delivered via the USB C connector. As is normally the case with new tech, the state of chargers and cables currently a mess.
+USB Power Delivery (PD) is the new charging standard on the block, and can charge at 10x faster than legacy chargers (up to 100W!!!). USB PD is delivered via the USB C connector. As is normally the case with new tech, the state of chargers and cables currently a mess.
 
 1. Not all USB-PD to USB-C connectors can carry USB-PD.
 1. Not all USB-C chargers support PD.

--- a/chop-logs/add-link-to-manager-book-appendix.md
+++ b/chop-logs/add-link-to-manager-book-appendix.md
@@ -147,7 +147,7 @@ _\*\*\*\*_
 
 _**User**_
 
-No to the point we're editting
+No to the point we're editing
 
 ---
 

--- a/chop-logs/incorporating-cursor-rules-into-ai-coder-md.md
+++ b/chop-logs/incorporating-cursor-rules-into-ai-coder-md.md
@@ -149,7 +149,7 @@ _\*\*\*\*_
 
 _**User**_
 
-No my editting blog page
+No my editing blog page
 
 ---
 

--- a/zz-chop-logs/2025-03-04_06-54-boosting-energy-for-productivity.md
+++ b/zz-chop-logs/2025-03-04_06-54-boosting-energy-for-productivity.md
@@ -1939,7 +1939,7 @@ Would you like me to draft specific transitions between these sections to help t
 
 _**User**_
 
-I like that, lets make it the ToC, and get rid of all the bullet points for everythign but the first straegy section
+I like that. Let's make it the ToC and remove all the bullet points for everything but the first strategy section
 
 ---
 

--- a/zz-chop-logs/2025-03-07_08-50-parcel-module-export-error-troubleshooting.md
+++ b/zz-chop-logs/2025-03-07_08-50-parcel-module-export-error-troubleshooting.md
@@ -6,7 +6,7 @@ _**User**_
 
 I have been messing with parcel modules, look in just files, and run js-build, but things are not exported correctly. Be sure to check for scripts
 
-For exmaple: I get this error now: 
+For example: I get this error now:
 
 Uncaught SyntaxError: The requested module '/assets/js/index.js' does not provide an export named 'CreateAutoComplete' (at 761:157:12)
 

--- a/zz-chop-logs/2025-03-08_08-30-optimizing-build-process-with-delta-integration.md
+++ b/zz-chop-logs/2025-03-08_08-30-optimizing-build-process-with-delta-integration.md
@@ -727,7 +727,7 @@ _****_
 
 _**User**_
 
-Does the file need ot beddited first?
+Does the file need to be edited first?
 
 ---
 

--- a/zz-chop-logs/2025-03-09_09-19-html-preview-for-github-test-results.md
+++ b/zz-chop-logs/2025-03-09_09-19-html-preview-for-github-test-results.md
@@ -1012,7 +1012,7 @@ This falls within your requested range. Is there something specific you'd like t
 
 _**User**_
 
-Update the rule to dot hat instead of counting to 100. Explain teh reasson for hte rule:
+Update the rule to dot hat instead of counting to 100. Explain the reason for the rule:
 
 We want to save the log of the conversation, but it doesn't get flushed, but counting to a big number, it tends to flush. After flushing we copy it to git using the `chop git-latest` command.
 


### PR DESCRIPTION
## Summary
- correct stray typos across docs and logs
- adjust resilience patterns section
- update editing references

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6872dfef51c48320811fc8ef14334315