### PR TITLE
fix: Update GitHub button link to use main branch instead of master

### DIFF
--- a/_includes/site-menu.html
+++ b/_includes/site-menu.html
@@ -27,7 +27,7 @@
     </button>
     <a
       class="nav-fa-icon"
-      href="https://github.com/idvorkin/idvorkin.github.io/blob/master/{{page.path}}"
+      href="https://github.com/idvorkin/idvorkin.github.io/blob/main/{{page.path}}"
     >
       <i class="fa fa-github"></i>
     </a>


### PR DESCRIPTION
The Issue/Feature:
The GitHub button in the site navigation was linking to the master branch, but the repository uses main as the default branch, causing 404 errors.

The Fix:
Updated the GitHub link in _includes/site-menu.html from: https://github.com/idvorkin/idvorkin.github.io/blob/master/{{page.path}} to:
https://github.com/idvorkin/idvorkin.github.io/blob/main/{{page.path}}

Testing Results:
- Tested locally with wget to verify the link now points to main branch
- Verified the link works correctly when clicked in the browser

Backwards Compat Risks:
None - this is a simple URL update with no functional changes

Fixes #45

🤖 Generated with [Claude Code](https://claude.ai/code)