### PR TITLE
Add log link to 2025-07-20 journal entry

### DIFF
--- a/_d/ai-journal.md
+++ b/_d/ai-journal.md
@@ -156,6 +156,7 @@ lets see if we can simulate him, step #1, lets bring the site down into markdown
   - [settings#3](https://github.com/idvorkin/Settings/pull/3) ✅ "Add Claude Code detection to tmux_helper window renaming"
   - [chop-conventions#2](https://github.com/idvorkin/chop-conventions/pull/2) ✅ "docs(dev-inner-loop): add PR workflow documentation for AI-assisted development"
   - All generated with Claude Code 🤖
+  - [Logs](https://github.com/idvorkin/idvorkin.github.io/blob/d5d20a8a0652ca22f72bd96deae328eaca44f0b4/zz-chop-logs/2025-07-20_20-53Z-document-today-s-project-updates.md)
 
 ### 2025-07-13
 


### PR DESCRIPTION
## Summary
- cross-link July 20 journal entry to the SpecStory chat log that generated it

## Testing
- `npx prettier --check 'src/**/*.{ts,js}'` *(fails: code style issues found)*
- `npx vitest run` *(fails: cannot fetch vitest from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_687d6034f9708320bb33df896f7b9b15