### PR TITLE
Configure auto-merge strategy for back-links.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,7 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Auto-generated files - always accept incoming changes on merge conflicts
+# This helps avoid conflicts when back-links.json is regenerated
+back-links.json merge=theirs


### PR DESCRIPTION
## Summary
- Configures Git to automatically resolve merge conflicts in `back-links.json` by accepting incoming changes
- Prevents manual merge conflict resolution for this auto-generated file

## Problem
The `back-links.json` file is auto-generated and frequently updated when content changes. This leads to merge conflicts in PRs when:
1. A PR modifies content and regenerates the file
2. Main branch is updated with another PR that also regenerated the file
3. The PR needs rebasing and encounters conflicts in the JSON structure

## Solution
Added a `.gitattributes` configuration that:
- Defines a custom merge strategy for `back-links.json`
- Uses the 'theirs' merge driver to automatically accept incoming changes during conflicts
- The driver is configured locally via `git config merge.theirs.driver "cp %B %A"`

## Implementation Details
- Modified `.gitattributes` to add merge strategy for `back-links.json`
- The 'theirs' driver copies the incoming version (%B) over the current version (%A)
- This only affects merge conflict resolution, not normal merges without conflicts

## Test Plan
- [ ] Verify `.gitattributes` changes are correct
- [ ] Test that future PRs with `back-links.json` conflicts auto-resolve
- [ ] Confirm the merge driver configuration works as expected

## Note
Each developer needs to run `git config merge.theirs.driver "cp %B %A"` locally for this to work on their machine. Consider adding this to the development setup documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)