### PR TITLE
fix: Remove broken zz-chop-conventions symlink to fix GitHub Actions build

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -33,7 +33,10 @@
       "Bash(open https://github.com/idvorkin/idvorkin.github.io/pull/59)",
       "Bash(git rm:*)",
       "Bash(gh pr comment:*)",
-      "mcp__github__get_pull_request"
+      "mcp__github__get_pull_request",
+      "Bash(gh run list:*)",
+      "mcp__github__search_repositories",
+      "Bash(just:*)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@
 
 Before starting any work, read and follow the instructions in:
 
-- `zz-chop-conventions/README.md` - Overview of development conventions
-- `zz-chop-conventions/dev-inner-loop/a_readme_first.md` - Core development guidelines
+- `~/gits/chop-conventions/README.md` - Overview of development conventions
+- `~/gits/chop-conventions/dev-inner-loop/a_readme_first.md` - Core development guidelines
 - Follow all instructions in these files, particularly clean-code.md and clean-commits.md
 
 ## Build/Test/Lint Commands

--- a/_config.yml
+++ b/_config.yml
@@ -101,7 +101,6 @@ exclude:
     ".husky",
     ".vscode",
     "blog.chroma.db",
-    "zz-chop-conventions/*",
     "devdocker",
     "docs",
     "tech_graveyard",

--- a/prd/README.md
+++ b/prd/README.md
@@ -54,7 +54,7 @@ When creating new PRDs:
 
 ## Related Documentation
 
-- [Development Conventions](../zz-chop-conventions/dev-inner-loop/)
+- [Development Conventions](~/gits/chop-conventions/dev-inner-loop/)
 - [Build Commands](../justfile)
 - [Testing Strategy](../tests/)
 - [Technical Documentation](../docs/)

--- a/zz-chop-conventions
+++ b/zz-chop-conventions
@@ -1,1 +1,0 @@
-/Users/idvorkin/gits/chop-conventions/


### PR DESCRIPTION
## Summary
- Remove zz-chop-conventions symlink that was causing GitHub Actions builds to fail
- Clean up _config.yml exclude list
- Fix the broken build from run [#16451571816](https://github.com/idvorkin/idvorkin.github.io/actions/runs/16451571816/job/46497903523)

## Changes
- Deleted the `zz-chop-conventions` symlink that pointed to `/Users/idvorkin/gits/chop-conventions`
- Removed `zz-chop-conventions/*` from the exclude list in `_config.yml`
- Updated paths in CLAUDE.md and prd/README.md to use `~/gits/chop-conventions` for local development

## Test plan
- [x] Verified symlink is removed
- [x] Confirmed _config.yml no longer references the missing directory
- [ ] GitHub Actions build should pass after merge

🤖 Generated with [Claude Code](https://claude.ai/code)