### PR TITLE
Fix: Disable force push in Vitest workflow

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -125,6 +125,7 @@ jobs:
           target-folder: test-results
           branch: test-results
           clean: false
+          force: false  # Disable force push to comply with branch protection rules
 
       - name: Upload test coverage as artifact
         if: always()

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -2,7 +2,6 @@
  * Shared utility functions
  *
  * This file contains utility functions that are shared across multiple modules.
- * Test comment: Verifying Claude review works after reverting to pull_request
  */
 
 /**

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -2,6 +2,7 @@
  * Shared utility functions
  *
  * This file contains utility functions that are shared across multiple modules.
+ * Test comment: Verifying Claude review works after reverting to pull_request
  */
 
 /**


### PR DESCRIPTION
## Summary
- Fixes Vitest workflow deployment failures caused by force push attempts
- Adds `force: false` to comply with branch protection rules

## Problem
The Vitest workflow has been failing when trying to deploy test results to the `test-results` branch. The error shows:
```
Repository rule violations found for refs/heads/test-results
- Changes must be made through a pull request
```

The JamesIves/github-pages-deploy-action was using force push by default, which is blocked by the repository's branch protection rules.

## Solution
Added `force: false` to the deploy action configuration to disable force pushes.

## Alternative Solutions
If this doesn't work, we could:
1. Exempt the `test-results` branch from protection rules in GitHub settings
2. Use a different deployment method that doesn't require force push
3. Create a GitHub App with special permissions for deployments

## Testing
Once merged, the Vitest workflow should successfully deploy test results without force push errors.

🤖 Generated with [Claude Code](https://claude.ai/code)