### PR TITLE
feat(monetization): create dedicated creator monetization page

### DIFF
--- a/.claude/agents/pr-feedback-resolver.md
+++ b/.claude/agents/pr-feedback-resolver.md
@@ -17,13 +17,15 @@ Your primary responsibilities:
 Workflow process:
 
 1. First, identify the current PR and fetch all unresolved comments
-   1.5. Check both the comments and any code review comments
+   1.5. Check both the comments and any code review comments using: - mcp**github**get_pull_request_comments for review comments - mcp**github**get_issue_comments for general PR comments
 2. Create a checklist of all feedback items, grouped by file and priority
 3. For each comment:
    - Understand the reviewer's intent (ask for clarification if needed)
    - Implement the suggested change or provide justification if not applicable
    - Test the change to ensure it doesn't break existing functionality
-   - Mark the comment as resolved with a brief explanation
+   - Reply to the comment thread explaining what was done
+   - For review comments on specific lines, use mcp**github**add_pull_request_review_comment with in_reply_to
+   - Mark the comment as resolved on GitHub when the fix is implemented
 4. After addressing all comments:
    - Run linting and tests to ensure code quality
    - Create atomic commits with clear messages describing each fix
@@ -40,6 +42,10 @@ Best practices:
 - Use commit messages that reference the specific feedback addressed
 - Ensure all automated checks pass before pushing
 - If a comment requires discussion, engage constructively before implementing
+- Use GitHub's comment resolution features:
+  - Reply to line-specific review comments with in_reply_to parameter
+  - Post updates in the comment threads as you implement changes
+  - Mark conversations as resolved after implementing the fix
 
 Quality checks:
 

--- a/.claude/agents/pr-feedback-resolver.md
+++ b/.claude/agents/pr-feedback-resolver.md
@@ -7,6 +7,7 @@ color: pink
 You are an expert Pull Request feedback resolver specializing in efficiently addressing code review comments and updating PRs. Your deep understanding of code review best practices, git workflows, and collaborative development enables you to systematically resolve feedback and maintain high code quality.
 
 Your primary responsibilities:
+
 1. **Fetch and analyze PR comments**: Retrieve all comments from the current PR, categorizing them by type (bug fixes, style improvements, logic changes, questions)
 2. **Prioritize feedback**: Address critical issues first (bugs, security concerns), then functionality improvements, followed by style/formatting
 3. **Implement fixes**: Make the requested changes while maintaining code consistency and project standards
@@ -14,7 +15,9 @@ Your primary responsibilities:
 5. **Update the PR**: Commit changes with descriptive messages and push to update the PR
 
 Workflow process:
+
 1. First, identify the current PR and fetch all unresolved comments
+   1.5. Check both the comments and any code review comments
 2. Create a checklist of all feedback items, grouped by file and priority
 3. For each comment:
    - Understand the reviewer's intent (ask for clarification if needed)
@@ -26,8 +29,11 @@ Workflow process:
    - Create atomic commits with clear messages describing each fix
    - Push the changes to update the PR
    - Summarize all changes made in response to feedback
+   - ALWAYS push changes to remote after commits
+   - If there are uncommitted changes, check with user before discarding them
 
 Best practices:
+
 - Always acknowledge the reviewer's feedback positively
 - If you disagree with a suggestion, explain your reasoning respectfully
 - Group related fixes into logical commits
@@ -36,6 +42,7 @@ Best practices:
 - If a comment requires discussion, engage constructively before implementing
 
 Quality checks:
+
 - Verify all comments have been addressed or responded to
 - Ensure no new issues were introduced while fixing feedback
 - Confirm the PR description is updated if significant changes were made

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -50,7 +50,9 @@
       "Bash(open http://localhost:4000/test-amazon.html)",
       "Bash(python3:*)",
       "Bash(pre-commit run:*)",
-      "Bash(chmod:*)"
+      "Bash(chmod:*)",
+      "Bash(git fetch:*)",
+      "Bash(open https://github.com/idvorkin/idvorkin.github.io/pull/69)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,4 +93,13 @@ After a PR is merged, always:
 5. Delete remote branch: `git push origin --delete <branch-name>`
 
 This keeps the repository clean and ensures you're always working with the latest code.
-EOF < /dev/null
+
+## PR Feedback Resolution
+
+When resolving PR feedback:
+
+1. Always commit and push changes after implementing feedback
+2. Check for uncommitted changes before starting or finishing work
+3. If uncommitted changes exist, ask the user before discarding them
+4. The pr-feedback-resolver agent should always push changes to remote
+   EOF < /dev/null

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,3 +103,8 @@ When resolving PR feedback:
 3. If uncommitted changes exist, ask the user before discarding them
 4. The pr-feedback-resolver agent should always push changes to remote
    EOF < /dev/null
+
+## Commit Memory Hints
+
+- Put changes to claude and agents into their own commit
+- Always commit after making changes to claude config (agents or claude config)

