### PR TITLE
igor-gap-year: cleanup, structure, and planning improvements

### DIFF
--- a/_d/igor-gap-year.md
+++ b/_d/igor-gap-year.md
@@ -15,6 +15,8 @@ The gap year concept is compelling in theory, but what does it look like when ru
 
 This is the personal companion to my broader piece on [the gap year paradox](/gap-year) - where theory meets Igor's very specific neuroses and circumstances.
 
+{% include summarize-page.html src="/gap-year" %}
+
 {% include blob_image_float_right.html src="blog/raccoon-gapyear.webp" %}
 
 <!-- prettier-ignore-start -->
@@ -44,13 +46,13 @@ This is the personal companion to my broader piece on [the gap year paradox](/ga
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
 
-{% include summarize-page.html src="/gap-year" %}
+
 
 ## Is Igor Gonna take a gap year?
 
 {% include alert.html content="I'm incredibly privileged to have both line of sight on savings and the support of my family to even consider a gap year" style="info" %}
 
-When I started at Meta in March 2020, my plan was to take a gap year after my Meta stock cliffed in 2024. After all, I had five job offers, including competitive offers from Google, Meta, and several mid-sized companies. But today's job market is much scarier than pre-COVID 2020 — it's become downright dicey out there.
+When I started at Meta in March 2020, my plan was to take a gap year after my Meta stock vested in 2024. After all, I had five job offers, including competitive offers from Google, Meta, and several mid-sized companies. But today's job market is much scarier than pre-COVID 2020 — it's become downright dicey out there.
 
 But there's more to life than collecting money, here are some what ifs I need to remember:
 
@@ -161,6 +163,7 @@ _If you're not gonna feel safe at 2 years \* your expenses, it's hard to imagine
 See my full [money philosophy](/money) and [retirement planning](/retire) for context on these financial triggers.
 
 {% include summarize-page.html src="/money" %}
+
 {% include summarize-page.html src="/retire" %}
 
 Igor at his best when 5am Igor "[Begins with end in Mind](/end-in-mind)", and sets up future Igor to run on Automatic. So here are some rules
@@ -181,14 +184,15 @@ Gap year is scary, here are some guard rails to make it happen:
   - Well, a magician never reveals his tricks, and Igor's gotta have some secrets.
 
 * Come on, can you at least give a formula?
-  - Have 2 years of expenses in the bank, if at the one year mark the market at 5% can replace the next year of cash, feel safe taking another gap year, else start a job hunt immediately
-  - This makes for the following assumptions
-    - You can get a job (possibly making much less than you do now) in under a year
-    - You don't have any "large unexpected expenses" Ensure your model can handle that.
-    - You are very confident in your expenses calculations (taxes, insurance, major house repairs, college)
+  - Baseline: Hold 2× annual expenses in cash-like accounts
+  - At month 12: If a 5% market return would replenish the next year’s cash draw, extend; otherwise begin job search
+  - Assumptions:
+    - Job search duration ≤ 12 months (possibly at lower comp)
+    - Model accommodates large unexpected expenses
+    - Expenses estimate includes taxes, insurance, repairs, college
 
 Extend-to-Year-2 rule:
-- If at month 10: health adherence ≥ 80%, 6+ artifacts shipped, and the 2× expenses + 5% replenishment rule holds, continue into Year 2; otherwise begin job search at month 11.
+- At month 10, extend if: health adherence ≥ 80%, 6+ artifacts shipped, and the 2× expenses + 5% replenishment condition holds; else begin job search at month 11.
 
 ## Igor's Decay Dragon: Health and Habits (Physical, Emotional, Relationship)
 
@@ -294,17 +298,16 @@ The real challenge isn't the quantity of time but learning to appreciate the qua
 
 **Success looks like:**
 
-- **Nothing is more valuable than family** - the time spent together holds the greatest meaning
-- I'm **fully engaged and genuinely present**, free from work distractions and stress
-- **Being available for spontaneous moments** - not missing unexpected connections because of conflicting commitments
-- We spontaneously talk to each other
-- We hang out passively (e.g., we go to a coffee shop together and do our own thing)
-- We establish a consistent date night approach
-- I accept them as they are, but still strive to influence them respectfully
-- I gracefully accept that I'm rarely their first choice - their peer relationships are essential for growth
-- I find ways to be present without intruding (e.g., driving them and friends places, stepping back when peers join)
-- I embrace the bittersweet nature of watching them grow - sad they'll never be small again, but grateful they get to grow up
-- STRETCH: We pick up a multi-month project we do together
+- **Nothing is more valuable than family** – the time together holds the greatest meaning
+- Fully engaged and present (free from work distractions and stress)
+- Available for spontaneous moments (no conflicts blocking connection)
+- Natural conversation happens regularly
+- Passive hangouts (e.g., coffee shop together doing our own thing)
+- Consistent date night approach
+- Acceptance with gentle influence where appropriate
+- Gracefully step back when peers join; facilitate logistics (driving, hosting)
+- Embrace the bittersweet nature of their growth
+- STRETCH: Multi-month project we do together
 - Metrics:
   - Monthly 1:1 with each kid; weekly spontaneous-time log
   - Weekly date night; monthly day date

--- a/_d/igor-gap-year.md
+++ b/_d/igor-gap-year.md
@@ -9,6 +9,10 @@ tags:
   - decision-making
   - life-planning
   - how igor ticks
+  - family
+  - health
+  - ai
+  - work-life-balance
 ---
 
 The gap year concept is compelling in theory, but what does it look like when rubber meets road? Here's my real-time wrestling match with the dragons guarding this treasure of time, complete with all the messy financial calculations, identity crises, and voice-in-head battles that come with considering a year off at 50.

--- a/_d/igor-gap-year.md
+++ b/_d/igor-gap-year.md
@@ -37,6 +37,7 @@ This is the personal companion to my broader piece on [the gap year paradox](/ga
   - [Loneliness Success](#loneliness-success)
 - [Igor's Identity Dragon](#igors-identity-dragon)
 - [Slaying Identity - PhD in AI, Content, and MRR](#slaying-identity---phd-in-ai-content-and-mrr)
+- [First 90 Days Plan](#first-90-days-plan)
 - [Gap Year Pre-Mortem](#gap-year-pre-mortem)
 - [Gap Year Voices in my head](#gap-year-voices-in-my-head)
 
@@ -183,6 +184,9 @@ Gap year is scary, here are some guard rails to make it happen:
     - You don't have any "large unexpected expenses" Ensure your model can handle that.
     - You are very confident in your expenses calculations (taxes, insurance, major house repairs, college)
 
+Extend-to-Year-2 rule:
+- If at month 10: health adherence ≥ 80%, 6+ artifacts shipped, and the 2× expenses + 5% replenishment rule holds, continue into Year 2; otherwise begin job search at month 11.
+
 ## Igor's Decay Dragon: Health and Habits (Physical, Emotional, Relationship)
 
 - What if I get lazy and lose all direction and discipline?
@@ -260,7 +264,10 @@ For me, addiction isn't about alcohol (I gave that up for better [sleep](/sleep)
 
 ### Addiction Success
 
-- Limited screen time on social media
+- Max 30 minutes/day on social apps
+- Phone set to grayscale; app timers enforced
+- One "no-screen" block after 8pm daily
+- Weekly screen-time audit and reset
 
 ## Battling Family Resentment
 
@@ -282,8 +289,6 @@ The real challenge isn't the quantity of time but learning to appreciate the qua
 
 ### Family Success
 
-{% include alert.html content="This section needs more thinking, but gotta start somewhere" style="info" %}
-
 **Success looks like:**
 
 - **Nothing is more valuable than family** - the time spent together holds the greatest meaning
@@ -297,6 +302,10 @@ The real challenge isn't the quantity of time but learning to appreciate the qua
 - I find ways to be present without intruding (e.g., driving them and friends places, stepping back when peers join)
 - I embrace the bittersweet nature of watching them grow - sad they'll never be small again, but grateful they get to grow up
 - STRETCH: We pick up a multi-month project we do together
+- Metrics:
+  - Monthly 1:1 with each kid; weekly spontaneous-time log
+  - Weekly date night; monthly day date
+  - One shared project per quarter
 
 **Successful parenting** ultimately means my children know, deep down, that I'm always there for them — quietly in the background, offering steady support without pressure, ready whenever they need me.
 
@@ -342,6 +351,30 @@ Mitigations:
 - STRETCH: **Mentorship at scale** - Helping others with my time and experience
 - STRETCH: **Online community building** - Meeting interesting people on the internet
 
+Metrics:
+- Two recurring daytime social blocks per week
+- One new person/group per month
+- One quarterly daylong/retreat with a friend
+
+## First 90 Days Plan
+
+Daily cadence:
+- Exercise (kettlebell/strength + walk)
+- Writing block (artifact-focused)
+- Learning block (AI/skills)
+- Family time window
+- Evening walk and shutdown
+
+Weekly cadence:
+- Two social blocks (daytime)
+- One long-form artifact or ship a micro-app
+- One deep work block (3–4 hours, no meetings)
+- One admin/finance review
+
+Accountability:
+- Weekly review and plan
+- Share an artifact publicly or with a small circle
+
 ## Igor's Identity Dragon
 
 - Forget telling the future, what does taking a gap year say about me ?
@@ -360,9 +393,9 @@ Creating artifacts is crucial - tangible outputs that prove the gap year was pro
 
 **AI Goals/Artifacts**
 
-- Learning artifacts: Comprehensive AI knowledge base, experiment logs, model implementations
-- Several Apps written via AI, starting with PRDs
-- Content artifacts: AI tutorial series, technical blog posts, open source contributions
+- 12 PRDs, 6 shipped micro-apps
+- 12 technical posts, 4 talks/videos
+- Working notes repo for experiments/implementations
 
 **Content Creation Goals/Artifacts**
 
@@ -373,16 +406,25 @@ Maybe no one will read/watch it but me and my Mom, but good enough for me.
 
 **MRR Goals/Artifacts**
 
-Monthly recurring revenue? That would be pretty cool. Certainly I get much higher MRR at Meta, but MRR is hopefully forever due to evergreen, or mostly evergreen content.
+Monthly recurring revenue would be nice, but likely modest vs. a tech salary.
 
-Will this actually slay the Financial Security Dragon? Let's be real - we're talking about pocket change compared to a tech salary. But hey, a man can dream of becoming the next MrBeast of gap year content!
-
-- Product artifacts: TBD
-- Revenue artifacts: Affiliate links? Course? Ad Revenue from Content? Who knows
+- Product: 1 paid template; 1 cohort workshop pilot
+- Revenue: Affiliate links; ad revenue experiments; course outline
 
 ## Gap Year Pre-Mortem
 
-In tech one of the tools we have to avoid failure is to run a pre-mortem, an exercise where we imagine we've failed, and how did it happen - I guess I should do this for a gap-year as well. I think this is another pivot on the dragons above
+Top failure modes and mitigations:
+
+- Drift/vegetating
+  - Mitigation: Daily plan + weekly review; external structure (trainer/classes)
+- Isolation/loneliness
+  - Mitigation: Pre-scheduled social slots; join clubs/classes; mentorship calendar
+- Scope creep on projects
+  - Mitigation: WIP limit (max two active projects); define “done” for each artifact
+- Cash anxiety
+  - Mitigation: Pre-fund 2× annual expenses; monthly runway update; rules in “Slaying Financial Security”
+- Family resentment
+  - Mitigation: Align expectations; time-window reality check; weekly gratitude log
 
 ## Gap Year Voices in my head
 

--- a/_d/igor-gap-year.md
+++ b/_d/igor-gap-year.md
@@ -9,10 +9,6 @@ tags:
   - decision-making
   - life-planning
   - how igor ticks
-  - family
-  - health
-  - ai
-  - work-life-balance
 ---
 
 The gap year concept is compelling in theory, but what does it look like when rubber meets road? Here's my real-time wrestling match with the dragons guarding this treasure of time, complete with all the messy financial calculations, identity crises, and voice-in-head battles that come with considering a year off at 50.

--- a/_d/igor-gap-year.md
+++ b/_d/igor-gap-year.md
@@ -26,7 +26,7 @@ This is the personal companion to my broader piece on [the gap year paradox](/ga
 - [Igor's Financial Security Dragon](#igors-financial-security-dragon)
 - [Slaying Financial Security](#slaying-financial-security)
 - [Igor's Decay Dragon: Health and Habits (Physical, Emotional, Relationship)](#igors-decay-dragon-health-and-habits-physical-emotional-relationship)
-- [Slaying Decay - Reframe: Health and Habits Capital Investment (Physical, Emotional, Relationship)](#slaying-decay---reframe-health-and-habits-capital-investment-physical-emotional-relationship)
+- [Slaying Decay - Health and Habits Investment](#slaying-decay---health-and-habits-investment)
 - [Battling Addiction](#battling-addiction)
   - [Addiction Success](#addiction-success)
 - [Battling Family Resentment](#battling-family-resentment)
@@ -36,7 +36,7 @@ This is the personal companion to my broader piece on [the gap year paradox](/ga
 - [Battling Loneliness](#battling-loneliness)
   - [Loneliness Success](#loneliness-success)
 - [Igor's Identity Dragon](#igors-identity-dragon)
-- [Slaying Identity - Reframe: PhD in AI, Content Creation, and MRR](#slaying-identity---reframe-phd-in-ai-content-creation-and-mrr)
+- [Slaying Identity - PhD in AI, Content, and MRR](#slaying-identity---phd-in-ai-content-and-mrr)
 - [Gap Year Pre-Mortem](#gap-year-pre-mortem)
 - [Gap Year Voices in my head](#gap-year-voices-in-my-head)
 
@@ -49,7 +49,7 @@ This is the personal companion to my broader piece on [the gap year paradox](/ga
 
 {% include alert.html content="I'm incredibly privileged to have both line of sight on savings and the support of my family to even consider a gap year" style="info" %}
 
-When I started at Meta in March 2020 my plan was to take a gap year after my Meta stock cliffed in 2024. After all, I had 5 job offers include competitive offers from Google, Meta, and several mid sized companies. But today's job market is much much scarier than pre-COVID 2020 - it's become downright dicey out there.
+When I started at Meta in March 2020, my plan was to take a gap year after my Meta stock cliffed in 2024. After all, I had five job offers, including competitive offers from Google, Meta, and several mid-sized companies. But today's job market is much scarier than pre-COVID 2020 — it's become downright dicey out there.
 
 But there's more to life than collecting money, here are some what ifs I need to remember:
 
@@ -91,7 +91,7 @@ In Phase 3, I anticipate wanting to work extensively - but Phases 1 and 2 repres
 
 **Hey you're not talking about Tori, doesn't time with her matter?**
 
-It certainly does, but Tori needs her own time, and our relationship is set up where we don't need a tonne of time together.
+It certainly does, but Tori needs her own time, and our relationship is set up where we don't need a ton of time together.
 
 **What about travel?**
 
@@ -137,7 +137,7 @@ The dragons are the same size they've always been. The difference is now you're 
   - This is very probable.
   - **But** Meta lets you have a "short interview loop" if you boomerang in a year
   - **But** I've always said if you won't take a job for a pay cut, you shouldn't take it. I guess that could be cuz the job is less fun, or cuz it's the highest paid job you'll take :)
-  - **So** My retirement is not delayed by 1.5 years, It's delayed by 'N' years, that's OK, the year now is much more valuable
+  - **So** My retirement isn't delayed by 1.5 years; it's delayed by N years. That's acceptable because the year now is more valuable
 
 - What if I'm wrong about my expenses?
   - It's critical you get this right.
@@ -174,7 +174,7 @@ Gap year is scary, here are some guard rails to make it happen:
 
 * What are the actual dates and numbers?
 
-  - Well, a magician never reveals his tricks, and Igor's gotta have some secrets 🎩✨
+  - Well, a magician never reveals his tricks, and Igor's gotta have some secrets.
 
 * Come on, can you at least give a formula?
   - Have 2 years of expenses in the bank, if at the one year mark the market at 5% can replace the next year of cash, feel safe taking another gap year, else start a job hunt immediately
@@ -237,7 +237,7 @@ Gap year is scary, here are some guard rails to make it happen:
   - **But** I have mental health support systems (therapy, medication, practices) that would continue
   - **So** Keep existing mental health infrastructure in place throughout the gap year
 
-## Slaying Decay - Reframe: Health and Habits Capital Investment (Physical, Emotional, Relationship)
+## Slaying Decay - Health and Habits Investment
 
 This connects to my broader thinking on [physical health](/physical-health), [mental health](/emotional-health), and [relationship health](/chapters).
 
@@ -298,7 +298,7 @@ The real challenge isn't the quantity of time but learning to appreciate the qua
 - I embrace the bittersweet nature of watching them grow - sad they'll never be small again, but grateful they get to grow up
 - STRETCH: We pick up a multi-month project we do together
 
-**Successful parenting** ultimately means my children know, deep down, that I'm always there for them—quietly in the background, offering steady support without pressure, ready whenever they need me.
+**Successful parenting** ultimately means my children know, deep down, that I'm always there for them — quietly in the background, offering steady support without pressure, ready whenever they need me.
 
 ## Battling Loneliness
 
@@ -350,11 +350,11 @@ Mitigations:
 - **But** It can be about overcoming my fear and investing in myself and relationships
 - **So:** Reframe to be a PhD and A Year of [Health](/physical-health) and [Habits](/d/habits) Capital Investments
 
-## Slaying Identity - Reframe: PhD in AI, Content Creation, and MRR
+## Slaying Identity - PhD in AI, Content, and MRR
 
 This aligns with my approach to [continuous learning](/timeoff) and [overcoming resistance](/d/resistance) to change.
 
-Instead of thinking about it as a gap year (for which I'd feel guilty), I'll think about it as pursuing a "PhD in AI, Content Creation, and MRR" - focusing on my professional development. On the technical side, I'd become an AI expert by learning everything about the field [TODO: link to AI posts], while also mastering content creation and building monthly recurring revenue streams.
+Instead of thinking about it as a gap year (for which I'd feel guilty), I'll think about it as pursuing a "PhD in AI, Content Creation, and MRR" - focusing on my professional development. On the technical side, I'd become an AI expert by learning everything about the field (see my posts on [AI](/ai)), while also mastering content creation and building monthly recurring revenue streams.
 
 Creating artifacts is crucial - tangible outputs that prove the gap year was productive and provide lasting value. These artifacts serve as both motivation during the year, long term deposits in your relationship and health bank accounts, and career capital when returning to work.
 
@@ -375,7 +375,7 @@ Maybe no one will read/watch it but me and my Mom, but good enough for me.
 
 Monthly recurring revenue? That would be pretty cool. Certainly I get much higher MRR at Meta, but MRR is hopefully forever due to evergreen, or mostly evergreen content.
 
-Will this actually slay the Financial Security Dragon? Let's be real - we're talking about pocket change compared to a tech salary. But hey, a man can dream of becoming the next MrBeast of gap year content! 🎬💰
+Will this actually slay the Financial Security Dragon? Let's be real - we're talking about pocket change compared to a tech salary. But hey, a man can dream of becoming the next MrBeast of gap year content!
 
 - Product artifacts: TBD
 - Revenue artifacts: Affiliate links? Course? Ad Revenue from Content? Who knows
@@ -385,7 +385,5 @@ Will this actually slay the Financial Security Dragon? Let's be real - we're tal
 In tech one of the tools we have to avoid failure is to run a pre-mortem, an exercise where we imagine we've failed, and how did it happen - I guess I should do this for a gap-year as well. I think this is another pivot on the dragons above
 
 ## Gap Year Voices in my head
-
-In tech one of the tools we have to avoid failure is to run a pre-mortem, an exercise where we imagine we've failed, and how did it happen - I guess I should do this for a gap-year as well. I think this is another pivot on the dragons above
 
 {%include summarize-page.html src="/voices"%}

--- a/_d/igor-gap-year.md
+++ b/_d/igor-gap-year.md
@@ -192,8 +192,7 @@ Gap year is scary, here are some guard rails to make it happen:
     - Model accommodates large unexpected expenses
     - Expenses estimate includes taxes, insurance, repairs, college
 
-Extend-to-Year-2 rule:
-- At month 10, extend if: health adherence ≥ 80%, 6+ artifacts shipped, and the 2× expenses + 5% replenishment condition holds; else begin job search at month 11.
+- **Extend-to-Year-2 rule**: At month 10, extend if: health adherence ≥ 80%, 6+ artifacts shipped, and the 2× expenses + 5% replenishment condition holds (i.e., you have at least two years of expenses in the bank, and at the one-year mark, your investments at a 5% return can replenish the next year's cash draw); else begin job search at month 11.
 
 ## Igor's Decay Dragon: Health and Habits (Physical, Emotional, Relationship)
 
@@ -272,7 +271,7 @@ For me, addiction isn't about alcohol (I gave that up for better [sleep](/sleep)
 
 ### Addiction Success
 
-{% include alert.html content="This section is a work in progress; tracking metrics will evolve" style="info" %}
+{% include alert.html content="This is progress" style="info" %}
 
 - Max 30 minutes/day on social apps
 - Phone set to grayscale; app timers enforced
@@ -351,7 +350,7 @@ Mitigations:
 
 ### Loneliness Success
 
-{% include alert.html content="This section is a work in progress; cadence and metrics may change" style="info" %}
+{% include alert.html content="Note in progress" style="info" %}
 
 **Success looks like:**
 
@@ -435,7 +434,7 @@ Maybe no one will read/watch it but me and my Mom, but good enough for me.
 Monthly recurring revenue would be miniscule vs. a tech salary.
 
 - Product: 1 paid template; 1 cohort workshop pilot
-- Revenue: Affiliate links; ad revenue experiments (goal: $100/month after 6 months); course outline
+- Revenue: Affiliate links; ad revenue experiments (goal: $100/month after 6 months); course outline; analysis of the voices in my head on the topic
 
 ## Gap Year Pre-Mortem
 

--- a/_d/igor-gap-year.md
+++ b/_d/igor-gap-year.md
@@ -161,7 +161,7 @@ _If you're not gonna feel safe at 2 years \* your expenses, it's hard to imagine
 
 ## Slaying Financial Security
 
-See my full [money philosophy](/money) and [retirement planning](/retire) for context on these financial triggers.
+See my full [money philosophy](/money), [retirement planning](/retire), and [stock concentration](/stock-concentration) for context on these financial triggers.
 
 {% include summarize-page.html src="/money" %}
 
@@ -272,6 +272,8 @@ For me, addiction isn't about alcohol (I gave that up for better [sleep](/sleep)
 
 ### Addiction Success
 
+{% include alert.html content="This section is a work in progress; tracking metrics will evolve" style="info" %}
+
 - Max 30 minutes/day on social apps
 - Phone set to grayscale; app timers enforced
 - One "no-screen" block after 8pm daily
@@ -349,6 +351,8 @@ Mitigations:
 
 ### Loneliness Success
 
+{% include alert.html content="This section is a work in progress; cadence and metrics may change" style="info" %}
+
 **Success looks like:**
 
 - **Deepened existing friendships** - Regular scheduled time with retired/gap year friends
@@ -382,6 +386,21 @@ Accountability:
 - Weekly review and plan
 - Share an artifact publicly or with a small circle
 
+{% include alert.html content="This plan is iterative; reassessment cadence below will adjust details" style="info" %}
+
+## Reassessment and Exit Triggers
+
+Cadence:
+- Monthly review: health adherence, artifact shipping, cash runway
+- Quarterly retro: adjust goals, social cadence, project WIP
+
+Early exit triggers:
+- Health adherence < 50% for 2 consecutive months
+- Family stress rising (qualitative check-ins indicate sustained strain)
+- Cash buffer < 1.25× annual expenses or large unexpected expense without coverage
+
+If any trigger persists after one month of mitigation, begin job search protocol.
+
 ## Igor's Identity Dragon
 
 - Forget telling the future, what does taking a gap year say about me ?
@@ -413,14 +432,14 @@ Maybe no one will read/watch it but me and my Mom, but good enough for me.
 
 **MRR Goals/Artifacts**
 
-Monthly recurring revenue would be nice, but likely modest vs. a tech salary.
+Monthly recurring revenue would be miniscule vs. a tech salary.
 
 - Product: 1 paid template; 1 cohort workshop pilot
-- Revenue: Affiliate links; ad revenue experiments; course outline
+- Revenue: Affiliate links; ad revenue experiments (goal: $100/month after 6 months); course outline
 
 ## Gap Year Pre-Mortem
 
-Top failure modes and mitigations:
+Top failure modes and mitigations (mapped to the dragons above):
 
 - Drift/vegetating
   - Mitigation: Daily plan + weekly review; external structure (trainer/classes)
@@ -436,3 +455,5 @@ Top failure modes and mitigations:
 ## Gap Year Voices in my head
 
 {% include summarize-page.html src="/voices" %}
+
+Closing thought: A gap year isn’t a year off; it’s a year on — intentional investment in health, relationships, and mastery while you still have the energy to enjoy the returns.

--- a/_d/igor-gap-year.md
+++ b/_d/igor-gap-year.md
@@ -160,6 +160,9 @@ _If you're not gonna feel safe at 2 years \* your expenses, it's hard to imagine
 
 See my full [money philosophy](/money) and [retirement planning](/retire) for context on these financial triggers.
 
+{% include summarize-page.html src="/money" %}
+{% include summarize-page.html src="/retire" %}
+
 Igor at his best when 5am Igor "[Begins with end in Mind](/end-in-mind)", and sets up future Igor to run on Automatic. So here are some rules
 
 Gap year is scary, here are some guard rails to make it happen:


### PR DESCRIPTION
Edits to _d/igor-gap-year.md: (1) copy/headers/TOC cleanup; (2) measurable success criteria, First 90 Days plan, pre-mortem, extend-to-year-2 rule; (3) summarize includes for /money and /retire.