### PR TITLE
fix: add Jekyll build to backlinks action

### DIFF
--- a/.github/workflows/update-backlinks.yml
+++ b/.github/workflows/update-backlinks.yml
@@ -36,6 +36,17 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # Need full history to get accurate diff
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Build Jekyll site
+        run: |
+          bundle exec jekyll build
+          echo "✅ Jekyll site built successfully"
+
       - name: Set up Python with uv
         uses: astral-sh/setup-uv@v4
         with:


### PR DESCRIPTION
## Fix
The backlinks action wasn't working because it needs the HTML files from `_site` to process.

## Changes
- Added Ruby setup
- Added Jekyll build step before running delta command
- This ensures the HTML files exist for the backlinks script to process

## Test
Once this is merged, the action should properly update backlinks when PRs are merged.