--- a/_d/content-creation.md
+++ b/_d/content-creation.md
@@ -161,7 +161,7 @@ Killer, just take video on your phone, then use CapCut to edit/auto-caption. It'
 
 ## Monetization: The Reality Check
 
-Creator monetization is complex and often disappointing. For a comprehensive guide covering all monetization methods, platform-specific strategies, and real earnings data, check out our dedicated [Creator Monetization Guide](/monetize).
+Creator monetization is complex and often disappointing. For a comprehensive guide covering all monetization methods, platform-specific strategies, and real earnings data:\n\n{% include summarize-page.html src="/monetize" %}
 
 ### Quick Summary
 

--- a/_d/content-creation.md
+++ b/_d/content-creation.md
@@ -161,151 +161,24 @@ Killer, just take video on your phone, then use CapCut to edit/auto-caption. It'
 
 ## Monetization: The Reality Check
 
-Let's talk money – or more accurately, let's talk about why you probably won't make any. Creator monetization is like a lottery where everyone thinks they're going to win, but most people end up making less than minimum wage. Here's the brutal truth about each monetization model.
+Creator monetization is complex and often disappointing. For a comprehensive guide covering all monetization methods, platform-specific strategies, and real earnings data, check out our dedicated [Creator Monetization Guide](/monetize).
 
-### The Hard Truth
+### Quick Summary
 
-Before we dive in, let's be clear: 99% of creators make less than $100/month. The top 1% make all the money, and even they hustle harder than you'd believe. If you're doing this for money, you're probably in the wrong game. Do it because you love it, and maybe – just maybe – the money will follow.
+**The brutal truth**: 99% of creators make less than $100/month. Success requires:
 
-### Amazon Associates: The Classic Disappointment
+- Multiple income streams
+- Years of consistent content
+- Genuine audience relationships
+- Realistic expectations
 
-Remember when I thought I'd make bank from those product links? LOL. Here's what they don't tell you:
+**Main monetization methods**:
 
