### PR TITLE
fix: Jekyll vendor directory issue in backlinks action

### DIFF
--- a/.github/workflows/update-backlinks.yml
+++ b/.github/workflows/update-backlinks.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build Jekyll site
         run: |
-          bundle exec jekyll build
+          bundle exec jekyll build --config _config.yml,_config_ci.yml
           echo "✅ Jekyll site built successfully"
 
       - name: Set up Python with uv

--- a/_config_ci.yml
+++ b/_config_ci.yml
@@ -1,0 +1,14 @@
+# CI-specific Jekyll configuration
+# This file is merged with _config.yml when building in CI
+
+# Exclude vendor directory (where bundler installs gems in CI)
+exclude:
+  - vendor/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - package.json
+  - package-lock.json
+  - README.md
+  - .git/
+  - .github/


### PR DESCRIPTION
## Fix
Jekyll build was failing in CI because it tried to process files in the vendor/bundle directory.

## Changes
- Added `_config_ci.yml` with CI-specific excludes
- Updated workflow to use both config files when building

## Result
This will prevent Jekyll from trying to process gem files in the vendor directory during CI builds.