### PR TITLE
docs(ai-journal): add Q&A about AI collaborator access

### DIFF
--- a/_d/ai-journal.md
+++ b/_d/ai-journal.md
@@ -189,6 +189,16 @@ lets see if we can simulate him, step #1, lets bring the site down into markdown
   - You can have all the right pieces but one misconfiguration ruins everything
   - Defense in depth only works if all the defenses are actually... defending
   - Always verify your security assumptions - "trust but verify" applies to your own setup too
+- **Q&A - "Why is the AI a collaborator at all?"**
+  - Q: Why not have Claude fork the repo and make PRs from its own account?
+  - A: Because the code review bots don't support cross-repo PRs! 🤦
+    - Copilot won't review PRs from forks
+    - Claude review bot needs repo access
+    - Cursor bot... same story
+  - So we're stuck giving the AI collaborator access just to get automated reviews
+  - Which means trusting branch protection rules to be... you know... ENABLED
+  - The irony: We need to give more access to get better security reviews
+  - **Groan**... security is REALLY hard to get right
 
 #### The Claude Review Workflow Saga - When Good Intentions Break Everything
 


### PR DESCRIPTION
## Summary
Added Q&A section explaining why AI needs collaborator access to the repository.

## The Security Catch-22
- Code review bots (Copilot, Claude, Cursor) don't support cross-repo PRs from forks
- So we need to give AI collaborator access to get automated security reviews
- Which creates the very security risk we're trying to avoid with reviews

## The Irony
We need to give MORE access to get BETTER security reviews. Security is hard!

🤖 Generated with [Claude Code](https://claude.ai/code)