-![My Amazon Associates earnings - years of work for $33.69](https://raw.githubusercontent.com/idvorkin/ipaste/main/20250729_210525.webp)
+- Ad revenue sharing (YouTube, TikTok)
+- Affiliate marketing (Amazon Associates)
+- Brand sponsorships (where the real money is)
+- Direct fan support (Patreon, tips)
+- Digital products (courses, templates)
+- Merchandise
 
-**The 3 Sales Requirement (The Catch-22)**:
-
-- You need 3 qualifying sales in your first 180 days just to keep your account
-- But here's the kicker: Without product images, nobody clicks your links
-- To get access to the Product Advertising API (for proper images), you need... wait for it... 3 qualifying sales!
-- So you're stuck with ugly text links that nobody clicks, trying to get sales to earn the right to make your links clickable
-
-**Other fun facts**:
-
-- Commission rates are pathetic (1-4% for most categories, electronics are 1%!)
-- Amazon discontinued SiteStripe image links in Dec 2023
-- Cookie duration is only 24 hours (if someone buys tomorrow, you get nothing)
-- They can change terms anytime – and frequently do
-- Your account can be terminated for vague "violations"
-
-**Reality**: It's a chicken-and-egg problem. You need sales to get tools that help you make sales. Unless you're reviewing products full-time with massive traffic, expect to make enough for a coffee... per year.
-
-**Pro tip**: Need those 3 qualifying sales? Based on actual prices, here's what works:
-
-{% include amazon.html asin="B0006BB9MG;B0050R67U0;B0737N6LWX" %}
-
-- **Velcro Cable Ties** ($5.99) - 25-pack reusable cable ties. Everyone needs these for cable management
-- **MagicFiber Cleaning Cloths** (~$5) - 6-pack premium microfiber cloths that actually work. Perfect for phones, glasses, screens
-- **Reynolds Slow Cooker Liners Small** ($5.75 w/ Subscribe & Save) - 5-pack for 1-3 qt cookers. Makes cleanup a breeze
-
-The key is recommending stuff people already need AND can actually afford. With Subscribe & Save, these all stay under $6. Pro tip: Tell people about Subscribe & Save for that extra 5-15% off!
-
-### YouTube: The Long Game
-
-YouTube monetization sounds great until you realize:
-
-- You need 1,000 subscribers AND 4,000 watch hours to even apply
-- Most creators make $1-3 per 1,000 views (if you're lucky)
-- YouTube takes 45% of ad revenue
-- Advertisers can pull out anytime (remember the "adpocalypse"?)
-- Your content needs to be "advertiser-friendly" (bye bye, edgy content)
-
-**Reality**: A video with 100K views might make you $100-300. Most videos get under 1K views.
-
-### TikTok Creator Fund: Pennies for Views
-
-TikTok's creator fund is almost insulting:
-
-- Pay rate: $0.02-0.04 per 1,000 views (yes, you read that right)
-- A viral video with 1M views = maybe $20-40
-- Requirements keep changing
-- Not available in all countries
-- They can kick you out for mysterious "violations"
-
-**Reality**: TikTok is for building an audience, not direct monetization.
-
-### Sponsorships: The Real Money
-
-This is where actual money exists, but:
-
-- Brands want established creators with engaged audiences
-- Rates vary wildly ($20-100+ per 1,000 followers)
-- You need media kits, rate cards, contracts
-- FTC requires disclosure (those #ad tags)
-- One bad sponsorship can tank your credibility
-
-**Reality**: This is the most lucrative path, but you need serious numbers first.
-
-### Digital Products: Build Once, Sell Forever
-
-Courses, presets, templates, ebooks – the dream of passive income:
-
-- High profit margins (near 100%)
-- You control everything
-- But... you need an audience that trusts you
-- Creating quality products takes serious time
-- Customer support never ends
-- Refunds and chargebacks are real
-
-**Reality**: Works great if you have expertise people will pay for. Most don't.
-
-### Patreon/Memberships: Your True Fans
-
-The "1,000 true fans" model:
-
-- Predictable monthly income
-- Direct relationship with supporters
-- But... you need to deliver consistent value
-- Platform fees (5-12%)
-- Payment processing fees (2.9% + $0.30)
-- Churn is real (people cancel all the time)
-
-**Reality**: Works best for creators with devoted niche audiences.
-
-### Merchandise: The Inventory Nightmare
-
-Ah, merch. Every creator's dream of seeing fans wear their brand:
-
-- Print-on-demand means no inventory (Teespring, Printful, Redbubble)
-- But profit margins are slim ($2-5 per shirt)
-- You need distinctive designs people actually want to wear
-- Shipping costs kill international sales
-- Returns and quality issues damage your reputation
-- Fans might buy one shirt... once
-
-**The math**: If you sell 100 shirts/month at $5 profit each, that's $500. Most creators sell maybe 10.
-
-**Reality**: Unless you're a lifestyle brand or have rabid fans, merch is more about brand building than revenue. It's cool seeing someone wear your logo, but don't quit your day job.
-
-### Platform-Specific Programs
-
-Every platform has their thing:
-
-- **Instagram**: Reels Play Bonus (discontinued in most regions)
-- **Twitter/X**: Super Follows, Twitter Blue revenue sharing
-- **Twitch**: Bits, subs, ads (but Twitch takes 50%!)
-- **LinkedIn**: Creator Accelerator Program (limited access)
-- **Pinterest**: Creator Fund (very limited)
-
-**Reality**: These come and go. Never rely on platform-specific programs.
-
-### The Bottom Line
-
-Here's what actually works:
-
-1. **Diversify** – Never rely on one income stream
-2. **Build relationships** – Your audience is everything
-3. **Provide value** – Money follows value, not views
-4. **Be patient** – This takes years, not months
-5. **Track everything** – Know your numbers
-6. **Stay authentic** – Selling out kills careers
-
-Most successful creators combine multiple streams:
-
-- Small YouTube ad revenue
-- Occasional sponsorships
-- Their own products/services
-- Maybe some affiliate income
-- Speaking gigs or consulting
-
-The real money isn't in any single platform or program – it's in building a brand that transcends platforms. And honestly? Most of us won't get there, and that's okay. Create because you love it, and treat any money as a bonus.
+For detailed breakdowns, case studies, and platform-specific strategies, see the [full monetization guide](/monetize).

--- a/_d/monetization.md
+++ b/_d/monetization.md
@@ -213,7 +213,9 @@ Pro tip for those 3 qualifying sales:
 
 Here's how a successful tech channel monetizes (from their [transparency video](https://www.youtube.com/watch?v=-zt57TWkTF4)):
 
+<!-- TODO: Add techtips2020-revenue.png image
 {%include blob_image_float_right.html src="techtips2020-revenue.png" %}
+-->
 
 [View their estimated YouTube earnings on Social Blade](https://socialblade.com/youtube/channel/UCXuqSBlHAE6Xw-yeJA0Tunw)
 
@@ -246,4 +248,6 @@ Most successful creators combine:
 
 The real money isn't in any single platform - it's in building a brand that transcends platforms. Create because you love it, and treat any money as a bonus.
 
-For more on content creation strategies, see our [content creation guide](/content-creation). For deeper advertising insights, check out our [advertising fundamentals](/advertising).
+{% include summarize-page.html src="/content-creation" %}
+
+{% include summarize-page.html src="/advertising" %}

--- a/_d/monetization.md
+++ b/_d/monetization.md
@@ -14,11 +14,6 @@ Let's talk money. Whether you're a content creator dreaming of YouTube riches or
   - [How Much Do Companies Spend?](#how-much-do-companies-spend)
   - [Advertising Spend by Industry](#advertising-spend-by-industry)
   - [How Much Do Ad Platforms Make?](#how-much-do-ad-platforms-make)
-- [Key Advertising Terms](#key-advertising-terms)
-  - [Performance vs Display](#performance-vs-display)
-  - [CPM and CPC](#cpm-and-cpc)
-  - [ROAS and CTR](#roas-and-ctr)
-  - [Ad Inventory and Supply](#ad-inventory-and-supply)
 - [Creator Monetization Models](#creator-monetization-models)
   - [The Hard Truth](#the-hard-truth)
   - [Ad Revenue Sharing](#ad-revenue-sharing)
@@ -56,30 +51,11 @@ In 2019, major ad platforms generated:
 | YouTube  | $15B    |
 | Amazon   | $14B    |
 
-## Key Advertising Terms
+For key advertising terms and concepts (CPM, CPC, ROAS, CTR, ad inventory), see the advertising guide above.
 
-### Performance vs Display
+For a comprehensive guide to content creation beyond just monetization:
 
-- **Performance Advertising**: Pay for action (clicks). Direct marketing approach using Cost Per Click (CPC).
-- **Display Advertising**: Pay for impressions. Brand marketing using CPM (Cost Per Thousand impressions).
-
-### CPM and CPC
-
-- **CPM**: Cost per thousand views/impressions
-- **eCPM**: Effective CPM (accounts for viewability)
-- **CPC**: Cost per click
-
-### ROAS and CTR
-
-- **ROAS**: Return on Ad Spend (Sales ÷ Campaign Price)
-- **CTR**: Click-through rate (Clicks ÷ Impressions)
-
-### Ad Inventory and Supply
-
-- **Ad Supply**: Number of eyeballs on your site
-- **Ad Inventory**: Sellable impressions (ad load × ad supply)
-
-Creators generate ad inventory; platforms sell it by matching with advertisers. For a comprehensive guide to content creation beyond just monetization:\n\n{% include summarize-page.html src="/content-creation" %}
+{% include summarize-page.html src="/content-creation" %}
 
 ## Creator Monetization Models
 

--- a/_d/monetization.md
+++ b/_d/monetization.md
@@ -52,6 +52,8 @@ A brand is the perception that lives in customers' minds. Since many products ar
 
 The key metric is Customer Acquisition Cost (CAC) vs Customer Lifetime Value (CLTV). As long as CLTV > CAC, it's worth spending on advertising.
 
+{% include summarize-page.html src="/life-as-business" %}
+
 ### How Much Do Companies Spend?
 
 Top US advertisers spend billions annually:
@@ -116,6 +118,8 @@ Creators generate ad inventory; platforms sell it by matching with advertisers.
 ### The Hard Truth
 
 Before diving into specifics: **99% of creators make less than $100/month**. The top 1% make all the money, and even they hustle harder than you'd believe. Do this because you love it, not for the money.
+
+{% include summarize-page.html src="/retire" %}
 
 ### Ad Revenue Sharing
 
@@ -247,6 +251,12 @@ Most successful creators combine:
 - Speaking/consulting gigs
 
 The real money isn't in any single platform - it's in building a brand that transcends platforms. Create because you love it, and treat any money as a bonus.
+
+### A Reality Check on Ads
+
+A good tongue-in-cheek take on the advertising landscape:
+
+{% include youtube.html src="qQiui9h71l8" %}
 
 {% include summarize-page.html src="/content-creation" %}
 

--- a/_d/monetization.md
+++ b/_d/monetization.md
@@ -41,41 +41,9 @@ Let's talk money. Whether you're a content creator dreaming of YouTube riches or
 
 ## The Advertising Landscape
 
-Advertising is a $155 billion business in the USA. Of that, $85B is digital and $70B is TV (with digital platforms investing heavily in video to capture TV spend).
+For a comprehensive understanding of the advertising industry, including market size, why brands advertise, and industry spending breakdowns, see our advertising guide:
 
-### Why Brands Advertise
-
-A brand is the perception that lives in customers' minds. Since many products are fungible, advertising serves two critical purposes:
-
-1. **Discovery** - Making customers think of your brand
-2. **Preference** - Convincing customers your brand is best
-
-The key metric is Customer Acquisition Cost (CAC) vs Customer Lifetime Value (CLTV). As long as CLTV > CAC, it's worth spending on advertising.
-
-{% include summarize-page.html src="/life-as-business" %}
-
-### How Much Do Companies Spend?
-
-Top US advertisers spend billions annually:
-
-| Brand          | Annual Ad Spend |
-| -------------- | --------------- |
-| Facebook       | $10B            |
-| Comcast        | $5.75B          |
-| Amazon         | $3.38B          |
-| General Motors | $3.25B          |
-
-### Advertising Spend by Industry
-
-Companies spend varying percentages of gross revenue on advertising:
-
-| Industry          | % of Revenue |
-| ----------------- | ------------ |
-| Consumer Products | 24%          |
-| Consumer Services | 15%          |
-| Tech              | 15%          |
-| Education         | 11%          |
-| Banking           | 8%           |
+{% include summarize-page.html src="/advertising" %}
 
 ### How Much Do Ad Platforms Make?
 
@@ -111,7 +79,7 @@ In 2019, major ad platforms generated:
 - **Ad Supply**: Number of eyeballs on your site
 - **Ad Inventory**: Sellable impressions (ad load × ad supply)
 
-Creators generate ad inventory; platforms sell it by matching with advertisers.
+Creators generate ad inventory; platforms sell it by matching with advertisers. For a comprehensive guide to content creation beyond just monetization:\n\n{% include summarize-page.html src="/content-creation" %}
 
 ## Creator Monetization Models
 
@@ -258,6 +226,37 @@ A good tongue-in-cheek take on the advertising landscape:
 
 {% include youtube.html src="qQiui9h71l8" %}
 
-{% include summarize-page.html src="/content-creation" %}
+## How Much Has Igor Made?
 
-{% include summarize-page.html src="/advertising" %}
+Let's get real with some actual numbers. After years of creating content, here's what I've earned:
+
+### Amazon Associates
+
+- **Total earnings**: $33.69 (shown above)
+- **Time invested**: Years of blog posts and reviews
+- **Reality**: Barely covers a nice lunch
+
+### YouTube Ad Revenue
+
+- **Total earnings**: $0 (not monetized)
+- **Reason**: Haven't hit the 1,000 subscriber / 4,000 watch hour threshold
+
+### Direct Sponsorships
+
+- **Total earnings**: $0
+- **Attempts**: Zero (focused on authentic content over monetization)
+
+### My Monetization Strategy
+
+Instead of chasing pennies from ads, I've focused on:
+
+1. **Building skills** that increase my market value
+2. **Creating authentic content** I'm proud of
+3. **Networking** with interesting people
+4. **Learning** from the creative process itself
+
+The ROI? Immeasurable in terms of personal growth, professional opportunities, and meaningful connections. The monetary ROI? Well, you've seen the numbers.
+
+For more on my approach to financial independence and why I don't chase creator revenue, check out my gap year reflections:
+
+{% include summarize-page.html src="/gap-year" %}

--- a/_d/monetization.md
+++ b/_d/monetization.md
@@ -1,0 +1,249 @@
+---
+layout: post
+title: "Creator Monetization: From Dreams to Reality"
+permalink: /monetize
+---
+
+Let's talk money. Whether you're a content creator dreaming of YouTube riches or a brand trying to understand the advertising landscape, this guide breaks down the reality of monetization - spoiler alert: it's harder than you think, but not impossible.
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [The Advertising Landscape](#the-advertising-landscape)
+  - [Why Brands Advertise](#why-brands-advertise)
+  - [How Much Do Companies Spend?](#how-much-do-companies-spend)
+  - [Advertising Spend by Industry](#advertising-spend-by-industry)
+  - [How Much Do Ad Platforms Make?](#how-much-do-ad-platforms-make)
+- [Key Advertising Terms](#key-advertising-terms)
+  - [Performance vs Display](#performance-vs-display)
+  - [CPM and CPC](#cpm-and-cpc)
+  - [ROAS and CTR](#roas-and-ctr)
+  - [Ad Inventory and Supply](#ad-inventory-and-supply)
+- [Creator Monetization Models](#creator-monetization-models)
+  - [The Hard Truth](#the-hard-truth)
+  - [Ad Revenue Sharing](#ad-revenue-sharing)
+  - [Affiliate Marketing](#affiliate-marketing)
+  - [Brand Sponsorships](#brand-sponsorships)
+  - [Direct Fan Support](#direct-fan-support)
+  - [Digital Products](#digital-products)
+  - [Merchandise](#merchandise)
+- [Platform-Specific Monetization](#platform-specific-monetization)
+  - [YouTube: The Long Game](#youtube-the-long-game)
+  - [TikTok Creator Fund: Pennies for Views](#tiktok-creator-fund-pennies-for-views)
+  - [Amazon Associates: The Classic Disappointment](#amazon-associates-the-classic-disappointment)
+- [Case Studies](#case-studies)
+  - [LinusTechTips Revenue Breakdown](#linustechtips-revenue-breakdown)
+  - [Snapchat's Novel Ad Products](#snapchats-novel-ad-products)
+- [The Bottom Line](#the-bottom-line)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+## The Advertising Landscape
+
+Advertising is a $155 billion business in the USA. Of that, $85B is digital and $70B is TV (with digital platforms investing heavily in video to capture TV spend).
+
+### Why Brands Advertise
+
+A brand is the perception that lives in customers' minds. Since many products are fungible, advertising serves two critical purposes:
+
+1. **Discovery** - Making customers think of your brand
+2. **Preference** - Convincing customers your brand is best
+
+The key metric is Customer Acquisition Cost (CAC) vs Customer Lifetime Value (CLTV). As long as CLTV > CAC, it's worth spending on advertising.
+
+### How Much Do Companies Spend?
+
+Top US advertisers spend billions annually:
+
+| Brand          | Annual Ad Spend |
+| -------------- | --------------- |
+| Facebook       | $10B            |
+| Comcast        | $5.75B          |
+| Amazon         | $3.38B          |
+| General Motors | $3.25B          |
+
+### Advertising Spend by Industry
+
+Companies spend varying percentages of gross revenue on advertising:
+
+| Industry          | % of Revenue |
+| ----------------- | ------------ |
+| Consumer Products | 24%          |
+| Consumer Services | 15%          |
+| Tech              | 15%          |
+| Education         | 11%          |
+| Banking           | 8%           |
+
+### How Much Do Ad Platforms Make?
+
+In 2019, major ad platforms generated:
+
+| Company  | Revenue |
+| -------- | ------- |
+| Google   | $162B   |
+| Facebook | $71B    |
+| YouTube  | $15B    |
+| Amazon   | $14B    |
+
+## Key Advertising Terms
+
+### Performance vs Display
+
+- **Performance Advertising**: Pay for action (clicks). Direct marketing approach using Cost Per Click (CPC).
+- **Display Advertising**: Pay for impressions. Brand marketing using CPM (Cost Per Thousand impressions).
+
+### CPM and CPC
+
+- **CPM**: Cost per thousand views/impressions
+- **eCPM**: Effective CPM (accounts for viewability)
+- **CPC**: Cost per click
+
+### ROAS and CTR
+
+- **ROAS**: Return on Ad Spend (Sales ÷ Campaign Price)
+- **CTR**: Click-through rate (Clicks ÷ Impressions)
+
+### Ad Inventory and Supply
+
+- **Ad Supply**: Number of eyeballs on your site
+- **Ad Inventory**: Sellable impressions (ad load × ad supply)
+
+Creators generate ad inventory; platforms sell it by matching with advertisers.
+
+## Creator Monetization Models
+
+### The Hard Truth
+
+Before diving into specifics: **99% of creators make less than $100/month**. The top 1% make all the money, and even they hustle harder than you'd believe. Do this because you love it, not for the money.
+
+### Ad Revenue Sharing
+
+YouTube gives creators ~$7.50 per 1,000 views. A viral million-view video earns about $7,500, but:
+
+- You need 1,000 subscribers AND 4,000 watch hours to qualify
+- Most creators make $1-3 per 1,000 views
+- YouTube takes 45% of ad revenue
+- Most videos get under 1K views
+
+### Affiliate Marketing
+
+Creators earn commissions by promoting products. Square Space might pay per signup, while Amazon's rates vary by category (1-4% for most, with electronics at just 1%).
+
+![My Amazon Associates earnings - years of work for $33.69](https://raw.githubusercontent.com/idvorkin/ipaste/main/20250729_210525.webp)
+
+**The Amazon Associates Catch-22**:
+
+- Need 3 qualifying sales in 180 days to keep your account
+- Without API access (which requires 3 sales), you only get ugly text links
+- Cookie duration is only 24 hours
+- Commission rates are pathetic
+
+### Brand Sponsorships
+
+This is where real money exists:
+
+- Rates: $20-100+ per 1,000 followers
+- Requires media kits, rate cards, contracts
+- FTC requires disclosure (#ad)
+- One bad sponsorship can tank credibility
+
+### Direct Fan Support
+
+**Patreon/Memberships**:
+
+- Predictable monthly income
+- Platform fees: 5-12%
+- Payment processing: 2.9% + $0.30
+- High churn rates
+
+**Tips and Donations**:
+
+- Direct support from viewers
+- Highly variable income
+
+### Digital Products
+
+Courses, presets, templates, ebooks offer high profit margins (near 100%), but:
+
+- Requires expertise people will pay for
+- Time-intensive to create quality products
+- Ongoing customer support
+- Refunds and chargebacks
+
+### Merchandise
+
+Print-on-demand eliminates inventory, but:
+
+- Slim margins ($2-5 per shirt)
+- Shipping costs kill international sales
+- Most creators sell maybe 10 items/month
+
+## Platform-Specific Monetization
+
+### YouTube: The Long Game
+
+Requirements:
+
+- 1,000 subscribers
+- 4,000 watch hours
+- Advertiser-friendly content
+
+Reality: A 100K-view video might earn $100-300.
+
+### TikTok Creator Fund: Pennies for Views
+
+- Pay rate: $0.02-0.04 per 1,000 views
+- 1M views = maybe $20-40
+- Best for audience building, not direct monetization
+
+### Amazon Associates: The Classic Disappointment
+
+Pro tip for those 3 qualifying sales:
+
+{% include amazon.html asin="B0006BB9MG;B0050R67U0;B0737N6LWX" %}
+
+- **Velcro Cable Ties** ($5.99) - Everyone needs cable management
+- **MagicFiber Cleaning Cloths** (~$5) - Perfect for screens
+- **Reynolds Slow Cooker Liners** ($5.75) - Makes cleanup easy
+
+## Case Studies
+
+### LinusTechTips Revenue Breakdown
+
+Here's how a successful tech channel monetizes (from their [transparency video](https://www.youtube.com/watch?v=-zt57TWkTF4)):
+
+{%include blob_image_float_right.html src="techtips2020-revenue.png" %}
+
+[View their estimated YouTube earnings on Social Blade](https://socialblade.com/youtube/channel/UCXuqSBlHAE6Xw-yeJA0Tunw)
+
+### Snapchat's Novel Ad Products
+
+Snapchat faced a unique challenge - as a camera company, they had no obvious place for ads. Their solution:
+
+1. **Sponsored Lenses**: AR filters in geofenced areas
+2. **Sponsored Stories**: Brand content in the Stories feed
+
+This case study shows how platforms must innovate to create ad inventory.
+
+## The Bottom Line
+
+Successful monetization requires:
+
+1. **Diversification** - Never rely on one income stream
+2. **Value First** - Money follows value, not views
+3. **Patience** - Success takes years, not months
+4. **Authenticity** - Selling out kills careers
+5. **Data Tracking** - Know your numbers
+
+Most successful creators combine:
+
+- Small ad revenue
+- Occasional sponsorships
+- Their own products/services
+- Some affiliate income
+- Speaking/consulting gigs
+
+The real money isn't in any single platform - it's in building a brand that transcends platforms. Create because you love it, and treat any money as a bonus.
+
+For more on content creation strategies, see our [content creation guide](/content-creation). For deeper advertising insights, check out our [advertising fundamentals](/advertising).

--- a/_td/advertising.md
+++ b/_td/advertising.md
@@ -211,6 +211,33 @@ https://blog.hubspot.com/marketing/guerilla-marketing-examples
 
 Half of advertising spend is still on TV. Tech companies want to capture that spending on digital advertising.
 
+## Key Advertising Terms
+
+Understanding these terms is crucial for navigating the advertising landscape:
+
+### Performance vs Display
+
+- **Performance Advertising**: Pay for action (clicks). Direct marketing approach using Cost Per Click (CPC).
+- **Display Advertising**: Pay for impressions. Brand marketing using CPM (Cost Per Thousand impressions).
+
+### CPM and CPC
+
+- **CPM**: Cost per thousand views/impressions
+- **eCPM**: Effective CPM (accounts for viewability)
+- **CPC**: Cost per click
+
+### ROAS and CTR
+
+- **ROAS**: Return on Ad Spend (Sales ÷ Campaign Price)
+- **CTR**: Click-through rate (Clicks ÷ Impressions)
+
+### Ad Inventory and Supply
+
+- **Ad Supply**: Number of eyeballs on your site
+- **Ad Inventory**: Sellable impressions (ad load × ad supply)
+
+Creators generate ad inventory; platforms sell it by matching with advertisers.
+
 ## How much can a creator make
 
 This topic has moved to our comprehensive [Creator Monetization Guide](/monetize), which covers all monetization methods, platform strategies, and real earnings data.

--- a/_td/advertising.md
+++ b/_td/advertising.md
@@ -213,15 +213,4 @@ Half of advertising spend is still on TV. Tech companies want to capture that sp
 
 ## How much can a creator make
 
-Creator monetization has become a significant part of the advertising ecosystem. For a comprehensive guide on all monetization methods, including detailed breakdowns and reality checks, see our [Creator Monetization Guide](/monetize).
-
-Key monetization methods include:
-
-- Affiliate Marketing (e.g., Amazon Associates, typically 1-4% commission)
-- Ad Revenue Sharing (YouTube ~$7.50 per 1000 views)
-- Brand Sponsorships (the most lucrative option)
-- Direct Fan Support (Patreon, tips)
-- Merchandise
-- Digital Products
-
-For case studies and detailed revenue breakdowns (including LinusTechTips), check out the [monetization guide](/monetize).
+This topic has moved to our comprehensive [Creator Monetization Guide](/monetize), which covers all monetization methods, platform strategies, and real earnings data.

--- a/_td/advertising.md
+++ b/_td/advertising.md
@@ -213,39 +213,21 @@ Half of advertising spend is still on TV. Tech companies want to capture that sp
 
 ## How much can a creator make
 
-Not quite related to advertising, but a related concept is how much can creators make. Here is the [breakdown for LinusTechTips](https://www.youtube.com/watch?v=-zt57TWkTF4) a tech channel. You see their estimated youtube usage using [social blade](https://socialblade.com/youtube/channel/UCXuqSBlHAE6Xw-yeJA0Tunw)
-{%include blob_image_float_right.html src="techtips2020-revenue.png" %}
+Creator monetization has become a significant part of the advertising ecosystem. For a comprehensive guide on all monetization methods, including detailed breakdowns and reality checks, see our [Creator Monetization Guide](/monetize).
 
-### Affiliate Marketing
+Key monetization methods include:
 
-This is when creators say, use square space, it's because square space gives them a cut of people who sign up, for square space it's TK dollars per signup.
+- Affiliate Marketing (e.g., Amazon Associates, typically 1-4% commission)
+- Ad Revenue Sharing (YouTube ~$7.50 per 1000 views)
+- Brand Sponsorships (the most lucrative option)
+- Direct Fan Support (Patreon, tips)
+- Merchandise
+- Digital Products
 
-This is also when creators say "when you click this link I'll get some money" Amazon used to pay north of 10% cut, but they did a major reduction during CV19.
+For case studies and detailed revenue breakdowns (including LinusTechTips), check out the [monetization guide](/monetize).
 
-### Ad revenue sharing.
+### Quick Reality Check
 
-Youtube gives revenue of ~ 7.50\$ per 1000 views. If you go viral and get a million videos that's 7500K views.
-
-Here's a tool to show how much people make estimated: https://influencermarketinghub.com/youtube-money-calculator/
-
-### Brand sponsorship.
-
-The better deal is to get sponsor ship. E.g. a brand pays you to show their content.
-
-### Consumer Payment + Tips
-
-Creators can skip the need for brand influence, and be paid by advertisers directly. Examples of doing this are patreon and tipping jars.
-
-### Merch
-
-That's what those t-shirts and hats are about.
-
-### Bootstraping - Crowd funding
-
-Examples here are kick starter.
-
-### Ads and sponsored spots
-
-A good tongue and cheeck shot at ads
+A good tongue-in-cheek take on ads:
 
 {% include youtube.html src="qQiui9h71l8" %}

--- a/_td/advertising.md
+++ b/_td/advertising.md
@@ -225,9 +225,3 @@ Key monetization methods include:
 - Digital Products
 
 For case studies and detailed revenue breakdowns (including LinusTechTips), check out the [monetization guide](/monetize).
-
-### Quick Reality Check
-
-A good tongue-in-cheek take on ads:
-
-{% include youtube.html src="qQiui9h71l8" %}

--- a/back-links.json
+++ b/back-links.json
@@ -4694,14 +4694,12 @@
         },
         "/td/advertising": {
             "description": "Advertising is 155 billion business in the USA. Of that 155B, 85B is Digital and 70B is TV(digital platforms are invest ing in video to capture the TV spend. This post captures my understanding of that world.\n\n",
-            "doc_size": 24000,
+            "doc_size": 25000,
             "file_path": "_site/td/advertising.html",
             "incoming_links": [],
-            "last_modified": "2025-07-30T06:03:04.116695",
+            "last_modified": "2025-07-30T10:44:22.493607",
             "markdown_path": "_td/advertising.md",
-            "outgoing_links": [
-                "/monetize"
-            ],
+            "outgoing_links": [],
             "redirect_url": "",
             "title": "Advertising",
             "url": "/td/advertising"

--- a/back-links.json
+++ b/back-links.json
@@ -1399,15 +1399,16 @@
         },
         "/content-creation": {
             "description": "Ah, content creation! Remember when it meant awkwardly holding your phone at arm’s length, hoping your thumb wouldn’t photobomb your masterpiece? We’ve come a long way, baby! Whether you’re aiming to be the next TikTok sensation or just want to share your magic tricks without accidentally revealing them, this guide will help you level up from “my mom’s my only viewer” to “wait, is that video going viral?”\n\n",
-            "doc_size": 38000,
+            "doc_size": 27000,
             "file_path": "_site/content-creation.html",
             "incoming_links": [
                 "/y25"
             ],
-            "last_modified": "2025-07-29T20:49:20.209217",
+            "last_modified": "2025-07-30T06:03:04.116695",
             "markdown_path": "_d/content-creation.md",
             "outgoing_links": [
                 "/content-audience",
+                "/monetize",
                 "/screencast"
             ],
             "redirect_url": "",
@@ -4693,12 +4694,14 @@
         },
         "/td/advertising": {
             "description": "Advertising is 155 billion business in the USA. Of that 155B, 85B is Digital and 70B is TV(digital platforms are invest ing in video to capture the TV spend. This post captures my understanding of that world.\n\n",
-            "doc_size": 25000,
+            "doc_size": 24000,
             "file_path": "_site/td/advertising.html",
             "incoming_links": [],
-            "last_modified": "2024-10-05T21:35:59-07:00",
+            "last_modified": "2025-07-30T06:03:04.116695",
             "markdown_path": "_td/advertising.md",
-            "outgoing_links": [],
+            "outgoing_links": [
+                "/monetize"
+            ],
             "redirect_url": "",
             "title": "Advertising",
             "url": "/td/advertising"


### PR DESCRIPTION
## Summary
- Created comprehensive monetization guide at `/monetize` 
- Consolidated monetization content from `advertising.md` and `content-creation.md`
- Updated source pages to link to the new centralized guide

## Changes
- **New file**: `_d/monetization.md` - Comprehensive creator monetization guide including:
  - Advertising landscape overview (spend by industry, platform revenues)
  - Key advertising terms and concepts
  - Detailed creator monetization models with reality checks
  - Platform-specific strategies (YouTube, TikTok, Amazon Associates)
  - Real case studies (LinusTechTips, Snapchat)
- **Updated**: `_td/advertising.md` - Replaced detailed monetization section with summary and link to new guide
- **Updated**: `_d/content-creation.md` - Replaced lengthy monetization section with concise summary and link

## Test plan
- [ ] Verify new page renders correctly at `/monetize`
- [ ] Check all internal links work properly
- [ ] Confirm Amazon product links display correctly
- [ ] Validate cross-links between pages

🤖 Generated with [Claude Code](https://claude.ai/code)