### PR TITLE
Fix title capitalizations across blog posts

### DIFF
--- a/_d/2010-2-15-2016-Misc-Uncategorized.md
+++ b/_d/2010-2-15-2016-Misc-Uncategorized.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "random un categorized notes"
+title: "Random Uncategorized Notes"
 comments: true
 inprogress: true
 permalink: random-idea

--- a/_d/2017-09-10-software-rot.md
+++ b/_d/2017-09-10-software-rot.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "software-rot"
+title: "Software Rot"
 date: "2017-09-10 07:25:12 Pacific Daylight Time"
 tags:
   - software engineering

--- a/_d/2018-09-23-mind-lines.md
+++ b/_d/2018-09-23-mind-lines.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "mind-lines"
+title: "Mind-Lines"
 date: "2010-09-23 17:50:41 +0000"
 tags:
 ---

--- a/_d/gpt-7-habits.md
+++ b/_d/gpt-7-habits.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "LEADER: Another take on the 7 habts"
+title: "LEADER: Another Take on the 7 Habits"
 tags:
   - book-notes
   - gpt

--- a/_d/grateful2.md
+++ b/_d/grateful2.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Gratefulnes"
+title: "Gratefulness"
 permalink: /grateful
 alias: /grateful
 ---

--- a/_posts/2015-3-13-why-is-no-one-referring.md
+++ b/_posts/2015-3-13-why-is-no-one-referring.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Why is noone referring my project"
+title: "Why Is No One Referring My Project"
 author: "Igor Dvorkin"
 tag: "startupville"
 comments: true

--- a/_posts/2018-05-25-strength-finder.md
+++ b/_posts/2018-05-25-strength-finder.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "My Strengths from  Strength Finder"
+title: "My Strengths from Strength Finder"
 date: "2018-05-24 06:49:58 Pacific Standard Time"
 comments: true
 tags:

--- a/_td/design.md
+++ b/_td/design.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Software Design And Architecture
+title: Software Design and Architecture
 permalink: /design
 redirect_from:
   - /architecture

--- a/_td/fix_cert_error.md
+++ b/_td/fix_cert_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 no-render-title: true
-title: The case of the cert validation error
+title: The Case of the Cert Validation Error
 permalink: /cert-error
 ---
 

--- a/_td/fix_ssh.md
+++ b/_td/fix_ssh.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 no-render-title: true
-title: ssh client commands timing out from some clients some times
+title: SSH Client Commands Timing Out from Some Clients Sometimes
 ---
 
 For some reason, SSH is just hanging out of no where. To debug on the server, be sure to open your firewall

--- a/_td/ios-nomad.md
+++ b/_td/ios-nomad.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 no-render-title: true
-title: iOS Software engineer nomad howto
+title: iOS Software Engineer Nomad How-To
 ---
 
 So you want to be an iPad Developer Nomad. A person who can do all their development on the iPad. I'm not sure why you'd want to be such a character, in fact, I'm not sure why I want to be such a character, but I do, and here's how I do it. To be a developer nomad, you better already be a command line wiz. If you're not at an expert at the terminal, vim or Emacs and TMUX - don't even try.

--- a/_td/linqpad_from_redshift.md
+++ b/_td/linqpad_from_redshift.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 no-render-title: true
-title: Make linqpad work with redshift.
+title: Make LINQPad Work with Redshift
 ---
 
 _[Copied from my GitHub techdiary](https://github.com/idvorkin/techdiary/blob/master/linqpad_from_redshift.md)_

--- a/_td/sicp.md
+++ b/_td/sicp.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Structure And Design of Computer Programs
+title: Structure and Design of Computer Programs
 permalink: /sicp
 redirect_from:
   - /wizard-book

--- a/_td/sqlalchemy-redshift.md
+++ b/_td/sqlalchemy-redshift.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 no-render-title: true
-title: SQL Alchemy with Redshift
+title: SQLAlchemy with Redshift
 ---
 
 _[Copied from my GitHub techdiary](https://github.com/idvorkin/techdiary/blob/master/sqlalchemy-redshift.md)_

--- a/_td/usbtech.md
+++ b/_td/usbtech.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 no-render-title: true
-title: Usb Tech
+title: USB Tech
 ---
 
 _[Copied from my GitHub techdiary](https://github.com/idvorkin/techdiary/blob/master/usbtech.md)_

--- a/_td/windbg.md
+++ b/_td/windbg.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 no-render-title: true
-title: WinDBG notes
+title: WinDbg Notes
 ---
 
 _[Copied from my GitHub techdiary](https://github.com/idvorkin/techdiary/blob/master/windbg.md)_


### PR DESCRIPTION
## Summary
- Fixed inconsistent title capitalizations across 16 blog posts
- Corrected typos in two titles (Gratefulnes → Gratefulness, habts → habits)
- Standardized title case conventions throughout the blog

## Changes by directory

### _td directory (9 files)
- USB Tech (was Usb Tech) - proper acronym capitalization
- iOS Software Engineer Nomad How-To - consistent capitalization
- Make LINQPad Work with Redshift - proper product name
- SQLAlchemy with Redshift - correct product name (one word)
- Structure and Design of Computer Programs - don't capitalize "and"
- SSH Client Commands Timing Out - proper acronym and capitalization
- The Case of the Cert Validation Error - consistent title case
- Software Design and Architecture - don't capitalize "and"
- WinDbg Notes - official product capitalization

### _d directory (5 files)
- Mind-Lines (was mind-lines) - proper title case
- Software Rot (was software-rot) - proper title case
- Random Uncategorized Notes - consistent capitalization
- Gratefulness - fixed typo (was Gratefulnes)
- LEADER: Another Take on the 7 Habits - fixed typo (was habts)

### _posts directory (2 files)
- Why Is No One Referring My Project - proper spacing and capitalization
- My Strengths from Strength Finder - removed double space

## Test plan
- [x] All files still render correctly
- [x] No functional changes, only title metadata updated
- [x] Verified each change maintains consistency with blog style

🤖 Generated with [Claude Code](https://claude.ai/code)