### PR TITLE
Add sort_order field for featured posts

### DIFF
--- a/_d/time-off-2025-08.md
+++ b/_d/time-off-2025-08.md
@@ -3,6 +3,7 @@ layout: post
 title: Time off August 2025 - Meta Recharge
 imagefeaturelocal: raccoon-vacation.png
 permalink: /time-off-2025-08
+sort_order: 300
 ---
 
 I'm incredibly fortunate to be able to take 6 weeks off this summer! After 5 years of service at Meta, you get 30 days (about 5 week) off!

--- a/_posts/2016-03-03-the-manager-book-2.md
+++ b/_posts/2016-03-03-the-manager-book-2.md
@@ -10,6 +10,7 @@ permalink: /manager-book
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/racoon-manager.webp
 redirect_from:
   - /the-manager-book
+sort_order: 100
 ---
 
 Being an engineering manager is hard. Supporting people well is harder. Lessons are hard earned and should be cherished. This post is designed to make explicit, and improve behaviors and practices. It reminds me how to behave and encourages my own continuous improvement.

--- a/_posts/2020-04-01-Igor-Eulogy.md
+++ b/_posts/2020-04-01-Igor-Eulogy.md
@@ -13,6 +13,7 @@ tags:
   - how igor ticks
   - emotional intelligence
   - search-featured
+sort_order: 200
 ---
 
 Wearing a silly hat or his zany $8 TEMU crazy shirt, his trusty folding bike at his feet, and using a purple fountain pen, Igor "Began with the end in mind" with the "important but not urgent" task of penning this eulogy, likely starting at 5am. Igor wanted this life, so he wrote it, he reviewed it, he lived it, and he worked with his family, friends, and multitude of mentors, to adjust and tweak it.


### PR DESCRIPTION
## Summary
- Added sort_order field to control which posts appear as featured in search results
- This field is used by Algolia for ranking when displaying featured posts

## Changes
- Added sort_order: 100 to _posts/2016-03-03-the-manager-book-2.md
- Added sort_order: 200 to _posts/2020-04-01-Igor-Eulogy.md  
- Added sort_order: 300 to _d/time-off-2025-08.md

## Testing
- Verified the fields are present in the frontmatter
- These will be picked up by Algolia on next index rebuild

## Related
- Split from PR #106 which implements the main inline search feature
- This is a separate feature to control featured post ordering