### PR TITLE
Fix fragment validation issues in pre-commit link checker

### DIFF
--- a/_d/ai-journal.md
+++ b/_d/ai-journal.md
@@ -108,19 +108,18 @@ This took me about 30 minutes to setup - crazy!!
 
 OK, I used to go to this psychiatrist, who had a full "consistent model" of psychiatry
 
-[here](https://whatilearnedsofar.com/practice/)
+here (https://whatilearnedsofar.com/practice/) (broken link)
 
 lets see if we can simulate him, step #1, lets bring the site down into markdown
 
 1. Lets use <https://github.com/paulpierre/markdown-crawler>:
 2. pip install markdown-crawler
-   markdown-crawler <https://whatilearnedsofar.com/practice/> --output-dir ./practice
+   markdown-crawler https://whatilearnedsofar.com/practice/ --output-dir ./practice (broken link)
 
 ## What I wrote summary
 
 - I tend to write a fair bit over a time span, and forget what I did. I used a simple [git log stat creator](https://github.com/idvorkin/settings/blob/7c747bf7061a2da774faedd6efe14fdff547e92d/shared/zsh_include.sh?plain=1#L133) to see it, but it was too simple
 - Turns, out LLMs are a great way to do this. So I wrote an [app for it](https://github.com/idvorkin/nlp/blob/303d7c58265b647dead79ccdbaeafd0cab58d1a0/changes.py?plain=1#L211). It does [great summaries](https://gist.github.com/idvorkin/7f457ef75330f5faee8c9a82a3d0d820). Inlining changes to this app as follows:
-
   - [changes.py](https://github.com/idvorkin/nlp/blob/303d7c58265b647dead79ccdbaeafd0cab58d1a0/changes.py)
   - Creation of a new Python script to handle Git diffs and summarize changes using OpenAI.
   - Major functionalities include:
@@ -170,7 +169,6 @@ lets see if we can simulate him, step #1, lets bring the site down into markdown
   - Originally created on July 18, 2025 ([commit 38d87330](https://github.com/idvorkin/idvorkin.github.io/commit/38d87330)) as "crafting spells to banish ruminating thoughts"
   - Added image features ([commit bab47de6](https://github.com/idvorkin/idvorkin.github.io/commit/bab47de6)) - a very lucky last commit or I'd never have found it.
 - **The Shocking Discovery**: File was deleted in [PR #67](https://github.com/idvorkin/idvorkin.github.io/pull/67) ([commit e73324f9](https://github.com/idvorkin/idvorkin.github.io/commit/e73324f9))
-
   - **PR title**: "Add random page navigation feature"
   - **Actual changes**: Also randomly deleted an entire page!
   - 251 lines of carefully crafted content about mental health - gone
@@ -201,7 +199,7 @@ lets see if we can simulate him, step #1, lets bring the site down into markdown
   - Like putting a bank vault door on a tent
 - **The Discovery**: Found I had a GitHub ruleset that SHOULD prevent this
   - It was **DISABLED** 🤦
-  - Link: [GitHub Rulesets Settings](https://github.com/idvorkin/idvorkin.github.io/settings/rules)
+  - Link: GitHub Rulesets Settings (https://github.com/idvorkin/idvorkin.github.io/settings/rules) (broken link)
   - The protection was there all along, just... turned off
 - **The Irony**:
   - Spent hours setting up container isolation
@@ -225,25 +223,21 @@ lets see if we can simulate him, step #1, lets bring the site down into markdown
 #### The Claude Review Workflow Saga - When Good Intentions Break Everything
 
 - **The Problem**: Claude Code Review had been failing on EVERY PR since August 17th with mysterious "Invalid OIDC token" errors
-
   - Someone (probably me via AI) had "fixed" the workflow to support fork PRs by changing from `pull_request` to `pull_request_target`
   - Classic case of "the fix that breaks everything else"
 
 - **The Wild Goose Chase**:
-
   - First hypothesis: OIDC tokens don't work with `pull_request_target` - let's add `github_token`!
   - Created PR #120 to add the token - still failed
   - Tested from a fork (PR #121) to be thorough - also failed
   - The beta Claude action just wasn't compatible with `pull_request_target` events
 
 - **The Real Fix**: Sometimes you just have to admit defeat and revert
-
   - PR #122: Reverted to the original `pull_request` event that actually worked
   - Lost fork PR support, but gained back ALL regular PR reviews
   - Better to have 95% working than 100% broken
 
 - **Bonus Discovery**: While debugging the Vitest workflow force-push failures
-
   - Found branch protection rules were set to `~ALL` instead of just `main`
   - This was blocking pushes to PR branches, test-results branch, everything!
   - One setting change fixed multiple mysterious CI failures
@@ -390,7 +384,7 @@ Instead of having to write the code myself, I can have aider upgrade my code to 
 
 [Aider code upgrade example](https://gist.github.com/idvorkin/2f30c4f7ca2c45ab8fa534ebaeedc1e5)
 
-![Aider code upgrade example](https://private-user-images.githubusercontent.com/280981/379853492-dad3d891-15cd-4cae-b4c2-955696409002.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mjk3ODcwNjIsIm5iZiI6MTcyOTc4Njc2MiwicGF0aCI6Ii8yODA5ODEvMzc5ODUzNDkyLWRhZDNkODkxLTE1Y2QtNGNhZS1iNGMyLTk1NTY5NjQwOTAwMi5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQxMDI0JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MTAyNFQxNjE5MjJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT04YjBkYjA2NTVjOWJjNjcxYWNmMjIzYTI1Y2I2ZGI2YjM4NWI4NGM4YmQ2MjE2NzA3MjMzZWYzNDhjNDYxMWY0JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.o2ZieBjjVVuYkP3vUgLPk8aEKT4LILmFyipVefHmUlU)
+Aider code upgrade example image (broken link - expired JWT): https://private-user-images.githubusercontent.com/280981/379853492-dad3d891-15cd-4cae-b4c2-955696409002.png
 
 Which makes these links:
 
@@ -450,7 +444,7 @@ Loras we can merge:
 
 The model I trained:
 
-The [model](https://replicate.com/idvorkin/idvorkin-flux-lora-1) on [hugging face](/idvorkin/idvorkin-flux-lora-1) - idvorkin/idvorkin-flux-lora-1
+The [model](https://replicate.com/idvorkin/idvorkin-flux-lora-1) on [hugging face](https://huggingface.co/idvorkin/idvorkin-flux-lora-1) - idvorkin/idvorkin-flux-lora-1
 
 ![Igor doing something](https://replicate.delivery/yhqm/CRLshgbk5ZomNp7GxHSISkMrtynHNufLEZJpFHCa7lcGvXrJA/out-0.webp)
 
@@ -510,7 +504,6 @@ Check out the great documentation at promptfoo, including redteaming I thgues st
 ### 2024-04-06
 
 - Containerize Bot
-
   - Secret Injection
   - Auto Starting
 
@@ -582,7 +575,7 @@ Check out the great documentation at promptfoo, including redteaming I thgues st
 ### 2023-07-04
 
 - Weight and Biases LangChain Traces
-  - <https://docs.wandb.ai/guides/prompts/quickstart>
+  - https://docs.wandb.ai/guides/prompts/quickstart (broken link)
   - See each call to the model
 
 ```zsh

--- a/back-links.json
+++ b/back-links.json
@@ -1,5864 +1,5863 @@
 {
-  "redirects": {
-    "/2024": "/y24",
-    "/2025": "/y25",
-    "/24": "/y24",
-    "/25": "/y25",
-    "/48-laws": "/laws-of-power",
-    "/50yo": "/40yo",
-    "/7h": "/7-habits",
-    "/7h-c0": "/7h-concepts",
-    "/7h-c1": "/be-proactive",
-    "/7h-c2": "/end-in-mind",
-    "/7h-c3": "/first-things-first",
-    "/7h-c4": "/win-win",
-    "/7h-c5": "/first-understand",
-    "/7h-c6": "/synergize",
-    "/7h-c7": "/sharpen-the-saw",
-    "/7habits": "/7-habits",
-    "/90": "/90days",
-    "/90-days": "/90days",
-    "/Business-Model-You": "/bmy",
-    "/Coaching-Questions": "/coaching",
-    "/Human-Meetings": "/human-meetings",
-    "/aGPT": "/ai-bestie",
-    "/activation-energy": "/activation",
-    "/addictions": "/addiction",
-    "/affirm": "/affirmations",
-    "/ai-coder": "/chop",
-    "/ai-papers": "/ai-paper",
-    "/ai-talk": "/genai-talk",
-    "/ai-training": "/ai-training",
-    "/alexa-charity": "/toysfortots",
-    "/anxious": "/anxiety",
-    "/architecture": "/design",
-    "/atomic-habits": "/d/habits",
-    "/augmentedreality": "/ar",
-    "/ballooning": "/balloon",
-    "/bbb": "/build-bubble-bike",
-    "/begin-with-the-end-in-mind": "/end-in-mind",
-    "/bells": "/kettlebell",
-    "/bespoke-everything": "/hyper-personal",
-    "/bestiegpt": "/ai-bestie",
-    "/bikes": "/bike",
-    "/biking": "/bike",
-    "/bmu": "/bmy",
-    "/book-writing": "/write-book",
-    "/books": "/books-that-defined-me",
-    "/boss": "/being-a-great-manager",
-    "/brain-attack": "/suicide",
-    "/brainattack": "/suicide",
-    "/breathe": "/breath",
-    "/breathing": "/breath",
-    "/bryan-johnson": "/blueprint",
-    "/care": "/caring",
-    "/centenarian": "/last-year",
-    "/chilliwack": "/bc",
-    "/classact": "/class-act",
-    "/coach": "/coaching",
-    "/cocaine": "/mania",
-    "/cold": "/warm",
-    "/compassion": "/curious",
-    "/compensation": "/comp",
-    "/concentration-risk": "/stock-concentration",
-    "/corona": "/covid",
-    "/correct-of-errors": "/coe",
-    "/couple-double-trouble": "/partner-trouble",
-    "/couples": "/partner-trouble",
-    "/covid19": "/covid",
-    "/create-consume": "/produce-consume",
-    "/creator": "/produce-consume",
-    "/cry": "/touching",
-    "/cv": "/covid",
-    "/d/2015-11-18-Outsourcing": "/outsourcing",
-    "/data-viz": "/viz",
-    "/dealjoy": "/joy",
-    "/decide": "/decisive",
-    "/decision": "/decisive",
-    "/delegation": "/delegate",
-    "/diagrams": "/viz",
-    "/don-juan": "/enemy",
-    "/double-trouble": "/partner-trouble",
-    "/dream-job": "/job",
-    "/dsat": "/work-satisfaction",
-    "/duck-pride": "/pride",
-    "/eat-that-frog": "/frog",
-    "/effectiveness": "/balance",
-    "/emotional-health-practices": "/emotional-health",
-    "/emotional-states": "/emotions",
-    "/enabling-environment": "/enable",
-    "/enemies": "/enemy",
-    "/enjoy": "/happy",
-    "/essential": "/essentialism",
-    "/exercise": "/physical-health",
-    "/failure": "/fail",
-    "/fatality": "/death",
-    "/feeling-meetings": "/human-meetings",
-    "/feelings": "/emotions",
-    "/first-thing-first": "/first-things-first",
-    "/first90days": "/90days",
-    "/forty-two": "/42",
-    "/fortytwo": "/42",
-    "/frugality": "/parkinson",
-    "/frustration": "/anger",
-    "/fuck-shame": "/shame",
-    "/future-igor": "/time-traveler",
-    "/future-self": "/time-traveler",
-    "/genai-intern": "/genai-talk",
-    "/getting-things-done": "/gtd",
-    "/getting-to-yes": "/negotiate",
-    "/goal": "/goals",
-    "/gopher": "/delegate",
-    "/grandma": "/curious",
-    "/grandmother": "/curious",
-    "/grandmother-mind": "/curious",
-    "/grandmothermind": "/curious",
-    "/gty": "/negotiate",
-    "/guilt": "/shame",
-    "/habit": "/d/habits",
-    "/habits": "/d/habits",
-    "/happiness": "/happy",
-    "/healthspan": "/last-year",
-    "/heap - potporri - potpori": "/random-idea",
-    "/heavy-club": "/kettlebell",
-    "/heavy-clubs": "/kettlebell",
-    "/high-energy": "/energy-abundance",
-    "/humanity": "/touching",
-    "/hyper-personalization": "/hyper-personal",
-    "/idle-loop": "/idle",
-    "/iina": "/vlc",
-    "/imposter": "/insecure",
-    "/in-real-life": "/irl",
-    "/insecurity": "/insecure",
-    "/intern-llm": "/genai-talk",
-    "/jupyter": "/pandas",
-    "/kb": "/kettlebell",
-    "/kettlebells": "/kettlebell",
-    "/life-chapters": "/chapters",
-    "/life-stages": "/chapters",
-    "/lisp": "/sicp",
-    "/llm-intern": "/genai-talk",
-    "/llm-security": "/ai-security",
-    "/llm-talk": "/genai-talk",
-    "/llm-training": "/ai-training",
-    "/loneliness": "/lonely",
-    "/machine-learning": "/ml",
-    "/machinelearning": "/ml",
-    "/makejoy": "/joy",
-    "/makes-me-cry": "/touching",
-    "/makesmile": "/joy",
-    "/manager": "/being-a-great-manager",
-    "/manic": "/mania",
-    "/mechanism": "/upstream",
-    "/meditate": "/siy",
-    "/meditation": "/siy",
-    "/mental-break-down": "/depression",
-    "/middleage": "/elder",
-    "/midlife": "/elder",
-    "/monsters": "/mind-monsters",
-    "/mortality": "/death",
-    "/mr": "/ar",
-    "/negotiation": "/negotiate",
-    "/nonjudgment": "/curious",
-    "/nvim": "/vim",
-    "/objective": "/goals",
-    "/okr": "/goals",
-    "/on-being-mortal": "/death",
-    "/overwork": "/overload",
-    "/pain": "/mental-pain",
-    "/parkinson-law": "/parkinson",
-    "/parkinsons-law": "/parkinson",
-    "/passion": "/caring",
-    "/pay": "/comp",
-    "/pd": "/timeoff",
-    "/perfect-job": "/job",
-    "/personal-development": "/timeoff",
-    "/phoney": "/insecure",
-    "/pm": "/product",
-    "/podcasting": "/podcast",
-    "/podcasts": "/podcast",
-    "/poh": "/happy",
-    "/proactive": "/be-proactive",
-    "/process": "/upstream",
-    "/procrastinate": "/frog",
-    "/procrastination": "/frog",
-    "/product-manager": "/product",
-    "/production-consumption": "/produce-consume",
-    "/productivity": "/productive",
-    "/psych-safety": "/insecure",
-    "/psychological-safety": "/insecure",
-    "/rage": "/anger",
-    "/ranking": "/recommend",
-    "/rca": "/coe",
-    "/recommender": "/recommend",
-    "/regret": "/regrets",
-    "/remote": "/remote-work",
-    "/remotework": "/remote-work",
-    "/resistance": "/d/resistance",
-    "/responsible": "/be-proactive",
-    "/retirement": "/retire",
-    "/retiring": "/retire",
-    "/rework": "/staysmallstaysmall",
-    "/root-cause-analysis": "/coe",
-    "/rsu-risk": "/stock-concentration",
-    "/sat": "/work-satisfaction",
-    "/satisfaction": "/happy",
-    "/satisfied": "/happy",
-    "/saving": "/money",
-    "/savings": "/money",
-    "/savor": "/happy",
-    "/search-inside-yourself": "/siy",
-    "/shadows": "/psychic-shadows",
-    "/simple-and-sinister": "/kettlebell",
-    "/sleepless": "/insomnia",
-    "/some": "/sleight-of-mouth",
-    "/stages": "/chapters",
-    "/stewardship": "/delegate",
-    "/strong": "/physical-health",
-    "/sublime-state": "/sublime",
-    "/sublime-states": "/sublime",
-    "/taxes": "/money",
-    "/td/advertising": "/advertising",
-    "/td/design": "/design",
-    "/td/machine-learning": "/ml",
-    "/tech-ritual": "/tech-rituals",
-    "/tft": "/toysfortots",
-    "/the-dip": "/dip",
-    "/the-manager-book": "/manager-book",
-    "/the-saw": "/sharpen-the-saw",
-    "/thedip": "/dip",
-    "/think": "/writing",
-    "/thinking": "/writing",
-    "/thought-spells": "/psychic-shadows",
-    "/time-off": "/timeoff",
-    "/time-off-2024-02": "/timeoff-2024-02",
-    "/time-off-2024-04": "/timeoff-2024-04",
-    "/time-off-2024-08": "/timeoff-2024-08",
-    "/time-off-2025-08": "/timeoff-2025-08",
-    "/time-off-next": "/timeoff-2024-08",
-    "/time-off-now": "/timeoff-2024-08",
-    "/todo": "/todo_enjoy",
-    "/todo-enjoy": "/todo_enjoy",
-    "/tolerance": "/anger",
-    "/too-busy": "/overload",
-    "/training": "/ai-training",
-    "/tribes": "/tribe",
-    "/twenty-two": "/22",
-    "/twentytwo": "/22",
-    "/uncategorized": "/random-idea",
-    "/untangled-book": "/untangled",
-    "/vacation": "/timeoff",
-    "/vancouver": "/bc",
-    "/video-player": "/vlc",
-    "/videoplayer": "/vlc",
-    "/virus": "/covid",
-    "/visualizations": "/viz",
-    "/voices-in-my-head": "/voices",
-    "/vr": "/ar",
-    "/warmth": "/warm",
-    "/what-i-wish-i-knew-at-22": "/22",
-    "/win-win-or-no-deal": "/win-win",
-    "/wizard-book": "/sicp",
-    "/wlb": "/sustainable-work",
-    "/wlb-manifesto": "/sustainable-work",
-    "/work-life-balance": "/sustainable-work",
-    "/workload": "/overload",
-    "/write": "/writing",
-    "/y2024": "/y24",
-    "/y2025": "/y25",
-    "/yellow-deli": "/ig66/717",
-    "/zero": "/blueprint"
-  },
-  "url_info": {
-    "/22": {
-      "description": "In 2019 I created a program for 15 fantastic interns! A program highlight was my talk titled “What I wish I knew at 22, and so might you”. The talk received a 94% overall rating from over 15 interns, 10 SDE-IIs, and 1 senior developer. Even though the talk focuses on how to live the good life, a big chunk of life is work, so there’s good coverage on how to optimize your career.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/22.html",
-      "incoming_links": [
-        "/chapters",
-        "/manager-book"
-      ],
-      "last_modified": "2024-05-05T08:25:00-07:00",
-      "markdown_path": "_d/22.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "What I wish I knew at 22 and so might you!",
-      "url": "/22"
-    },
-    "/40yo": {
-      "description": "In 2002, I started programming at MSFT with lots of other 20-year-olds. I don’t recall the age distributions, but maybe 90% of the programmers I knew were under 40. In 2020, at 41, I’m no longer a programmer, and the majority of programmers are much younger than me. This begs the question, where do all the programmers go as they get older? I’m very curious about the answer. Here are some of my theories….\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/40yo.html",
-      "incoming_links": [
-        "/elder"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/40-yo-programmer.md",
-      "outgoing_links": [
-        "/chop",
-        "/elder"
-      ],
-      "redirect_url": "",
-      "title": "Age Before Beauty: The Vanishing Act of Older Coders",
-      "url": "/40yo"
-    },
-    "/42": {
-      "description": "You survived young kids, marriage, house, some easy crises, and now it’s time for remember , a healthy woman has a thousand wishes, a sick woman - just one: Things i wish I knew at 42\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/42.html",
-      "incoming_links": [
-        "/chapters",
-        "/retire",
-        "/y24",
-        "/y25"
-      ],
-      "last_modified": "2025-07-20T19:13:52-07:00",
-      "markdown_path": "_d/42.md",
-      "outgoing_links": [
-        "/chapters",
-        "/diet",
-        "/last-year",
-        "/physical-health",
-        "/retire",
-        "/sustainable-work",
-        "/terzepatide"
-      ],
-      "redirect_url": "",
-      "title": "What I wish I knew at 42",
-      "url": "/42"
-    },
-    "/4dx": {
-      "description": "The 4 Disciplines of Execution (4DX) is a proven framework for executing your most important strategic priorities in the midst of the whirlwind of day-to-day demands. This framework has been tested and refined by hundreds of organizations and thousands of teams over many years.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/4dx.html",
-      "incoming_links": [
-        "/goals"
-      ],
-      "last_modified": "2025-02-17T10:16:11-08:00",
-      "markdown_path": "_d/4dx.md",
-      "outgoing_links": [
-        "/end-in-mind",
-        "/essentialism",
-        "/first-things-first",
-        "/goals",
-        "/gtd"
-      ],
-      "redirect_url": "",
-      "title": "The 4 Disciplines of Execution (4DX)",
-      "url": "/4dx"
-    },
-    "/7-habits": {
-      "description": "Need a user manual for life? For me, that’s The 7 Habits of Highly Effective People. From dependent, to independent to interdependent, and then rinse and repeat for the different roles in your life. Like other self-help books? Excellent chance it’s a reframe or deep dive into these concepts.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/7-habits.html",
-      "incoming_links": [
-        "/7h-concepts",
-        "/balance",
-        "/be-proactive",
-        "/books-that-defined-me",
-        "/depression",
-        "/end-in-mind",
-        "/eulogy",
-        "/first-things-first",
-        "/first-understand",
-        "/psychic-weight",
-        "/sharpen-the-saw",
-        "/synergize",
-        "/timeoff-2020-12",
-        "/win-win"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_posts/2018-01-04-7-habits.md",
-      "outgoing_links": [
-        "/7h-concepts",
-        "/balance",
-        "/be-proactive",
-        "/end-in-mind",
-        "/eulogy",
-        "/first-things-first",
-        "/first-understand",
-        "/sharpen-the-saw",
-        "/synergize",
-        "/win-win"
-      ],
-      "redirect_url": "",
-      "title": "Seven Habits: A manual for life",
-      "url": "/7-habits"
-    },
-    "/7h-concepts": {
-      "description": "To discuss the 7 habits we need some foundational ideas, P/PC, paradigms, etc. These are my insights based on the 7 habits Chapter 0.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/7h-concepts.html",
-      "incoming_links": [
-        "/7-habits",
-        "/advice",
-        "/writing"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/7h-c0.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/balance",
-        "/sleight-of-mouth"
-      ],
-      "redirect_url": "",
-      "title": "7 habits concepts",
-      "url": "/7h-concepts"
-    },
-    "/90days": {
-      "description": "The first 90 days is a how to manual for starting a new job. While it’s focused on executive roles, it’s applicable to lower levels as well. It’s also the best written business book from a structural perspective. I highly recommend it.\n\n",
-      "doc_size": 50000,
-      "file_path": "_site/90days.html",
-      "incoming_links": [
-        "/manager-book",
-        "/writing"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_d/90days.md",
-      "outgoing_links": [
-        "/amazon",
-        "/curious",
-        "/first-things-first",
-        "/insecure",
-        "/shame",
-        "/writing"
-      ],
-      "redirect_url": "",
-      "title": "The first 90 days",
-      "url": "/90days"
-    },
-    "/Canadian-Spotting": {
-      "description": "“I bet you the bill that dude by the window is Canadian,” I challenged.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/Canadian-Spotting.html",
-      "incoming_links": [],
-      "last_modified": "2022-04-06T13:56:34-07:00",
-      "markdown_path": "_posts/2017-01-10-Canadian-Spotting.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Canadian Spotting",
-      "url": "/Canadian-Spotting"
-    },
-    "/Immutable-Laws-Of-Hard": {
-      "description": "Exercise, Diet, Personal Development, each of these is governed by the immutable laws of hard things. It’s possible these laws don’t apply to you, but I doubt it.\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/Immutable-Laws-Of-Hard.html",
-      "incoming_links": [
-        "/frog",
-        "/operating-manual"
-      ],
-      "last_modified": "2018-12-25T15:32:00-08:00",
-      "markdown_path": "_posts/2016-6-30-Immutable-Laws-Of-Hard.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "The Immutable Laws of Hard Things",
-      "url": "/Immutable-Laws-Of-Hard"
-    },
-    "/The-Genesis-Node": {
-      "description": "Igor, you know the odds of shipping Azure on time are slim to none.”\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/The-Genesis-Node.html",
-      "incoming_links": [
-        "/eulogy"
-      ],
-      "last_modified": "2020-05-06T21:46:45-07:00",
-      "markdown_path": "_posts/2018-11-03-The-Genesis-Node.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Microsoft Azure - The Genesis Node",
-      "url": "/The-Genesis-Node"
-    },
-    "/about": {
-      "description": "Igor's Blog",
-      "doc_size": 20000,
-      "file_path": "_site/about.html",
-      "incoming_links": [],
-      "last_modified": "2025-07-27T15:35:40-07:00",
-      "markdown_path": "about.md",
-      "outgoing_links": [
-        "/new-skills",
-        "/recent"
-      ],
-      "redirect_url": "",
-      "title": "Where am I?",
-      "url": "/about"
-    },
-    "/activation": {
-      "description": "Doing activities requires will power, addictions and procrastination require negative will power, while positive habits, especially new ones require high will power. Here’s a model for these things.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/activation.html",
-      "incoming_links": [
-        "/addiction",
-        "/balance",
-        "/energy",
-        "/energy-abundance",
-        "/produce-consume",
-        "/slow",
-        "/timeoff-2021-12"
-      ],
-      "last_modified": "2025-08-30T09:57:08-07:00",
-      "markdown_path": "_d/activation.md",
-      "outgoing_links": [
-        "/addiction",
-        "/blueprint",
-        "/d/habits",
-        "/d/resistance",
-        "/insomnia"
-      ],
-      "redirect_url": "",
-      "title": "Activation Energy",
-      "url": "/activation"
-    },
-    "/adblocker-trojan": {
-      "description": "Out of the blue I started seeing ads in my google search. They were especially prominent due to the fact they were white, and I use a back background. It was caused by a trojan running in my chrome extension, which I suspect was installed by a name-jacked NPM plugin.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/adblocker-trojan.html",
-      "incoming_links": [
-        "/timeoff-2021-11"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_td/adblocker_trojan.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "The Mystery of the google ads",
-      "url": "/adblocker-trojan"
-    },
-    "/addiction": {
-      "description": "Addiction is not about drugs or alcohol - it is about escape. Quoting “Do the Work”: When we can’t stand the fear, the shame, and the self-reproach that we feel, we obliterate it with an addiction. The addiction becomes the shadow version, the evil twin of our calling to service or to art. That’s why addicts are so interesting and so boring at the same time. They’re interesting because they’re called to something — something new, something unique, something that we, watching, can’t wait to see them bring forth into manifestation. At the same time, they’re boring because they never do the work. The addiction becomes his purpose, his novel, his adventure, his great love. The work of art or service that might have been produced is replaced by the drama, conflict, and suffering of the addict’s crazy, haunted, shattered life.\n\n",
-      "doc_size": 22000,
-      "file_path": "_site/addiction.html",
-      "incoming_links": [
-        "/activation",
-        "/anxiety-management",
-        "/d/resistance",
-        "/first-things-first",
-        "/happy",
-        "/idle",
-        "/mental-pain",
-        "/mind-at-work",
-        "/productive",
-        "/psychic-shadows",
-        "/psychic-weight",
-        "/timeoff"
-      ],
-      "last_modified": "2025-09-01T09:23:45-07:00",
-      "markdown_path": "_d/addiction.md",
-      "outgoing_links": [
-        "/activation",
-        "/covid",
-        "/elder",
-        "/mental-pain",
-        "/mind-at-work"
-      ],
-      "redirect_url": "",
-      "title": "Escape Artists: The True Face of Addiction",
-      "url": "/addiction"
-    },
-    "/advertising": {
-      "description": "Advertising is 155 billion business in the USA. Of that 155B, 85B is Digital and 70B is TV(digital platforms are invest ing in video to capture the TV spend. This post captures my understanding of that world.\n\n",
-      "doc_size": 25000,
-      "file_path": "_site/advertising.html",
-      "incoming_links": [
-        "/monetize"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/advertising.md",
-      "outgoing_links": [
-        "/monetize"
-      ],
-      "redirect_url": "",
-      "title": "Advertising",
-      "url": "/advertising"
-    },
-    "/advice": {
-      "description": "Welcome to The Advice Lab! Think of advice like software - some versions are stable, others are still in beta, and what works perfectly on one system might crash another. Here we’ll explore the art and science of giving and receiving life’s most valuable patches and updates.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/advice.html",
-      "incoming_links": [],
-      "last_modified": "2025-01-26T15:44:57-08:00",
-      "markdown_path": "_d/advice.md",
-      "outgoing_links": [
-        "/7h-concepts",
-        "/first-understand"
-      ],
-      "redirect_url": "",
-      "title": "The Advice Lab: Where Wisdom Gets Beta Tested",
-      "url": "/advice"
-    },
-    "/affirmations": {
-      "description": "Every day I write out my affirmations. These positive statements help me challenge and overcome my self-sabotaging and negative thoughts and behaviors. Repeating them reinforces them, helping me be the person I want to be. My affirmations have power to me and have evolved over time. You’ll want to find the ones that speak best to you. Oh and bonus points if beyond just writing out your daily affirmations you reflect on how you can/will and have applied them.\n\n",
-      "doc_size": 22000,
-      "file_path": "_site/affirmations.html",
-      "incoming_links": [
-        "/gap-year-igor",
-        "/mortality-software",
-        "/operating-manual",
-        "/process-journal"
-      ],
-      "last_modified": "2025-06-17T07:29:01-07:00",
-      "markdown_path": "_d/affirmations2.md",
-      "outgoing_links": [
-        "/anxiety",
-        "/appreciate",
-        "/be-proactive",
-        "/class-act",
-        "/curious",
-        "/end-in-mind",
-        "/essentialism",
-        "/first-things-first",
-        "/first-understand",
-        "/insecure",
-        "/joy",
-        "/sublime",
-        "/writing"
-      ],
-      "redirect_url": "",
-      "title": "Affirmations",
-      "url": "/affirmations"
-    },
-    "/ai": {
-      "description": "AI becomes the\nThe transition from A landing page for all my ai pages - a nice jumping off point (especially from the graph).\n\n",
-      "doc_size": 26000,
-      "file_path": "_site/ai.html",
-      "incoming_links": [
-        "/ai-developer"
-      ],
-      "last_modified": "2025-05-19T09:09:26-07:00",
-      "markdown_path": "_d/ai.md",
-      "outgoing_links": [
-        "/ai-art",
-        "/ai-bestie",
-        "/ai-bm",
-        "/ai-developer",
-        "/ai-image",
-        "/ai-journal",
-        "/ai-paper",
-        "/ai-security",
-        "/ai-testing",
-        "/chop",
-        "/chow",
-        "/ml",
-        "/recommend",
-        "/vibe"
-      ],
-      "redirect_url": "",
-      "title": "All posts on AI",
-      "url": "/ai"
-    },
-    "/ai-art": {
-      "description": "Creativity is a critical aspect of art, and that’s something which I think AI can be really good at. Some very random ideas\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/ai-art.html",
-      "incoming_links": [
-        "/ai",
-        "/ai-journal"
-      ],
-      "last_modified": "2025-09-07T17:04:01-07:00",
-      "markdown_path": "_d/ai-art.md",
-      "outgoing_links": [
-        "/ai-image",
-        "/gpt"
-      ],
-      "redirect_url": "",
-      "title": "AI and art",
-      "url": "/ai-art"
-    },
-    "/ai-bestie": {
-      "description": "My best friend and I communicate over chat lots (33,60,101 messages/day P50, P75, P95). I have years of chat history, and so this seemed like a super fun way to get deeper into ML. This is created and shared with his permission.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/ai-bestie.html",
-      "incoming_links": [
-        "/ai",
-        "/y24"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/ai-bestie.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Igor's AI Bestie Simulator",
-      "url": "/ai-bestie"
-    },
-    "/ai-bm": {
-      "description": "Business Models drive the world, and they’ll drive the world of AI too.\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/ai-bm.html",
-      "incoming_links": [
-        "/ai"
-      ],
-      "last_modified": "2024-12-05T09:18:22-08:00",
-      "markdown_path": "_d/ai-business-model.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "AI Security",
-      "url": "/ai-bm"
-    },
-    "/ai-developer": {
-      "description": "ML Engineer is a hot new job. It’s the boys and girls who train and deploy models. I heard the word AI developer the other day, and I’ll refer to it as AI application engineers. People who use AI to solve use cases. NOTE: This is not what most developers do today. What most developers do today is ask how can AI do the things I would have done (e.g. write the function).\n\n",
-      "doc_size": 40000,
-      "file_path": "_site/ai-developer.html",
-      "incoming_links": [
-        "/ai"
-      ],
-      "last_modified": "2025-07-20T19:13:52-07:00",
-      "markdown_path": "_d/ai-developer.md",
-      "outgoing_links": [
-        "/ai"
-      ],
-      "redirect_url": "",
-      "title": "AI Developer",
-      "url": "/ai-developer"
-    },
-    "/ai-image": {
-      "description": "Everyone talks about GPT, but you can also generate images. Lately, I’ve been playing with Flux, which is an image generator. You can generate images of me using the idvorkin with this lora on replicate.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/ai-image.html",
-      "incoming_links": [
-        "/ai",
-        "/ai-art"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/ai-imagegen.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "AI Image Generation",
-      "url": "/ai-image"
-    },
-    "/ai-journal": {
-      "description": "A journal of random explorations in AI. Keeping track of them so I don’t get super lost\n\n",
-      "doc_size": 63000,
-      "file_path": "_site/ai-journal.html",
-      "incoming_links": [
-        "/ai"
-      ],
-      "last_modified": "2025-09-07T17:30:11-07:00",
-      "markdown_path": "_d/ai-journal.md",
-      "outgoing_links": [
-        "/ai-art",
-        "/ai-security",
-        "/eulogy",
-        "/genai-talk",
-        "/gpt",
-        "/hyper-personal",
-        "/idvorkin/idvorkin-flux-lora-1",
-        "/mental-pain"
-      ],
-      "redirect_url": "",
-      "title": "Igor's AI Journal",
-      "url": "/ai-journal"
-    },
-    "/ai-paper": {
-      "description": "The original AI papers were all about training, super technical, and not that usable as a practitioner. Nowadays papers are less “mathy” and more applicable to practitioners. Here are some worth reading\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/ai-paper.html",
-      "incoming_links": [
-        "/ai"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/ai-paper.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Seminal AI Papers",
-      "url": "/ai-paper"
-    },
-    "/ai-security": {
-      "description": "Security is super interesting, AI is super interesting, the combination, is super-duper interesting!\n\n",
-      "doc_size": 27000,
-      "file_path": "_site/ai-security.html",
-      "incoming_links": [
-        "/ai",
-        "/ai-journal"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/ai-security.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "AI Security",
-      "url": "/ai-security"
-    },
-    "/ai-testing": {
-      "description": "Testing math is easy, it’s right or wrong. Testing spelling is easy too, but testing if a joke is funny - now that’s tough. Let’s talk about how to test AI.\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/ai-testing.html",
-      "incoming_links": [
-        "/ai",
-        "/chop",
-        "/genai-talk",
-        "/ml",
-        "/testing",
-        "/timeoff-2024-04"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/ai-testing.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Testing AI",
-      "url": "/ai-testing"
-    },
-    "/amazon": {
-      "description": "I spent 4 years working at Amazon, some things I loved, some not so much. Amazon is a huge company and the variation of behavior within a company exceeds the variation between the “median” behavior between companies. Even within the two teams I was on at Amazon I saw the exact opposite behaviors. When I talk about the good, I’ll talk about the ideal good, and when I talk about the bad, I’ll talk to some issues I saw that were systemically bad. As a result you’ll often see me describing something as both good and bad, as it’s done differently in different parts of the company.\n\n",
-      "doc_size": 29000,
-      "file_path": "_site/amazon.html",
-      "incoming_links": [
-        "/90days",
-        "/manager-book-appendix",
-        "/parkinson",
-        "/writing"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/amazon.md",
-      "outgoing_links": [
-        "/coe",
-        "/design",
-        "/manager-book",
-        "/td/cloud-first-applications",
-        "/td/data-systems",
-        "/toysfortots",
-        "/writing"
-      ],
-      "redirect_url": "",
-      "title": "My thoughts on Amazon",
-      "url": "/amazon"
-    },
-    "/anger": {
-      "description": "It’s 8 am; The normal rush, the kids are late to school, we’re yelling at them to eat their breakfast, pack their lunch, brush their teeth, get ready for school. 30 minutes earlier, I’d decided I’d bike Amelia, my 7 year old daughter, to school. I told Tori, my wife, who normally drives the kids to school. Tori didn’t acknowledge me. As I got my bike helmet Tori put the kids in the car. I ran out and tried to get her attention, waving frantically and running to the car. (In my head), Tori ignored me, wouldn’t look at me, even as I ran to the car and gesticulated wildly. I really had my heart set on biking Amelia to school, and I went into a rage, as Tori pulled off, I flipped her off. Adulting fail - not my best moment.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/anger.html",
-      "incoming_links": [
-        "/emotions",
-        "/mood"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_d/anger.md",
-      "outgoing_links": [
-        "/depression",
-        "/mental-pain"
-      ],
-      "redirect_url": "",
-      "title": "Anger is the enemy",
-      "url": "/anger"
-    },
-    "/anxiety": {
-      "description": "Anxiety is the difference between reality and expectations. It is the pain, while stress is the suffering. The pain of anxiety is designed for threatening circumstances drawing your attention to a problem requiring urgent attention. This narrows your perspective allowing you to focus on a resolution. However, like many autonomous systems anxiety can be over-triggered, and handled poorly without deliberate action.\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/anxiety.html",
-      "incoming_links": [
-        "/affirmations",
-        "/anxiety-management",
-        "/depression",
-        "/fail",
-        "/gtd",
-        "/happy",
-        "/operating-manual",
-        "/overload",
-        "/productive",
-        "/slow",
-        "/touching",
-        "/voices"
-      ],
-      "last_modified": "2025-08-24T10:29:13-07:00",
-      "markdown_path": "_d/anxiety.md",
-      "outgoing_links": [
-        "/anxiety-management",
-        "/be-proactive",
-        "/idle",
-        "/slow",
-        "/voices"
-      ],
-      "redirect_url": "",
-      "title": "Anxiety, the gap between reality and expectations",
-      "url": "/anxiety"
-    },
-    "/anxiety-management": {
-      "description": "When your emotions aren’t serving you well, it’s helpful to have a solid protocol. First you need to rebuild perspective, and then you need to focus on maximizing your influence.\n\n",
-      "doc_size": 22000,
-      "file_path": "_site/anxiety-management.html",
-      "incoming_links": [
-        "/anxiety",
-        "/fail",
-        "/psychic-shadows"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/anxiety_management.md",
-      "outgoing_links": [
-        "/addiction",
-        "/anxiety",
-        "/frog",
-        "/mental-pain",
-        "/psychic-shadows",
-        "/siy"
-      ],
-      "redirect_url": "",
-      "title": "Anxiety Management",
-      "url": "/anxiety-management"
-    },
-    "/appreciate": {
-      "description": "Think of the last time you were appreciated: How did you feel? Think about the last hour: How many things could you have appreciated? It takes 7 positive experiences to make up for 1 negative experience - what can you appreciate?\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/appreciate.html",
-      "incoming_links": [
-        "/affirmations",
-        "/class-act"
-      ],
-      "last_modified": "2022-03-20T09:28:13-07:00",
-      "markdown_path": "_d/appreciate2.md",
-      "outgoing_links": [
-        "/grateful"
-      ],
-      "redirect_url": "",
-      "title": "Appreciate",
-      "url": "/appreciate"
-    },
-    "/ar": {
-      "description": "My notes on AR\n\n",
-      "doc_size": 19000,
-      "file_path": "_site/ar.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/ar.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Augmented Reality",
-      "url": "/ar"
-    },
-    "/asciinema": {
-      "description": "Lets clean this up and see what it looks like …\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/asciinema.html",
-      "incoming_links": [],
-      "last_modified": "2024-04-08T15:04:01-07:00",
-      "markdown_path": "_td/asciinema.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "asciinema",
-      "url": "/asciinema"
-    },
-    "/ast-grep": {
-      "description": "Sometimes you need to search/replace but on code, so let’s use ASTs for that. The tool is called ast-grep (which you invoke with sg).\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/ast-grep.html",
-      "incoming_links": [],
-      "last_modified": "2024-09-22T16:18:28-07:00",
-      "markdown_path": "_td/ast-grep.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "AST Grep",
-      "url": "/ast-grep"
-    },
-    "/balance": {
-      "description": "I’m good at a lot of things, but balance is really hard for me. Hard for everyone I bet. I think this would be an area that can really benefit from mortality software. TODO: decide if this post should fork into energy and balance\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/balance.html",
-      "incoming_links": [
-        "/7-habits",
-        "/7h-concepts",
-        "/energy-abundance",
-        "/life-as-business",
-        "/productive",
-        "/slow",
-        "/timeoff-2021-12"
-      ],
-      "last_modified": "2025-08-24T10:29:13-07:00",
-      "markdown_path": "_d/balance2.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/activation",
-        "/energy",
-        "/essentialism",
-        "/eulogy",
-        "/moments",
-        "/mortality-software",
-        "/parkinson",
-        "/productive",
-        "/slow",
-        "/sustainable-work",
-        "/timeoff",
-        "/weeks"
-      ],
-      "redirect_url": "",
-      "title": "Balance - The Holy Grail",
-      "url": "/balance"
-    },
-    "/balloon": {
-      "description": "Want to plaster a huge smile on someone’s face with 10 cents of material and 20 seconds of work? Make them a balloon! In 2022, I discovered ballooning, and have used it in my joy-delivering arsenal ever since.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/balloon.html",
-      "incoming_links": [
-        "/eulogy",
-        "/joy",
-        "/timeoff"
-      ],
-      "last_modified": "2025-04-04T06:53:08-07:00",
-      "markdown_path": "_d/balloon.md",
-      "outgoing_links": [
-        "/joy"
-      ],
-      "redirect_url": "",
-      "title": "Being a Ballooner",
-      "url": "/balloon"
-    },
-    "/bc": {
-      "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/bc.html",
-      "incoming_links": [],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/bc-vacation.md",
-      "outgoing_links": [
-        "/ig66/718",
-        "/ig66/749",
-        "/timeoff-2024-02"
-      ],
-      "redirect_url": "",
-      "title": "BC Vacation Guide: Vancouver & Chilliwack Adventures",
-      "url": "/bc"
-    },
-    "/be-proactive": {
-      "description": "I choose ‘.’ I am responsible for my own life ‘.’ My behavior is a function of my decisions, not my conditions ‘.’ I can subordinate feelings to values ‘.’ I have the initiative and the responsibility to make things happen. These are my insights from 7 habits Chapter 1.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/be-proactive.html",
-      "incoming_links": [
-        "/7-habits",
-        "/affirmations",
-        "/anxiety",
-        "/d/habits",
-        "/emotions",
-        "/frog",
-        "/idle",
-        "/process-journal",
-        "/regrets",
-        "/siy"
-      ],
-      "last_modified": "2025-04-02T22:07:54-07:00",
-      "markdown_path": "_d/7h-c1.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/essentialism",
-        "/frog",
-        "/siy"
-      ],
-      "redirect_url": "",
-      "title": "Be Proactive",
-      "url": "/be-proactive"
-    },
-    "/being-a-great-manager": {
-      "description": "I aspire to be the best manager I can be. I’ll often fall short of my goal, but through continuous practice I will get closer. This post will gather my research on being a great manager, enumerate some of my learnings, and inspire me to be my best. Few things make me prouder than this public feedback on LinkedIn from people who worked with me over several years. I’m also writing a manager guidebook, which goes into much more depth on management.\n\n",
-      "doc_size": 22000,
-      "file_path": "_site/being-a-great-manager.html",
-      "incoming_links": [
-        "/bmy",
-        "/eulogy",
-        "/job",
-        "/manager-book"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_posts/2018-03-18-being-a-great-manager.md",
-      "outgoing_links": [
-        "/books-that-defined-me",
-        "/coaching",
-        "/curious",
-        "/decisive",
-        "/human-meetings",
-        "/manager-book",
-        "/mind-monsters",
-        "/moments-at-work",
-        "/pride",
-        "/static/idvorkin-linked-in-feedback-lastest.pdf",
-        "/sustainable-work"
-      ],
-      "redirect_url": "",
-      "title": "Being the best manager I can be",
-      "url": "/being-a-great-manager"
-    },
-    "/bike": {
-      "description": "Biking, is something that make my very happy. I have multiple bikes, here are my notes.\n\n",
-      "doc_size": 22000,
-      "file_path": "_site/bike.html",
-      "incoming_links": [
-        "/eulogy",
-        "/irl",
-        "/operating-manual"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_posts/2017-03-01-bike.md",
-      "outgoing_links": [
-        "/brompton-toys",
-        "/warm"
-      ],
-      "redirect_url": "",
-      "title": "Biking",
-      "url": "/bike"
-    },
-    "/blueprint": {
-      "description": "So there’s this guy who measures his nightly erections, doesn’t go out into the sun, and strives to delegate all his decision making to an algorithm called blue print. Certainly a nut job, but a nut job who has explored many of the thoughts I’m very interested in. Depression, purpose, sleep, exercise. Here are my notes.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/blueprint.html",
-      "incoming_links": [
-        "/activation",
-        "/operating-manual",
-        "/sleep",
-        "/timeoff-2024-02"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/blueprint.md",
-      "outgoing_links": [
-        "/ig66/663",
-        "/voices"
-      ],
-      "redirect_url": "",
-      "title": "Bryan Johnson - A 50 year old 18 year old",
-      "url": "/blueprint"
-    },
-    "/bmy": {
-      "description": "The business model canvas is a tool for understanding how a company makes money. This same model can be applied to a person’s career. While job hunting this was helpful figuring out my dream job. I suppose it should also prioritize my work energy, and probably how to prioritize my life energy. But that’s to come.\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/bmy.html",
-      "incoming_links": [
-        "/job-hunt-stress"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/bmu.md",
-      "outgoing_links": [
-        "/being-a-great-manager",
-        "/eulogy",
-        "/job",
-        "/job-hunt-stress"
-      ],
-      "redirect_url": "",
-      "title": "Business Model You",
-      "url": "/bmy"
-    },
-    "/books-that-defined-me": {
-      "description": "Books allow great thoughts to enter our mind and mold us into who we want to become. These are the books that are molding me.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/books-that-defined-me.html",
-      "incoming_links": [
-        "/being-a-great-manager",
-        "/manager-book",
-        "/manager-book-appendix"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_posts/2015-11-02-books-that-defined-me.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/d/resistance",
-        "/essentialism",
-        "/getting-to-yes-with-yourself",
-        "/gtd",
-        "/humans-are-underrated",
-        "/siy"
-      ],
-      "redirect_url": "",
-      "title": "Books that defined me",
-      "url": "/books-that-defined-me"
-    },
-    "/breath": {
-      "description": "Breathing, an act so simple yet so crucial, harbors the potential to transform our health, mind, and life. This blog post is a deep dive into the world of breathing techniques, exploring a range of practices from Box Breathing and Victory Breath to Sitali Breath and the Breath Focus Technique. Each technique is detailed with its benefits and step-by-step instructions. In addition, the scientific perspective on breathing is explored. Whether you’re seeking to reduce stress, improve focus, or simply understand the science of breathing, this post is your comprehensive guide. Join us as we explore the art of breathing, its techniques, and the science behind it.\n\n",
-      "doc_size": 27000,
-      "file_path": "_site/breath.html",
-      "incoming_links": [],
-      "last_modified": "2025-03-02T20:00:19-08:00",
-      "markdown_path": "_d/breath.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Breathing as if your life depends on it",
-      "url": "/breath"
-    },
-    "/brompton-toys": {
-      "description": "I LOVE my Brompton, and have spent much time researching accessories for it. Here are the accoutraments I’ve bought for my Brompton, and hopefully it’ll save other Brompton owners time, and/or make them aware of accessories they don’t known about.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/brompton-toys.html",
-      "incoming_links": [
-        "/bike"
-      ],
-      "last_modified": "2018-12-25T15:32:00-08:00",
-      "markdown_path": "_posts/2016-4-9-brompton-toys.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "My Brompton and its accoutrements",
-      "url": "/brompton-toys"
-    },
-    "/brython": {
-      "description": "This page is built with brython, a python running in browser via WASM. This is my playground to try interesting things with brython.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/brython.html",
-      "incoming_links": [
-        "/timeoff-2021-11"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/brython_.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "A playground for brython and pystory",
-      "url": "/brython"
-    },
-    "/build-bubble-bike": {
-      "description": "What the heck is a bubble bike? Ah, you see, bringing joy for others is my thing. As they say in Buddhism there are many vehicles to bring joy, and my vehicle is the bubble bike.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/build-bubble-bike.html",
-      "incoming_links": [
-        "/joy"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/build-bubble-bike.md",
-      "outgoing_links": [
-        "/joy"
-      ],
-      "redirect_url": "",
-      "title": "Building a bubble bike",
-      "url": "/build-bubble-bike"
-    },
-    "/cache": {
-      "description": "Internal incubations are fun, but I love shipping products. In the case of Microsoft Cache, before I joined, the team had been incubating OneClip, and needed help bringing it to market. My self and a top tier product manager joined the team to help them ship. We immediately got to work, recruiting senior talent, and closing the gaps. We tackled the technical, product market fit, and logistical issues required to bring the product to market.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/cache.html",
-      "incoming_links": [
-        "/eulogy",
-        "/job"
-      ],
-      "last_modified": "2023-12-17T18:53:39+00:00",
-      "markdown_path": "_posts/2018-1-1-cache.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Shipping incubations: Cache",
-      "url": "/cache"
-    },
-    "/caring": {
-      "description": "Let’s define caring, as the intensity of our emotions, critical given a lack of emotional intensity is depression. Intense emotions are synonymous with interest and mental energy, which is a double edged sword: Good caring (commitment to our identity, positive habits) charges us up, but bad caring (attachment, anger, anxiety, focus on things we don’t control), brings us down. When bad caring manifests as repetitive, ruminating thought patterns, they become psychic shadows requiring specialized techniques:\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/caring.html",
-      "incoming_links": [
-        "/depression"
-      ],
-      "last_modified": "2025-07-18T07:57:44-07:00",
-      "markdown_path": "_d/caring.md",
-      "outgoing_links": [
-        "/depression",
-        "/psychic-shadows"
-      ],
-      "redirect_url": "",
-      "title": "Caring - The story of emotional intensity",
-      "url": "/caring"
-    },
-    "/cert-error": {
-      "description": "Dad the website isn’t secure! You’re the security expert fix it! Zach, my 10 year old at the time son, runs a web site, and it got an occasional this website is not secure message. I tried to debug, but couldn’t get a consistent enough repro to debug, so had to move on. It stayed in this state for 6 months, at which point Zach told me the certificate had expired. Now i had a 100% repro so went to work.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/cert-error.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T10:48:49-07:00",
-      "markdown_path": "_td/fix_cert_error.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "The Case of the Cert Validation Error",
-      "url": "/cert-error"
-    },
-    "/chapters": {
-      "description": "Our lives are stories, containing many different chapters. However, regardless of what is in the chapters, we all go through life stages, being young, growing up, getting old, etc. What you need as a 22-year-old, and what you need as a 42-year-old sure are different. I think our lives are both chapters in terms of the plot, but also in terms of the stages of life.\n\n",
-      "doc_size": 22000,
-      "file_path": "_site/chapters.html",
-      "incoming_links": [
-        "/42",
-        "/gap-year",
-        "/gap-year-igor",
-        "/lonely",
-        "/retire",
-        "/y25"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/chapters.md",
-      "outgoing_links": [
-        "/22",
-        "/42",
-        "/enemy"
-      ],
-      "redirect_url": "",
-      "title": "The chapters of our lives",
-      "url": "/chapters"
-    },
-    "/chasing-daylight": {
-      "description": "Monday morning: You’re Eugene O’Kelly, CEO of KPMG, reviewing next quarter’s strategy. Your calendar is packed with board meetings, your daughter’s college visits are scheduled for fall, and you’re planning that anniversary trip for next summer. Tuesday afternoon: You’re sitting in a doctor’s office, trying to process the words “terminal brain cancer” and “three months to live.” In an instant, your calendar becomes meaningless - all those carefully planned years collapse into a countdown of just 100 days. This was O’Kelly’s reality, and his response was remarkable: he chose to approach his death with the same clarity and purpose that had marked his life. This is what I learned from his story.\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/chasing-daylight.html",
-      "incoming_links": [
-        "/gap-year-igor",
-        "/last-year"
-      ],
-      "last_modified": "2025-02-23T06:32:12-08:00",
-      "markdown_path": "_d/chasing-daylight.md",
-      "outgoing_links": [
-        "/death",
-        "/happy",
-        "/last-year",
-        "/moments"
-      ],
-      "redirect_url": "",
-      "title": "Chasing Daylight: Imagine you're gonna die in less then 100 days",
-      "url": "/chasing-daylight"
-    },
-    "/chop": {
-      "description": "Welcome to The CHOP Shop! CHOP - or Chat-Oriented Programming - is revolutionizing how we write code. Think of those old-school auto shops: AI started as the shop hand, fetching tools and cleaning parts. Then it became an apprentice mechanic, helping diagnose problems and suggesting fixes. Now? It’s a master mechanic, capable of rebuilding entire engines from your high-level specs. Our AIs are getting smarter by the day, and we’ll explore how to make the most of this evolution.\n\n",
-      "doc_size": 59000,
-      "file_path": "_site/chop.html",
-      "incoming_links": [
-        "/40yo",
-        "/ai",
-        "/chow",
-        "/gtd",
-        "/process-journal",
-        "/tech-rituals",
-        "/vibe",
-        "/y24",
-        "/y25"
-      ],
-      "last_modified": "2025-09-10T09:24:52-07:00",
-      "markdown_path": "_d/ai-coder.md",
-      "outgoing_links": [
-        "/ai-testing",
-        "/humans-are-underrated",
-        "/process-journal",
-        "/testing",
-        "/vibe"
-      ],
-      "redirect_url": "",
-      "title": "The CHOP Shop: Where AI Meets Code",
-      "url": "/chop"
-    },
-    "/chow": {
-      "description": "Welcome to The CHOW Kitchen! CHOW - or Chat-Oriented Writing - is transforming how we create content. Think of those bustling restaurant kitchens: AI started as the prep cook, chopping vegetables and measuring ingredients. Then it became a line cook, helping with recipes and plating. Now? It’s becoming a sous chef, capable of crafting entire dishes from your creative vision. Our AIs are getting more sophisticated daily, and we’ll explore how to make the most of this culinary revolution in writing.\n\n",
-      "doc_size": 28000,
-      "file_path": "_site/chow.html",
-      "incoming_links": [
-        "/ai"
-      ],
-      "last_modified": "2025-02-16T07:25:27-08:00",
-      "markdown_path": "_d/chow.md",
-      "outgoing_links": [
-        "/chop",
-        "/enable",
-        "/td/data-systems",
-        "/writing"
-      ],
-      "redirect_url": "",
-      "title": "The CHOW Kitchen: Where AI Meets Writing",
-      "url": "/chow"
-    },
-    "/class-act": {
-      "description": "Be a class act. Fantatic advice.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/class-act.html",
-      "incoming_links": [
-        "/affirmations"
-      ],
-      "last_modified": "2024-11-30T08:42:37-08:00",
-      "markdown_path": "_d/classact2.md",
-      "outgoing_links": [
-        "/appreciate",
-        "/curious",
-        "/first-understand",
-        "/touching"
-      ],
-      "redirect_url": "",
-      "title": "Be a class act",
-      "url": "/class-act"
-    },
-    "/coaching": {
-      "description": "Coaching is like midwifery. A midwife can not give birth to the baby, she facilitates the birth. Similarly, a coach can not give a solution, she must give birth to the insight from within the coachee. Coaching is asking questions, guiding, and facilitating understanding, and this post collects my studies on the topic.\n\n",
-      "doc_size": 30000,
-      "file_path": "_site/coaching.html",
-      "incoming_links": [
-        "/being-a-great-manager",
-        "/first-understand",
-        "/insecure",
-        "/job",
-        "/manager-book",
-        "/moments-at-work",
-        "/prompts",
-        "/writing"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_d/coaching.md",
-      "outgoing_links": [
-        "/curious",
-        "/decisive",
-        "/manager-book",
-        "/pride",
-        "/prompts",
-        "/siy"
-      ],
-      "redirect_url": "",
-      "title": "Coaching - How to help others find insight",
-      "url": "/coaching"
-    },
-    "/coe": {
-      "description": "Everyone can make a mistake once, that’s totally fine. Repeating mistakes is unacceptable. Correction of Errors (COE) is the name Amazon gives it’s mechanism for correcting errors. Microsoft uses the term Root cause analysis (RCA), it’s the same concept. This mechanism originated with service outages but can be applied for any “error”, like missing your sons kindergarten graduation, or getting fired.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/coe.html",
-      "incoming_links": [
-        "/amazon",
-        "/fail",
-        "/manager-book",
-        "/physical-pain",
-        "/switch",
-        "/writing"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/correction-of-errors.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Learning from mistakes",
-      "url": "/coe"
-    },
-    "/comp": {
-      "description": "Different companies use different compensation models. To compare models, use total compensation, not salary. The compensation models are arbitrary and complicated. For example, Amazon caps salary at 160K$/yr and doesn’t have bonuses. Google vests stocks monthly. Facebook bonuses have a company performance multiplier. At some companies, signing bonuses can be over 100% of salary!\n\n",
-      "doc_size": 29000,
-      "file_path": "_site/comp.html",
-      "incoming_links": [
-        "/job-hunt-stress",
-        "/manager-book",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_posts/2017-11-16-understandingtechcompensation.md",
-      "outgoing_links": [
-        "/job-hunt-stress",
-        "/pride"
-      ],
-      "redirect_url": "",
-      "title": "Care about Total Compensation",
-      "url": "/comp"
-    },
-    "/content-audience": {
-      "description": "When I started creating content — okay, let’s be honest, when I started uploading random videos to YouTube and TikTok — I didn’t have a plan. I’d record something, maybe clean it up in post, and toss it online. No real story, no strategy, and usually… no good. Looking back, I realize I never stopped to ask the two questions that actually matter: Who is this for? And why am I doing it? This blog is me trying to answer those questions — and maybe help you ask them too.\n\n",
-      "doc_size": 25000,
-      "file_path": "_site/content-audience.html",
-      "incoming_links": [
-        "/content-creation"
-      ],
-      "last_modified": "2025-09-08T09:25:35-07:00",
-      "markdown_path": "_d/content-audience.md",
-      "outgoing_links": [
-        "/end-in-mind",
-        "/manager-book"
-      ],
-      "redirect_url": "",
-      "title": "Content Audience",
-      "url": "/content-audience"
-    },
-    "/content-creation": {
-      "description": "Ah, content creation! Remember when it meant awkwardly holding your phone at arm’s length, hoping your thumb wouldn’t photobomb your masterpiece? We’ve come a long way, baby! Whether you’re aiming to be the next TikTok sensation or just want to share your magic tricks without accidentally revealing them, this guide will help you level up from “my mom’s my only viewer” to “wait, is that video going viral?”\n\n",
-      "doc_size": 27000,
-      "file_path": "_site/content-creation.html",
-      "incoming_links": [
-        "/monetize",
-        "/y25"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/content-creation.md",
-      "outgoing_links": [
-        "/content-audience",
-        "/monetize",
-        "/screencast"
-      ],
-      "redirect_url": "",
-      "title": "Content Creation: From Shaky Selfies to Social Superstar",
-      "url": "/content-creation"
-    },
-    "/covid": {
-      "description": "Corona Virus (CV) may be the defining moment in our lives. In such times, lets remember three things 1) Keep your circle of concern within your circle of influence 2) Don’t feed mind monsters - see the positive 3) In crisis, you see both the best and worse. Focus on the best.\n\n",
-      "doc_size": 27000,
-      "file_path": "_site/covid.html",
-      "incoming_links": [
-        "/addiction",
-        "/facebook",
-        "/operating-manual"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/covid19.md",
-      "outgoing_links": [
-        "/death"
-      ],
-      "redirect_url": "",
-      "title": "Notes from Covid 19",
-      "url": "/covid"
-    },
-    "/curious": {
-      "description": "Lead with curiosity, not judgment. This applies to yourself and to others. Think of a grandmother - a grandmother is full of love and compassion for her grandchildren. She loves them without conditions, no strings attached.She takes care of her grandchildren without needing anything in return. She cares selflessly and she has only the children’s best interest in mind. As she loves her grandchildren, she won’t allow self-destructive behavior and will step in when necessary. But she will always do this with the utmost care and love.\n\n",
-      "doc_size": 19000,
-      "file_path": "_site/curious.html",
-      "incoming_links": [
-        "/90days",
-        "/affirmations",
-        "/being-a-great-manager",
-        "/class-act",
-        "/coaching",
-        "/emotions",
-        "/essentialism",
-        "/first-understand",
-        "/getting-to-yes-with-yourself",
-        "/happy",
-        "/negotiate",
-        "/operating-manual",
-        "/psychic-weight",
-        "/regrets",
-        "/shame",
-        "/voices"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/grandmother.md",
-      "outgoing_links": [
-        "/first-understand",
-        "/mental-pain",
-        "/negotiate",
-        "/shame",
-        "/siy",
-        "/win-win"
-      ],
-      "redirect_url": "",
-      "title": "Isn't that curious",
-      "url": "/curious"
-    },
-    "/d/2016-02-03-positive-computing-survey": {
-      "description": "Positive computing is the software branch focused on increasing human well being. Similar to positive psychology, it is a brand new field and our industry has barely begun. I’ll use this post to gather my half baked thoughts on the various applications I’ve seen. For now it’ll be confusing as I’m brain dumping to various audiences with various knowledge.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/d/2016-02-03-positive-computing-survey.html",
-      "incoming_links": [],
-      "last_modified": "2018-12-25T15:34:24-08:00",
-      "markdown_path": "_d/2016-02-03-positive-computing-survey.md",
-      "outgoing_links": [
-        "/tech-health-toys"
-      ],
-      "redirect_url": "",
-      "title": "Positive computing a whirlwind tour",
-      "url": "/d/2016-02-03-positive-computing-survey"
-    },
-    "/d/2016-05-09-lost-interview": {
-      "description": "Uneditted notes on a Q+A with Steve Jobs.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/d/2016-05-09-lost-interview.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/2016-05-09-lost-interview.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Steve Jobs -- The Lost Interview",
-      "url": "/d/2016-05-09-lost-interview"
-    },
-    "/d/2016-2-14-Health-In-The-Head": {
-      "description": "Fit in my head, isn’t fit in reality. In the last few years I’ve learned this lesson for physical health, and now I’m learning it for emotional health.\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/d/2016-2-14-Health-In-The-Head.html",
-      "incoming_links": [],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_d/2016-2-14-Health-In-The-Head.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Emotional Health In My Head",
-      "url": "/d/2016-2-14-Health-In-The-Head"
-    },
-    "/d/2016-2-15-Seth-Godin-Notes": {
-      "description": "Seth godin has many ideas that are critical in the new world. Ideas include: Choosing yourself, Tribes, The limited value of cogs, connection, and the dip.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/d/2016-2-15-Seth-Godin-Notes.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-24T09:03:19-07:00",
-      "markdown_path": "_d/2016-2-15-Seth-Godin-Notes.md",
-      "outgoing_links": [
-        "/dip"
-      ],
-      "redirect_url": "",
-      "title": "Seth Godin- Ideas",
-      "url": "/d/2016-2-15-Seth-Godin-Notes"
-    },
-    "/d/2016-7-14-Customer-Service": {
-      "description": "Customer obsession, manifest in customer service, can be a key differentiator. This post explores the benefits, and business model impact of a customer obsessed organization.\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/d/2016-7-14-Customer-Service.html",
-      "incoming_links": [],
-      "last_modified": "2018-12-25T15:34:24-08:00",
-      "markdown_path": "_d/2016-7-14-Customer-Service.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Companies with customer obsession",
-      "url": "/d/2016-7-14-Customer-Service"
-    },
-    "/d/2016-8-1-Twelve-Tech-Forces": {
-      "description": "The digital revolution has gone through 3 changes: the copy of the industrial age, the link age, and the streaming age. This is a summary of the concepts representing the new age.\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/d/2016-8-1-Twelve-Tech-Forces.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-24T09:03:19-07:00",
-      "markdown_path": "_d/2016-8-1-Twelve-Tech-Forces.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "12 Tech forces that will shape our future",
-      "url": "/d/2016-8-1-Twelve-Tech-Forces"
-    },
-    "/d/2017-07-22-vacationphotos": {
-      "description": "Vacation photos are great, they remind you of the good times you’ve had, the people you’ve had them with and the places you’ve had them at. Here are my tips for vacation photos, and “reminiscing” type photos in general.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/d/2017-07-22-vacationphotos.html",
-      "incoming_links": [],
-      "last_modified": "2019-01-12T22:04:24+00:00",
-      "markdown_path": "_d/2017-07-22-vacationphotos.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Vacation Photos",
-      "url": "/d/2017-07-22-vacationphotos"
-    },
-    "/d/2017-09-10-software-rot": {
-      "description": "After a year of not working on one of my hobby software projects, I decided it’d be fun to make a minor change - should only be few lines of code. Should be easier still since I followed all the project best practices: I had full unit tests, and a fully automated command line build but boy was I wrong.\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/d/2017-09-10-software-rot.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T10:48:49-07:00",
-      "markdown_path": "_d/2017-09-10-software-rot.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Software Rot",
-      "url": "/d/2017-09-10-software-rot"
-    },
-    "/d/2017-11-04-clean-architecture": {
-      "description": "Architecture is the highest level of abstraction that models a software system. The architecture is composed from modules, which are composed of objects, which are composed of functions. Design is applied to each of these layers, and when executed successfully results in a system that is easy to build and maintain. Clean architecture discusses designs at a high level, which like architecture is highly useful. On the topic of architecture, the software industry’s use of the word architect is confusing. The construction analog of a “software architect” is a “structural engineer” and the software equivalent of a “construction architect” is a product manager.\n\n",
-      "doc_size": 50000,
-      "file_path": "_site/d/2017-11-04-clean-architecture.html",
-      "incoming_links": [
-        "/design"
-      ],
-      "last_modified": "2022-02-20T20:01:29-08:00",
-      "markdown_path": "_d/2017-11-04-clean-architecture.md",
-      "outgoing_links": [
-        "/design"
-      ],
-      "redirect_url": "",
-      "title": "Clean Architecture",
-      "url": "/d/2017-11-04-clean-architecture"
-    },
-    "/d/2018-02-10-you-do-want-your-favorite-app-to-be-a-service": {
-      "description": "When selling subscription software, a publisher needs to continue to prove the value of their software, or users will not renew their contracts. This is very beneficial to the users and to the publisher.\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/d/2018-02-10-you-do-want-your-favorite-app-to-be-a-service.html",
-      "incoming_links": [],
-      "last_modified": "2025-07-12T16:50:19-07:00",
-      "markdown_path": "_d/2018-02-10-you-do-want-your-favorite-app-to-be-a-service.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Software as a service is good for users",
-      "url": "/d/2018-02-10-you-do-want-your-favorite-app-to-be-a-service"
-    },
-    "/d/2018-09-23-mind-lines": {
-      "description": "Mind Lines\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/d/2018-09-23-mind-lines.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/2018-09-23-mind-lines.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Mind-Lines",
-      "url": "/d/2018-09-23-mind-lines"
-    },
-    "/d/apollo": {
-      "description": "The original Kenedy speech\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/d/apollo.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/apollo.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Quality",
-      "url": "/d/apollo"
-    },
-    "/d/habits": {
-      "description": "Habits are the automatic actions, both positive and negative, you take through your life. Atomic Habits describes how to change habits, it’s the how-to manual for “Sharpening the Saw”.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/d/habits.html",
-      "incoming_links": [
-        "/activation",
-        "/d/resistance",
-        "/energy-abundance",
-        "/hobby",
-        "/idle",
-        "/life-as-business",
-        "/manager-book",
-        "/mind-at-work",
-        "/operating-manual",
-        "/physical-health",
-        "/productive",
-        "/psychic-weight",
-        "/sharpen-the-saw",
-        "/slow",
-        "/switch"
-      ],
-      "last_modified": "2025-08-13T07:43:13-07:00",
-      "markdown_path": "_d/habits.md",
-      "outgoing_links": [
-        "/be-proactive"
-      ],
-      "redirect_url": "",
-      "title": "Atomic habits - How to add and remove habits",
-      "url": "/d/habits"
-    },
-    "/d/management_interviews": {
-      "description": "FACEBOOK MANAGEMENT INTERVIEWING 101\n\n",
-      "doc_size": 34000,
-      "file_path": "_site/d/management_interviews.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/management_interviews.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Types of interviews ",
-      "url": "/d/management_interviews"
-    },
-    "/d/resistance": {
-      "description": "Stop. Take an ice cold shower right now. You didn’t, did you? Trust me, even if you tried, you wouldn’t. Before you turned on the water, you’d have this irrational fear of stepping in and you wouldn’t do it. The force that stops you is the resistance. The resistance is the personification of the force that stops you from doing the important. The resistance lies, telling us things are hard when they are not. The resistance adds suffering when there is minimal pain and that confuses us, stopping us from doing things which give us the most value, joy and positive identity. The resistance is the enemy of progress.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/d/resistance.html",
-      "incoming_links": [
-        "/activation",
-        "/books-that-defined-me",
-        "/enemy",
-        "/energy",
-        "/energy-abundance",
-        "/fail",
-        "/first-things-first",
-        "/frog",
-        "/gap-year",
-        "/gap-year-igor",
-        "/mental-pain",
-        "/parkinson",
-        "/productive",
-        "/psychic-shadows",
-        "/psychic-weight",
-        "/slow",
-        "/timeoff"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/resistance.md",
-      "outgoing_links": [
-        "/addiction",
-        "/d/habits",
-        "/end-in-mind",
-        "/frog",
-        "/gtd",
-        "/magic",
-        "/mental-pain"
-      ],
-      "redirect_url": "",
-      "title": "Resistance: Why you can't make yourself take an ice cold shower",
-      "url": "/d/resistance"
-    },
-    "/d/where-have-all-the-bugs-gone": {
-      "description": "I’ve been a software developer since 2001, and back then we used to have lots of bugs. Nowadays, it seems we don’t have bugs, and I’ve wondered why. Now we have tickets which we get from our systems running in production, but that’s quite different. What’s going on?\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/d/where-have-all-the-bugs-gone.html",
-      "incoming_links": [],
-      "last_modified": "2022-08-13T08:09:48-07:00",
-      "markdown_path": "_d/where-have-all-the-bugs-gone.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Where have all the bugs gone",
-      "url": "/d/where-have-all-the-bugs-gone"
-    },
-    "/dad": {
-      "description": "\n\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/dad.html",
-      "incoming_links": [],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/gpt-dad.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Being a Good Dad - A Guide to Fatherhood",
-      "url": "/dad"
-    },
-    "/death": {
-      "description": "Bad news, you’re dying, so is everyone else. Good news, if we didn’t die we’d run out of resources, and our kids would be screwed. Bad news, our health care system is optimized for keeping you alive, not for maximizing the enjoyable time you have on earth. Good news, knowing is half the battle - armed with this knowledge you can decide how you want to die, which is ultimately how you want to live.\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/death.html",
-      "incoming_links": [
-        "/chasing-daylight",
-        "/covid",
-        "/elder",
-        "/gap-year-igor",
-        "/last-year",
-        "/mortality-software",
-        "/psychic-weight"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/on-being-mortal.md",
-      "outgoing_links": [
-        "/last-year"
-      ],
-      "redirect_url": "",
-      "title": "On being Mortal - Guess what? You're dying",
-      "url": "/death"
-    },
-    "/debug": {
-      "description": "Igor's Blog",
-      "doc_size": 23000,
-      "file_path": "_site/debug.html",
-      "incoming_links": [],
-      "last_modified": "2025-03-16T16:15:36+00:00",
-      "markdown_path": "debug.html",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Debug the page",
-      "url": "/debug"
-    },
-    "/decisive": {
-      "description": "Decisions are hard because we have Narrow Framing, Confirmation Bias, Short Term Emotion and Overconfidence. We can overcome this by Widening our Options, Reality-Testing our Assumptions, Attaining Distance before Deciding and Preparing to Be Wrong.\n\n",
-      "doc_size": 45000,
-      "file_path": "_site/decisive.html",
-      "incoming_links": [
-        "/being-a-great-manager",
-        "/coaching",
-        "/gap-year",
-        "/job-hunt-stress",
-        "/manager-book",
-        "/pride",
-        "/random-idea",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2025-06-20T08:56:14-07:00",
-      "markdown_path": "_posts/2019-09-21-decisive.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Decision making 201",
-      "url": "/decisive"
-    },
-    "/defi": {
-      "description": "Finance has existed for as long as civilization. And like most things before the Internet age was based on the trust of centralized law and authority (like banks and governments). Decentralized Finance (DeFi) is the movement that asks could we perform our financial transaction with out centralized trust. Finance has evolved many instruments to meet the needs of civilization, all of which are based on trust (store of value, currency, loans), de-fi will search for equivalences of each of these.\n\n",
-      "doc_size": 31000,
-      "file_path": "_site/defi.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/defi.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Decentralized Finance",
-      "url": "/defi"
-    },
-    "/delegate": {
-      "description": "At some point you need to scale out, and that’s called delegation! Stewardship delegation is the form of delegation where the responsibility for the delegated task is transferred to the delegatee. Stewardship delegation requires upfront effort, but results in long-term effectiveness. For stewardship delegation, you need agreement on the following 5 things: The desired results, the operating parameters, the available resources, the measurement system, and the consequences of their stewardship.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/delegate.html",
-      "incoming_links": [
-        "/first-things-first"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/delegate.md",
-      "outgoing_links": [
-        "/first-things-first"
-      ],
-      "redirect_url": "",
-      "title": "Stewardship Delegation 101",
-      "url": "/delegate"
-    },
-    "/depression": {
-      "description": "When you’re depressed you don’t think you’ve put on a gray veil - seeing the world through the haze of a bad mood. You think that a veil has been taken away. The veil of happiness, and you believe you’re seeing the world as it truly is: alone, petrifying, and painful. But the truth lies. The depressed say “No one loves me.” And you say, “I love you, your wife loves you, your mother loves you.” and the depressed ignore you. The depressed will continue, “None of this matters, we’re just going to die in the end.” To which you have to say, “That’s true, but I think right now should focus on what to have for breakfast.”\n\n",
-      "doc_size": 22000,
-      "file_path": "_site/depression.html",
-      "incoming_links": [
-        "/anger",
-        "/caring",
-        "/mental-pain",
-        "/mood"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_d/depression.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/anxiety",
-        "/caring",
-        "/eulogy",
-        "/getting-to-yes-with-yourself",
-        "/gtd",
-        "/idle",
-        "/insecure",
-        "/insomnia",
-        "/physical-health",
-        "/psychic-shadows",
-        "/psychic-weight",
-        "/shame",
-        "/siy",
-        "/sustainable-work",
-        "/voices"
-      ],
-      "redirect_url": "",
-      "title": "Depression is the opposite of vitality",
-      "url": "/depression"
-    },
-    "/design": {
-      "description": "Software is measured in two dimensions: use cases (end user behavior) and malleability. End user behavior is the delivery of use cases, while malleability is the ease with which the software can modify the existing use cases, or add new ones. Software malleability is the evaluation function for an architecture. Malleability is the more important of these dimensions because over time there will be far more changes to the software then the original use case (e.g. the cost of maintenance far exceeds the software writing cost). A key property of software architecture is it’s obvious there is one place to make changes, and where that place is.\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/design.html",
-      "incoming_links": [
-        "/amazon",
-        "/d/2017-11-04-clean-architecture",
-        "/system-design",
-        "/testing"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/design.md",
-      "outgoing_links": [
-        "/d/2017-11-04-clean-architecture",
-        "/td/cloud-first-applications",
-        "/testing"
-      ],
-      "redirect_url": "",
-      "title": "Software Design and Architecture",
-      "url": "/design"
-    },
-    "/diet": {
-      "description": "Diet dominates weight, as weight is simple arithmetic -“calories in” minus “calories out”. Weight is essential because it reduces the effort required to do physical activities, and because it reduces the risk of many diseases. Exercise, while critical to energy, is mostly a red herring for weight loss. A great way to see this is comparing what you eat to physical Activity. A side of fries adds 500 calories to your day, but running for 30 minutes only burns 300 calories.\n\n",
-      "doc_size": 19000,
-      "file_path": "_site/diet.html",
-      "incoming_links": [
-        "/42",
-        "/operating-manual",
-        "/physical-health",
-        "/retire",
-        "/sharpen-the-saw",
-        "/timeoff"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/diet.md",
-      "outgoing_links": [
-        "/physical-health",
-        "/terzepatide"
-      ],
-      "redirect_url": "",
-      "title": "Diet",
-      "url": "/diet"
-    },
-    "/dip": {
-      "description": "New things start fun, but once the new wears off they are hard because of the Dip. The Dip is the long slog between starting and mastery. Unlike Dips, cul-de-sacs are places you can put in a lot of energy and nothing will come of it. You need to quit cul-de-sacs and lean into dips. Much of our failure comes from being distracted by tasks we don’t have the guts to quit. Winners quit all the time. They quit the right stuff, so their energy can be saved to cross the Dip.\n\n",
-      "doc_size": 32000,
-      "file_path": "_site/dip.html",
-      "incoming_links": [
-        "/d/2016-2-15-Seth-Godin-Notes",
-        "/end-in-mind",
-        "/gtd",
-        "/manager-book",
-        "/parkinson",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/2017-11-12-thedip.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "The Dip - Should you fold or double down",
-      "url": "/dip"
-    },
-    "/docker": {
-      "description": "Docker has 2 values, isolation and repeatable setup. Here are my notes\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/docker.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/docker_.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Docker tools",
-      "url": "/docker"
-    },
-    "/e1": {
-      "description": "\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/e1.html",
-      "incoming_links": [],
-      "last_modified": "2025-05-25T10:09:41-07:00",
-      "markdown_path": "_d/e1.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Igor's Identity",
-      "url": "/e1"
-    },
-    "/elder": {
-      "description": "Midlife has a marketing problem, it’s always followed by the word crisis. Honestly, for good reason: Midlife is the chapter of your life where the things you and society value decline. E.g. you’re getting weaker and dumber. Embrace and optimize for this reality or suffer. Luckily there is a good formula here: both to embrace it, and to find new strengths to focus on.\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/elder.html",
-      "incoming_links": [
-        "/40yo",
-        "/addiction"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/elder.md",
-      "outgoing_links": [
-        "/40yo",
-        "/death",
-        "/end-in-mind",
-        "/essentialism"
-      ],
-      "redirect_url": "",
-      "title": "Wrinkles and Wisdom: A Guide to Aging Like Fine Wine (Not Milk)",
-      "url": "/elder"
-    },
-    "/emotional-health": {
-      "description": "Emotionally healthy folks can let it go, empathize with others, and most importantly, sleep well at night. Just like physically healthy folks do physical practices, like walking daily, stretching, biking, there are also emotional practices. Here are the ones I’ve been exploring.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/emotional-health.html",
-      "incoming_links": [
-        "/essentialism",
-        "/gap-year-igor",
-        "/irl",
-        "/mania",
-        "/mind-at-work",
-        "/operating-manual",
-        "/process-journal",
-        "/sharpen-the-saw",
-        "/siy",
-        "/sublime"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/emotional-health-hold.md",
-      "outgoing_links": [
-        "/sharpen-the-saw",
-        "/siy",
-        "/sublime",
-        "/voices"
-      ],
-      "redirect_url": "",
-      "title": "Emotional Health Practices",
-      "url": "/emotional-health"
-    },
-    "/emotions": {
-      "description": "Ever notice how emotions are like that one friend who shows up uninvited and fucks up your perfectly planned party? Sometimes they bring cake and make everything awesome, other times they’re drunk and knocking over your carefully arranged furniture while screaming “YOLO!” Well, here’s your guide to that emotional party crasher living rent-free in your head, because let’s face it - they’re not moving out anytime soon.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/emotions.html",
-      "incoming_links": [
-        "/slow"
-      ],
-      "last_modified": "2024-12-25T17:59:13-08:00",
-      "markdown_path": "_d/emotions.md",
-      "outgoing_links": [
-        "/anger",
-        "/be-proactive",
-        "/curious",
-        "/happy",
-        "/joy",
-        "/regrets",
-        "/shame",
-        "/sublime"
-      ],
-      "redirect_url": "",
-      "title": "Emotions",
-      "url": "/emotions"
-    },
-    "/enable": {
-      "description": "Imagine the place you do your best work. Andy Matuschak defined this, and as someone who aspires to effectiveness, I fell in love with the concept. As a techie who loves efficiency, I also set about building my own. From Andy: An enabling environment significantly expands its participants’ capacity to do things they find meaningful and important. This blog is the consumption environment for mine. When we talk about an AI enabling environment the key is not to figure out how you can prompt the AI, but how the AI can prompt you.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/enable.html",
-      "incoming_links": [
-        "/chow",
-        "/writing"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/enabling-environment.md",
-      "outgoing_links": [
-        "/podcast",
-        "/switch",
-        "/vim",
-        "/vim-for-writing",
-        "/writing"
-      ],
-      "redirect_url": "",
-      "title": "Enabling Environment",
-      "url": "/enable"
-    },
-    "/end-in-mind": {
-      "description": "All things are created twice, once in the design phase, and then again in the implementation phase. If you don’t perform the first creation, someone else will. At the extreme, imagine your eulogy, that’s the end too.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/end-in-mind.html",
-      "incoming_links": [
-        "/4dx",
-        "/7-habits",
-        "/affirmations",
-        "/content-audience",
-        "/d/resistance",
-        "/elder",
-        "/gap-year-igor",
-        "/manager-book",
-        "/productive",
-        "/siy"
-      ],
-      "last_modified": "2025-05-12T09:24:30-07:00",
-      "markdown_path": "_d/7h-c2.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/dip",
-        "/essentialism",
-        "/eulogy",
-        "/joy",
-        "/touching"
-      ],
-      "redirect_url": "",
-      "title": "Begin with the end in mind",
-      "url": "/end-in-mind"
-    },
-    "/enemy": {
-      "description": "Fear, Arrogance, Authority, and Apathy are the four enemies of satisfaction as described in Don Juan’s teachings.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/enemy.html",
-      "incoming_links": [
-        "/chapters",
-        "/retire"
-      ],
-      "last_modified": "2023-12-30T11:50:51-08:00",
-      "markdown_path": "_d/don-juan2.md",
-      "outgoing_links": [
-        "/d/resistance",
-        "/pride"
-      ],
-      "redirect_url": "",
-      "title": "Four enemies",
-      "url": "/enemy"
-    },
-    "/energy": {
-      "description": "We often say we don’t have time, but usually we mean we don’t have energy. That’s great news because time is finite, and monotonically decreasing. Energy, by contrast, is dynamic. Activities and experiences can create and destroy energy. What’s amazing to me is how going to the gym can be energy positive.\n\n",
-      "doc_size": 19000,
-      "file_path": "_site/energy.html",
-      "incoming_links": [
-        "/balance",
-        "/energy-abundance",
-        "/mood",
-        "/productive",
-        "/slow",
-        "/timeoff"
-      ],
-      "last_modified": "2025-08-24T10:29:13-07:00",
-      "markdown_path": "_d/energy.md",
-      "outgoing_links": [
-        "/activation",
-        "/d/resistance",
-        "/joy",
-        "/mania",
-        "/mood",
-        "/operating-manual",
-        "/productive",
-        "/sleep",
-        "/slow",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Control your Energy",
-      "url": "/energy"
-    },
-    "/energy-abundance": {
-      "description": "I got asked that the other day, and thought, boy, there is a lot here, I need to think this through. Here’s my thinking so far.\n\n",
-      "doc_size": 27000,
-      "file_path": "_site/energy-abundance.html",
-      "incoming_links": [
-        "/life-as-business"
-      ],
-      "last_modified": "2025-03-08T09:45:30-08:00",
-      "markdown_path": "_d/energy-abundance.md",
-      "outgoing_links": [
-        "/activation",
-        "/balance",
-        "/d/habits",
-        "/d/resistance",
-        "/energy",
-        "/operating-manual",
-        "/strategy",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Igor - how do you have the time to complete all the stuff on your blog?",
-      "url": "/energy-abundance"
-    },
-    "/essentialism": {
-      "description": "Essentialism is deciding what goes on your todo list, not how many things you can cross off. Being an essentialist means you say ‘I choose to’ not ‘I have to’, ‘Only a few things matter’, not ‘all things matter’ and ‘I will do one thing’, not ‘I will do both’. The essential questions are ‘How do I know when I’m done?’, ‘If I didn’t own this, would I buy it?’, ‘If I didn’t have this opportunity what would I do to acquire it?’\n\n",
-      "doc_size": 41000,
-      "file_path": "_site/essentialism.html",
-      "incoming_links": [
-        "/4dx",
-        "/affirmations",
-        "/balance",
-        "/be-proactive",
-        "/books-that-defined-me",
-        "/elder",
-        "/end-in-mind",
-        "/first-things-first",
-        "/frog",
-        "/gtd",
-        "/overload",
-        "/parkinson",
-        "/partner-trouble",
-        "/timeoff",
-        "/timeoff-2022-07"
-      ],
-      "last_modified": "2025-08-24T09:03:19-07:00",
-      "markdown_path": "_posts/2015-11-28-essentialism.md",
-      "outgoing_links": [
-        "/curious",
-        "/emotional-health",
-        "/insomnia",
-        "/physical-health"
-      ],
-      "redirect_url": "",
-      "title": "Essentialism",
-      "url": "/essentialism"
-    },
-    "/eulogy": {
-      "description": "Wearing a silly hat or his zany $8 TEMU crazy shirt, his trusty folding bike at his feet, and using a purple fountain pen, Igor “Began with the end in mind” with the “important but not urgent” task of penning this eulogy, likely starting at 5am. Igor wanted this life, so he wrote it, he reviewed it, he lived it, and he worked with his family, friends, and multitude of mentors, to adjust and tweak it.\n\n",
-      "doc_size": 37000,
-      "file_path": "_site/eulogy.html",
-      "incoming_links": [
-        "/7-habits",
-        "/ai-journal",
-        "/balance",
-        "/bmy",
-        "/depression",
-        "/end-in-mind",
-        "/frog",
-        "/happy",
-        "/hobby",
-        "/irl",
-        "/joy",
-        "/operating-manual",
-        "/retire",
-        "/timeoff",
-        "/todo_enjoy",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2025-09-07T16:11:35-07:00",
-      "markdown_path": "_posts/2020-04-01-Igor-Eulogy.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/The-Genesis-Node",
-        "/balloon",
-        "/being-a-great-manager",
-        "/bike",
-        "/cache",
-        "/human-meetings",
-        "/ig66/687",
-        "/ig66/717",
-        "/ig66/732",
-        "/job",
-        "/kettlebell",
-        "/magic",
-        "/physical-health",
-        "/process-journal",
-        "/siy",
-        "/terzepatide",
-        "/tesla",
-        "/tori",
-        "/toysfortots"
-      ],
-      "redirect_url": "",
-      "title": "Igor's Eulogy - How I want to live",
-      "url": "/eulogy"
-    },
-    "/facebook": {
-      "description": "Facebook is a ‘social’ company; we value 1-1 time, fostering trust-driven relationships, and providing skip-level escalations and support. Here are my notes on Facebook\n\n",
-      "doc_size": 34000,
-      "file_path": "_site/facebook.html",
-      "incoming_links": [
-        "/manager-book-appendix"
-      ],
-      "last_modified": "2025-09-08T09:26:52-07:00",
-      "markdown_path": "_d/facebook.md",
-      "outgoing_links": [
-        "/covid"
-      ],
-      "redirect_url": "",
-      "title": "My thoughts on Facebook",
-      "url": "/facebook"
-    },
-    "/fail": {
-      "description": "Failure is not an option; it’s a necessity. Failure is not a person but an event. You can’t grow without failing, and you can’t beat yourself up over it. The key is to analyze without judgment, understand why it failed, and learn to move on.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/fail.html",
-      "incoming_links": [],
-      "last_modified": "2025-03-11T05:04:46-07:00",
-      "markdown_path": "_d/fail2.md",
-      "outgoing_links": [
-        "/anxiety",
-        "/anxiety-management",
-        "/coe",
-        "/d/resistance"
-      ],
-      "redirect_url": "",
-      "title": "Failure is not an option, it is a necessity",
-      "url": "/fail"
-    },
-    "/first-things-first": {
-      "description": "The key to effective management, is allocating energy through the lens of importance rather than urgency. E.g, ask yourself what one thing could you do that if you did on a regular basis, would make a tremendous positive difference in your life? Lemme guess, it’s important, but not urgent so you’re not doing it. These are my insights based on the 7 habits Chapter 3.\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/first-things-first.html",
-      "incoming_links": [
-        "/4dx",
-        "/7-habits",
-        "/90days",
-        "/affirmations",
-        "/delegate",
-        "/frog"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_d/7h-c3.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/addiction",
-        "/d/resistance",
-        "/delegate",
-        "/essentialism",
-        "/frog",
-        "/gtd",
-        "/switch",
-        "/upstream"
-      ],
-      "redirect_url": "",
-      "title": "First things first",
-      "url": "/first-things-first"
-    },
-    "/first-understand": {
-      "description": "Imagine going to the eye doctor. After hearing your complaint he takes off his glasses and hands them to you.\n“Put these on,” he says. “I’ve worn this pair of glasses for ten years now and they’ve really helped me. I have an extra pair at home; you can wear these.” So you put them on, but it only makes the problem worse. “This is terrible!” you exclaim. “I can’t see a thing!” “Well, what’s wrong?” he asks. “They work great for me. Try harder.” “I am trying,” you insist. “Everything is a blur.” “Well, what’s the matter with you? Think positively.” “Okay. I positively can’t see a thing.” “Boy, are you ungrateful!” he chides. “And after all I’ve done to help you!”\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/first-understand.html",
-      "incoming_links": [
-        "/7-habits",
-        "/advice",
-        "/affirmations",
-        "/class-act",
-        "/curious",
-        "/negotiate",
-        "/sell",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2021-10-30T10:02:27-07:00",
-      "markdown_path": "_d/7h-c5.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/coaching",
-        "/curious",
-        "/ig66/587",
-        "/prompts",
-        "/siy"
-      ],
-      "redirect_url": "",
-      "title": "Seek first to understand, then to be understood",
-      "url": "/first-understand"
-    },
-    "/frog": {
-      "description": "Procrastination is the success killer, a powerful manifestations of the resistance. Eat that frog gives 21 antidotes to procrastination. These are my re-framing of the concepts into my favorite mental models. Chapter titles come from the book.\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/frog.html",
-      "incoming_links": [
-        "/anxiety-management",
-        "/be-proactive",
-        "/d/resistance",
-        "/first-things-first",
-        "/gtd",
-        "/idle",
-        "/mental-pain",
-        "/parkinson",
-        "/productive",
-        "/psychic-weight",
-        "/timeoff",
-        "/timeoff-2020-03"
-      ],
-      "last_modified": "2025-04-02T21:53:46-07:00",
-      "markdown_path": "_d/frog.md",
-      "outgoing_links": [
-        "/Immutable-Laws-Of-Hard",
-        "/be-proactive",
-        "/d/resistance",
-        "/essentialism",
-        "/eulogy",
-        "/first-things-first",
-        "/gtd"
-      ],
-      "redirect_url": "",
-      "title": "Eat that frog",
-      "url": "/frog"
-    },
-    "/gap-year": {
-      "description": "Here’s a thought that’ll push back your retirement: Would you rather work until 65 and retire comfortably, or take a full year off at 50, return to work, and retire at 67 with less money? If you’re like most people, you immediately think “that’s crazy - I can’t afford to lose a year’s income!” But what if I told you that gap year might be the best investment you’ll ever make?\n\n",
-      "doc_size": 33000,
-      "file_path": "_site/gap-year.html",
-      "incoming_links": [
-        "/gap-year-igor",
-        "/monetize",
-        "/retire",
-        "/stock-concentration"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/gap-year.md",
-      "outgoing_links": [
-        "/chapters",
-        "/d/resistance",
-        "/decisive",
-        "/gap-year-igor",
-        "/money",
-        "/partner-trouble",
-        "/physical-health",
-        "/retire",
-        "/timeoff",
-        "/y24",
-        "/y25"
-      ],
-      "redirect_url": "",
-      "title": "The Gap Year Paradox: Why Taking a Year Off at 50 beats retiring at 65",
-      "url": "/gap-year"
-    },
-    "/gap-year-igor": {
-      "description": "Done right, a gap year isn’t a year off; it’s a year on — intentional investment in health, relationships, and mastery while you still have the capital to invest. Think of it as pursuing a PhD in Life Optimization, making deposits that compound for decades. A gap year is one of those uncharted spaces—seductive when discussed longingly over a beer, terrifying when holding a resignation letter outside your boss’s office. Early maps warned: “HC SVNT DRACONES.” Here be dragons. I’m mapping them in real time: the Scarcity Dragon whispering you can’t afford it, the Entropy Dragon promising you’ll decay without structure, and the Squander Dragon insisting you’ll waste this precious opportunity. But these dragons guard treasure — the chance to invest in what truly matters while you still have the capacity to do so. This is the map of how to tame them.\n\n",
-      "doc_size": 68000,
-      "file_path": "_site/gap-year-igor.html",
-      "incoming_links": [
-        "/gap-year",
-        "/stock-concentration",
-        "/timeoff-2025-08"
-      ],
-      "last_modified": "2025-09-06T12:12:27-07:00",
-      "markdown_path": "_d/igor-gap-year.md",
-      "outgoing_links": [
-        "/affirmations",
-        "/chapters",
-        "/chasing-daylight",
-        "/d/resistance",
-        "/death",
-        "/emotional-health",
-        "/end-in-mind",
-        "/gap-year",
-        "/kettlebell",
-        "/money",
-        "/parkinson",
-        "/physical-health",
-        "/retire",
-        "/siy",
-        "/sleep",
-        "/stock-concentration",
-        "/structure",
-        "/sustainable-work",
-        "/timeoff",
-        "/tori",
-        "/y24",
-        "/y25"
-      ],
-      "redirect_url": "",
-      "title": "Will Igor Take a Gap Year? Wrestling with Dragons and Dreams",
-      "url": "/gap-year-igor"
-    },
-    "/genai-talk": {
-      "description": "Generative AI (GenAI) is taking the world by storm, and it takes a new mindset to make use of it as a programmer. A good mental model of GenAI is interns!\n\n",
-      "doc_size": 38000,
-      "file_path": "_site/genai-talk.html",
-      "incoming_links": [
-        "/ai-journal"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/genai-talk.md",
-      "outgoing_links": [
-        "/ai-testing"
-      ],
-      "redirect_url": "",
-      "title": "Your new interns - GenAI for fun and profit",
-      "url": "/genai-talk"
-    },
-    "/getting-to-yes-with-yourself": {
-      "description": "Before you can negotiate with others, you need to be in sync with yourself. This book applies the negotiating principles to yourself. It’s an awkward application of the model, but this book is filled with good concepts regardless.\n\n",
-      "doc_size": 25000,
-      "file_path": "_site/getting-to-yes-with-yourself.html",
-      "incoming_links": [
-        "/books-that-defined-me",
-        "/depression"
-      ],
-      "last_modified": "2025-08-24T09:03:19-07:00",
-      "markdown_path": "_posts/2015-12-23-getting-to-yes-with-yourself.md",
-      "outgoing_links": [
-        "/curious",
-        "/negotiate",
-        "/welcome-to-holland"
-      ],
-      "redirect_url": "",
-      "title": "Getting to yes with yourself",
-      "url": "/getting-to-yes-with-yourself"
-    },
-    "/goals": {
-      "description": "Goals are critical, there are multiple goal systems and they have consequences. They are mechanisms to deliver without micro management.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/goals.html",
-      "incoming_links": [
-        "/4dx",
-        "/parkinson"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/goals.md",
-      "outgoing_links": [
-        "/4dx",
-        "/mortality-software"
-      ],
-      "redirect_url": "",
-      "title": "Goals - How to define and ensure success",
-      "url": "/goals"
-    },
-    "/google-photos": {
-      "description": "I like having a blog, but honestly it’s faster to write it in google photos as that has a better WYSWIG viewer. But, I don’t get features like search, or previews, which matters to me. I also don’t trust Google not to break photos in the future. Of course exporting is a PITA, here are some hacks to export and make it into my blog format. NOTE: There is an API to extract photos, but it doesn’t include the text (which I like to have, as recall WYSWIG editor)\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/google-photos.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/scrape_google_photo_album.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Accessing Google Photos",
-      "url": "/google-photos"
-    },
-    "/gpt": {
-      "description": "Just like the search bar in google fills in what you’re typing when you say “Where can I ge .. “ GPT3 complete strings as well. Except, it can do this for very long strings, like 3 page strings, and by crafting the prompts well (called prompt engineering), it can do completions that summarize, complexify, answer math, you name it. But there’s a catch, GPT3 doesn’t do the same thing twice (non-deterministic), it’s like coaching a super intelligent cat into learning a new trick: you can ask it, and it will do the trick perfectly sometimes, which makes it all the more frustrating when it rolls over to lick its butt instead. You know the problem is not that it can’t but that it won’t(From Gwern).\n\n",
-      "doc_size": 25000,
-      "file_path": "_site/gpt.html",
-      "incoming_links": [
-        "/ai-art",
-        "/ai-journal",
-        "/ml",
-        "/nlp"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/gpt2.md",
-      "outgoing_links": [
-        "/nurture",
-        "/rapport"
-      ],
-      "redirect_url": "",
-      "title": "GPT3 and language models",
-      "url": "/gpt"
-    },
-    "/gpt-7h": {
-      "description": "\n\n\n",
-      "doc_size": 32000,
-      "file_path": "_site/gpt-7h.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T10:48:49-07:00",
-      "markdown_path": "_d/gpt-7-habits.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "LEADER: Another Take on the 7 Habits",
-      "url": "/gpt-7h"
-    },
-    "/gpt-system-design": {
-      "description": "\n\n\n",
-      "doc_size": 28000,
-      "file_path": "_site/gpt-system-design.html",
-      "incoming_links": [],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/gpt-system-design-interview.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "System Design Interviews- The SHINE Method",
-      "url": "/gpt-system-design"
-    },
-    "/grammerly": {
-      "description": "\n\n",
-      "doc_size": 12000,
-      "file_path": "_site/grammerly.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-24T09:03:19-07:00",
-      "markdown_path": "_td/grammerly.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Grammarly",
-      "url": "/grammerly"
-    },
-    "/graph": {
-      "description": "Igor's Blog",
-      "doc_size": 13000,
-      "file_path": "_site/graph.html",
-      "incoming_links": [],
-      "last_modified": "2025-07-26T10:43:02-07:00",
-      "markdown_path": "graph.html",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Graph",
-      "url": "/graph"
-    },
-    "/grateful": {
-      "description": "Gratefulness exercises work - here’s somethings to help.\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/grateful.html",
-      "incoming_links": [
-        "/appreciate",
-        "/process-journal"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/grateful2.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Gratefulness",
-      "url": "/grateful"
-    },
-    "/groupchat": {
-      "description": "Imagine a group chat as the bustling kitchen of a high-end restaurant. In place of culinary masterpieces, it’s ideas, gossip, and insights that are cooked up, seasoned, and served. Just as a great dinner party brings together eclectic personalities for a memorable evening, a stellar group chat assembles diverse voices for ongoing, vibrant conversations. Basically Sriram’s awesome post on great group chats.\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/groupchat.html",
-      "incoming_links": [],
-      "last_modified": "2024-06-08T09:10:34-07:00",
-      "markdown_path": "_d/groupchat.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "My favorite group chats - the forever dinner party",
-      "url": "/groupchat"
-    },
-    "/gtd": {
-      "description": "Getting Things Done (GTD) is a model based on David Allen’s book of the same name. It’s a deep dive into Habit 3 - first things first, with some lite weight Habit 2 - begin with the end in mind, mixed in for good measure. By using GTD religiously you can have a drastic reduction in stress and procrastination.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/gtd.html",
-      "incoming_links": [
-        "/4dx",
-        "/books-that-defined-me",
-        "/d/resistance",
-        "/depression",
-        "/first-things-first",
-        "/frog",
-        "/parkinson",
-        "/psychic-weight"
-      ],
-      "last_modified": "2025-07-20T19:13:52-07:00",
-      "markdown_path": "_d/gtd.md",
-      "outgoing_links": [
-        "/anxiety",
-        "/chop",
-        "/dip",
-        "/essentialism",
-        "/frog",
-        "/idle",
-        "/outsourcing",
-        "/psychic-weight"
-      ],
-      "redirect_url": "",
-      "title": "Getting things done",
-      "url": "/gtd"
-    },
-    "/happy": {
-      "description": "Happy is a 5 letter word that many use as the answer to what is the point of life. The follow up question of “How can you be happy” is usually followed by a blank stare, so here’s my study of the subject.\n\n",
-      "doc_size": 27000,
-      "file_path": "_site/happy.html",
-      "incoming_links": [
-        "/chasing-daylight",
-        "/emotions",
-        "/hobby",
-        "/joy",
-        "/mood",
-        "/siy",
-        "/timeoff",
-        "/timeoff-2020-12",
-        "/timeoff-2021-12",
-        "/timeoff-2022-02",
-        "/timeoff-2022-07",
-        "/timeoff-2022-11",
-        "/timeoff-2022-12",
-        "/timeoff-2023-04",
-        "/timeoff-2023-08",
-        "/timeoff-2023-11",
-        "/timeoff-2024-08",
-        "/timeoff-2025-08"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_posts/2017-04-12-happy.md",
-      "outgoing_links": [
-        "/addiction",
-        "/anxiety",
-        "/curious",
-        "/eulogy",
-        "/idle",
-        "/joy",
-        "/mental-pain",
-        "/moments",
-        "/mood",
-        "/negotiate"
-      ],
-      "redirect_url": "",
-      "title": "Happy",
-      "url": "/happy"
-    },
-    "/heath-class-act": {
-      "description": "\n\n\n",
-      "doc_size": 32000,
-      "file_path": "_site/heath-class-act.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/class-act-4.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Being a Class Act - How to Stand Out with Grace and Dignity in Any Situation",
-      "url": "/heath-class-act"
-    },
-    "/hobby": {
-      "description": "Some days thinking about work makes me stressed, thinking of my family makes me resentful, and I don’t want to feel like a sloth feeding my addictions to TikTok, and doom scrolling. Those days, I’m grateful for my hobbies. This post gives you reasons to find a hobby and teaches you the attributes in an ideal hobby: Being accessible, Supporting mastery, Reinforcing your identity, and building relationships.\n\n",
-      "doc_size": 19000,
-      "file_path": "_site/hobby.html",
-      "incoming_links": [
-        "/operating-manual",
-        "/retire"
-      ],
-      "last_modified": "2022-05-09T07:53:36-07:00",
-      "markdown_path": "_d/hobby.md",
-      "outgoing_links": [
-        "/d/habits",
-        "/eulogy",
-        "/happy",
-        "/joy",
-        "/magic"
-      ],
-      "redirect_url": "",
-      "title": "Why a Engineering Manager masquerades as a magician on the weekends",
-      "url": "/hobby"
-    },
-    "/human-meetings": {
-      "description": "Having our emotions heard is a fundamental human need. The modern world denies this need, but that doesn’t make the need go away. More than denying the need, society gives, and encourages, us to suppress our emotions. Feelings meetings stand in opposition. They exist to allow us, no, encourage us, to fulfill our fundamental need of expressing emotion.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/human-meetings.html",
-      "incoming_links": [
-        "/being-a-great-manager",
-        "/eulogy",
-        "/job"
-      ],
-      "last_modified": "2022-03-20T09:40:39-07:00",
-      "markdown_path": "_d/human-meeting.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Feelings/Human Meetings",
-      "url": "/human-meetings"
-    },
-    "/humans-are-underrated": {
-      "description": "As robots become better then humans at most things, what roles will be left for humans? What skills are required for those roles? Empathizing, collaborating, leading,and building relationships.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/humans-are-underrated.html",
-      "incoming_links": [
-        "/books-that-defined-me",
-        "/chop"
-      ],
-      "last_modified": "2025-03-01T18:25:15-08:00",
-      "markdown_path": "_posts/2015-12-12-humans-are-underrated.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Humans are underrated",
-      "url": "/humans-are-underrated"
-    },
-    "/husband": {
-      "description": "\n\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/husband.html",
-      "incoming_links": [],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/good_husband-4.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Being a GOOD Husband",
-      "url": "/husband"
-    },
-    "/hyper-personal": {
-      "description": "Useful writing tells people (including, possibly most importantly you) something true and important that they didn’t already know in a way that leaves no doubt. And Everyone is different. So how to do both?\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/hyper-personal.html",
-      "incoming_links": [
-        "/ai-journal"
-      ],
-      "last_modified": "2025-09-08T09:31:34-07:00",
-      "markdown_path": "_d/hyper-personal.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Hyper Personalization",
-      "url": "/hyper-personal"
-    },
-    "/idle": {
-      "description": "Waiting in line at the grocery store, sitting in an Uber, pooping - in these invisible times, we execute our idle loop. We spend a lot of time in our idle loop, and it can either increase our energy or drain it. By being aware of and then modifying how we spend our idle loop we can improve our lives one poop at a time.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/idle.html",
-      "incoming_links": [
-        "/anxiety",
-        "/depression",
-        "/gtd",
-        "/happy",
-        "/psychic-weight"
-      ],
-      "last_modified": "2025-09-06T12:06:16-07:00",
-      "markdown_path": "_d/idle-loop.md",
-      "outgoing_links": [
-        "/addiction",
-        "/be-proactive",
-        "/d/habits",
-        "/frog",
-        "/magic",
-        "/mental-pain",
-        "/mind-monsters",
-        "/psychic-shadows",
-        "/siy"
-      ],
-      "redirect_url": "",
-      "title": "Your idle loop",
-      "url": "/idle"
-    },
-    "/insecure": {
-      "description": "We all get it. Imposter syndrome, which includes shame\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/insecure.html",
-      "incoming_links": [
-        "/90days",
-        "/affirmations",
-        "/depression",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2024-09-14T14:16:00-07:00",
-      "markdown_path": "_d/imposter.md",
-      "outgoing_links": [
-        "/coaching",
-        "/shame"
-      ],
-      "redirect_url": "",
-      "title": "Insecurity and Imposter Syndrome",
-      "url": "/insecure"
-    },
-    "/insomnia": {
-      "description": "Insomnia controls you, instead of you controlling your sleep. If you want advice on how to deal with insomnia, do NOT ask a person who hasn’t slept in two nights. Instead, ask someone who’s had insomnia several times, and has a checklist on how to respond when insomnia flares up. By the way, I’ve never actually taken this advice, but maybe writing it down will make it more likely that I’ll take it in the future.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/insomnia.html",
-      "incoming_links": [
-        "/activation",
-        "/depression",
-        "/essentialism",
-        "/physical-health",
-        "/sleep"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_d/2016-2-11-Insomnia.md",
-      "outgoing_links": [
-        "/sleep"
-      ],
-      "redirect_url": "",
-      "title": "What I should do when I can't sleep",
-      "url": "/insomnia"
-    },
-    "/interviewsarehard": {
-      "description": "I’ve been hard on myself these last few months as I haven’t made a lot of progress on my habits or goals. Reflecting, that shouldn’t be a surprise as I’ve been putting a tonne of energy into my job hunt. Here is a reminder of the effort required, which will aid setting realistic expectations during the job hunt.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/interviewsarehard.html",
-      "incoming_links": [
-        "/job-hunt-stress"
-      ],
-      "last_modified": "2023-12-17T18:53:39+00:00",
-      "markdown_path": "_posts/2016-11-26-interviewsarehard.markdown",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Be easy on yourself, job hunts are hard",
-      "url": "/interviewsarehard"
-    },
-    "/ios-accessibility": {
-      "description": "iOS has some great accessibility features which allow hands-free and eye-less control of the device. Here they are.\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/ios-accessibility.html",
-      "incoming_links": [],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_td/ios-accessibility.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "iOS Accessibility",
-      "url": "/ios-accessibility"
-    },
-    "/irl": {
-      "description": "I started writing a technical blog to help me remember the many things I explore. One day, I realized I’ve got a real life too. Here’s a place I can remember the many things I explore IRL (In real Life)\n\n",
-      "doc_size": 79000,
-      "file_path": "_site/irl.html",
-      "incoming_links": [
-        "/physical-health",
-        "/td/ios-nomad"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_td/irl.md",
-      "outgoing_links": [
-        "/bike",
-        "/emotional-health",
-        "/eulogy",
-        "/physical-health",
-        "/siy",
-        "/tesla"
-      ],
-      "redirect_url": "",
-      "title": "In Real Life Diary",
-      "url": "/irl"
-    },
-    "/job": {
-      "description": "In my dream job, I learn the customer and business needs and focus the team on delivering them in a sustainable manner. Simultaneously, I help team members grow, develop our culture, and build valuable tech. When talking to others I prefer a couch to a table, and when I need a break, you might see me juggling, practicing magic, or riding my folding bike—often in the office.\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/job.html",
-      "incoming_links": [
-        "/bmy",
-        "/eulogy",
-        "/job-hunt-stress",
-        "/manager-book",
-        "/manager-book-appendix"
-      ],
-      "last_modified": "2025-09-07T05:53:44-07:00",
-      "markdown_path": "_posts/2018-06-7-my-perfect-job.md",
-      "outgoing_links": [
-        "/being-a-great-manager",
-        "/cache",
-        "/coaching",
-        "/human-meetings",
-        "/manager-book",
-        "/moments-at-work",
-        "/software-leadership-roles"
-      ],
-      "redirect_url": "",
-      "title": "My Dream Job",
-      "url": "/job"
-    },
-    "/job-hunt-stress": {
-      "description": "Job hunts are stressful, and my goal for job hunts is getting the job I want while minimizing my stress. The stress comes from: lack of confidence, being rushed, not having options, disappointing others and the pressure from current job responsibilities. By expecting and mitigating each of these stressors I greatly reduce stress during my job hunt.\n\n",
-      "doc_size": 25000,
-      "file_path": "_site/job-hunt-stress.html",
-      "incoming_links": [
-        "/bmy",
-        "/comp",
-        "/manager-book",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2025-08-24T09:03:19-07:00",
-      "markdown_path": "_posts/2017-02-17-job-hunt-stress.md",
-      "outgoing_links": [
-        "/bmy",
-        "/comp",
-        "/decisive",
-        "/interviewsarehard",
-        "/job",
-        "/system-design"
-      ],
-      "redirect_url": "",
-      "title": "Reducing job hunt stress",
-      "url": "/job-hunt-stress"
-    },
-    "/joy": {
-      "description": "If you could have one superpower, what would it be? At 46, you’d think I’d have a quick answer, but the usual ideas—flying, invisibility, stopping time—felt childish. Probably the setting: a circle of 9-17-year-olds, breaking the ice, sharing their wished-for superpowers. As my mind scrambled, a mild panic set in. Nothing surfaced—until a bit of my eulogy came to me: Igor lived to see eyes go wide and mouths gape with wonder. He loved when strangers were drawn in against their objections, when a kid in meltdown, or an adult weighed down by life, forgot their troubles. Relief washed over me, I knew my answer. The super power I wished for:  bringing joy to others.\n\n",
-      "doc_size": 31000,
-      "file_path": "_site/joy.html",
-      "incoming_links": [
-        "/affirmations",
-        "/balloon",
-        "/build-bubble-bike",
-        "/emotions",
-        "/end-in-mind",
-        "/energy",
-        "/happy",
-        "/hobby",
-        "/magic",
-        "/mood",
-        "/sublime"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/joy.md",
-      "outgoing_links": [
-        "/balloon",
-        "/build-bubble-bike",
-        "/eulogy",
-        "/happy",
-        "/ig66/621",
-        "/like-switch",
-        "/magic",
-        "/smilebox",
-        "/touching"
-      ],
-      "redirect_url": "",
-      "title": "Smiles, Joy and Wonder",
-      "url": "/joy"
-    },
-    "/kayak": {
-      "description": "When Meta announced they’d start charging $15 a day for parking, my first thought was: “Are you kidding me? Fifteen dollars a DAY?” I couldn’t believe they were suddenly gouging us employees for something that had been free for years. The math was infuriating - that’s $75 a week, $300 a month, nearly $4,000 a year just to park my damn car at work!\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/kayak.html",
-      "incoming_links": [],
-      "last_modified": "2025-07-29T19:19:42-07:00",
-      "markdown_path": "_d/kayak-commuting.md",
-      "outgoing_links": [
-        "/tesla"
-      ],
-      "redirect_url": "",
-      "title": "Kayak Commuting: From Parking Fees to Paddling Adventures",
-      "url": "/kayak"
-    },
-    "/kettlebell": {
-      "description": "There’s no way I’m swinging that thing between my legs; I’m going to kill my back. When I started working out with a trainer in 2020, they tried to get me to do a kettlebell swing, and I was like, no way. Then they spent 3 weeks teaching me Turkish Get-Ups (TGUs), which I absolutely loved. Then I read Simple and Sinister, and now I’ve achieved Timeless Simple and do heavy clubs instead of halos.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/kettlebell.html",
-      "incoming_links": [
-        "/eulogy",
-        "/gap-year-igor",
-        "/physical-health",
-        "/timeoff",
-        "/untangled",
-        "/y24"
-      ],
-      "last_modified": "2025-07-20T19:13:52-07:00",
-      "markdown_path": "_d/bells.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Kettlebells - A rock with a handle",
-      "url": "/kettlebell"
-    },
-    "/last-year": {
-      "description": "Bad news, you’ve got a last year on earth. Good news, if you’re lucky you’ll accept that “grand father dies, father dies, son dies” is the best blessing you can have (imagine a different ordering). If you’re luckier, you’ll have age appropriate health right up till that last year, or even better that last few months. If you’re even luckier you’ll have the strength to do what you want in your personal “centenarian Olympics”.\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/last-year.html",
-      "incoming_links": [
-        "/42",
-        "/chasing-daylight",
-        "/death",
-        "/retire",
-        "/y24",
-        "/y25"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/last-year.md",
-      "outgoing_links": [
-        "/chasing-daylight",
-        "/death"
-      ],
-      "redirect_url": "",
-      "title": "Kick the Bucket List: Your Guide to an Epic Last Year on Earth",
-      "url": "/last-year"
-    },
-    "/laws-of-power": {
-      "description": "A very cynical book about the laws of power. Probably worth a read in case you want to better understand the dark side.\n\n",
-      "doc_size": 47000,
-      "file_path": "_site/laws-of-power.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/48-laws-of-power.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "The 48 laws of power",
-      "url": "/laws-of-power"
-    },
-    "/learn-code": {
-      "description": "Coding is way easier then people think. Here’s some pointers.\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/learn-code.html",
-      "incoming_links": [],
-      "last_modified": "2025-05-11T06:34:37-07:00",
-      "markdown_path": "_d/learn-to-code.md",
-      "outgoing_links": [
-        "/ig66/602"
-      ],
-      "redirect_url": "",
-      "title": "Learn to Code",
-      "url": "/learn-code"
-    },
-    "/life-as-business": {
-      "description": "Businesses exist to generate profit. But what about life? Can we manage our lives with the same intentionality and clarity businesses use to thrive? Viewing life through this lens helps prioritize what truly matters, sustain energy, and deepen relationships. Just as businesses carefully manage resources, we can intentionally allocate our energy, nurture meaningful assets, and measure success beyond mere productivity. Life operates on two intertwined currencies—Life Value (the true worth of our existence) and energy (the operational fuel). These currencies are generated and sustained by carefully nurturing life assets such as relationships, health, skills, and character.\n\n",
-      "doc_size": 36000,
-      "file_path": "_site/life-as-business.html",
-      "incoming_links": [],
-      "last_modified": "2025-03-06T06:43:27-08:00",
-      "markdown_path": "_d/life-as-business.md",
-      "outgoing_links": [
-        "/balance",
-        "/d/habits",
-        "/energy-abundance",
-        "/operating-manual",
-        "/strategy",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Life as a Business: Managing Energy, Assets, and Satisfaction",
-      "url": "/life-as-business"
-    },
-    "/like-switch": {
-      "description": "The like switch, written by an ex-FBI agent, goes into detail on how to make friends and influence people in a much more modern form.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/like-switch.html",
-      "incoming_links": [
-        "/joy"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/the-like-switch.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "How to build rapport and set people at ease",
-      "url": "/like-switch"
-    },
-    "/lonely": {
-      "description": "Loneliness is not simply being alone. It’s a painful emotional experience that comes from feeling disconnected—from others, from the world, or sometimes from yourself. It is the sense that the connections you need—emotional, social, or even spiritual—are missing or inadequate. And it’s not just a personal feeling— 36% of americans feel lonely “frequently”, “almost all the time” or “all the time” in the prior four weeks. 61% of young people aged 18-25 and 51% of mothers with young children reported these miserable degrees of loneliness. The cost of loneliness is high: it is linked to early mortality and a wide array of serious physical and emotional problems, including depression, anxiety, heart disease, substance abuse, and domestic abuse.\n\n",
-      "doc_size": 43000,
-      "file_path": "_site/lonely.html",
-      "incoming_links": [
-        "/mental-pain"
-      ],
-      "last_modified": "2025-07-13T06:56:50-07:00",
-      "markdown_path": "_d/lonely.md",
-      "outgoing_links": [
-        "/chapters"
-      ],
-      "redirect_url": "",
-      "title": "Loneliness",
-      "url": "/lonely"
-    },
-    "/magic": {
-      "description": "Being a dealer of smiles and wonder is a priority in my life, and magic is my instrument. This post details my history and some highlights\n\n",
-      "doc_size": 25000,
-      "file_path": "_site/magic.html",
-      "incoming_links": [
-        "/d/resistance",
-        "/eulogy",
-        "/hobby",
-        "/idle",
-        "/joy",
-        "/operating-manual",
-        "/timeoff",
-        "/touching"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_posts/2016-04-21-magical-memories.md",
-      "outgoing_links": [
-        "/joy"
-      ],
-      "redirect_url": "",
-      "title": "Magical memories",
-      "url": "/magic"
-    },
-    "/manager-book": {
-      "description": "Being an engineering manager is hard. Supporting people well is harder. Lessons are hard earned and should be cherished. This post is designed to make explicit, and improve behaviors and practices. It reminds me how to behave and encourages my own continuous improvement.\n\n",
-      "doc_size": 169000,
-      "file_path": "_site/manager-book.html",
-      "incoming_links": [
-        "/amazon",
-        "/being-a-great-manager",
-        "/coaching",
-        "/content-audience",
-        "/job",
-        "/manager-book-appendix",
-        "/retire",
-        "/software-leadership-roles",
-        "/tribe",
-        "/work-satisfaction",
-        "/y24",
-        "/y25"
-      ],
-      "last_modified": "2025-08-14T20:41:27-07:00",
-      "markdown_path": "_posts/2016-03-03-the-manager-book-2.md",
-      "outgoing_links": [
-        "/22",
-        "/90days",
-        "/being-a-great-manager",
-        "/books-that-defined-me",
-        "/coaching",
-        "/coe",
-        "/comp",
-        "/d/habits",
-        "/decisive",
-        "/dip",
-        "/end-in-mind",
-        "/job",
-        "/job-hunt-stress",
-        "/manager-book-appendix",
-        "/ml",
-        "/moments-at-work",
-        "/overload",
-        "/pride",
-        "/product",
-        "/prompts",
-        "/remote-work",
-        "/software-leadership-roles",
-        "/static/idvorkin-linked-in-feedback-lastest.pdf",
-        "/strategy",
-        "/td/cloud-first-applications",
-        "/testing",
-        "/what-makes-a-leader",
-        "/work-satisfaction",
-        "/writing"
-      ],
-      "redirect_url": "",
-      "title": "How to EM: Be the manager everyone wants",
-      "url": "/manager-book"
-    },
-    "/manager-book-appendix": {
-      "description": "A hodgepodge of additional resources for the manager book.\n\n",
-      "doc_size": 34000,
-      "file_path": "_site/manager-book-appendix.html",
-      "incoming_links": [
-        "/manager-book",
-        "/operating-manual"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/manager-book-appendix.md",
-      "outgoing_links": [
-        "/amazon",
-        "/books-that-defined-me",
-        "/facebook",
-        "/job",
-        "/manager-book",
-        "/parkinson",
-        "/writing"
-      ],
-      "redirect_url": "",
-      "title": "Manager Book Appendix",
-      "url": "/manager-book-appendix"
-    },
-    "/mania": {
-      "description": "The words that follow, I pray will never be my own – What pains me most is I see how crystal clear my illness was in the beginning and how I was surrounded by so much love. So, so many family and friends were desperately trying to intervene, and I spurned them and then reacted despicably. I am so, so sorry. I failed as a husband, a father, a brother, friend, and as a kind human being. It is a hard pill to swallow that I was the Evil one. Why did I fail? Me. My brain. My manic self. I wanted more than anything to prove them wrong. That I could do this. But I couldn’t. You can learn a lot, but you can’t unlearn bipolar disorder. I desperately wanted to believe that bipolar disorder wasn’t real and that I could stop living in fear of it. That all the doubters were wrong (from a friend with bipolar).\n\n",
-      "doc_size": 22000,
-      "file_path": "_site/mania.html",
-      "incoming_links": [
-        "/energy",
-        "/mood"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/mania.md",
-      "outgoing_links": [
-        "/emotional-health",
-        "/tesla"
-      ],
-      "redirect_url": "",
-      "title": "Mania: It's like a free cocaine drip",
-      "url": "/mania"
-    },
-    "/media-edit": {
-      "description": "Lets play with media editing. So far I’ve liked luma fusion for post:\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/media-edit.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/media-edit.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Media Editing",
-      "url": "/media-edit"
-    },
-    "/mental-pain": {
-      "description": "Pain is in the brain as they say, which is especially true for mental pains. Pain isn’t the enemy though, pain is a signal. The pain system, when working properly draws our attention to a problem so that we can deal with it. However, our pain can evolve into unecassary suffering, be phantom pain, meaning it is being applied when it should not be, or chronic pain, which flares up even though it is no longer providing value.\n\n",
-      "doc_size": 37000,
-      "file_path": "_site/mental-pain.html",
-      "incoming_links": [
-        "/addiction",
-        "/ai-journal",
-        "/anger",
-        "/anxiety-management",
-        "/curious",
-        "/d/resistance",
-        "/happy",
-        "/idle",
-        "/mind-monsters",
-        "/physical-pain",
-        "/psychic-shadows",
-        "/psychic-weight",
-        "/regrets",
-        "/shame",
-        "/timeoff-2020-12",
-        "/work-satisfaction",
-        "/y24"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/mental-pain.md",
-      "outgoing_links": [
-        "/addiction",
-        "/d/resistance",
-        "/depression",
-        "/frog",
-        "/lonely",
-        "/physical-pain",
-        "/pride"
-      ],
-      "redirect_url": "",
-      "title": "The thoughts that pain us",
-      "url": "/mental-pain"
-    },
-    "/mermaid": {
-      "description": "Lets try d2\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/mermaid.html",
-      "incoming_links": [],
-      "last_modified": "2023-12-17T18:49:14+00:00",
-      "markdown_path": "_d/mermaid.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Playing w/Mermaid",
-      "url": "/mermaid"
-    },
-    "/micro-economics": {
-      "description": "Supply, demands and markets, oh my!\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/micro-economics.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/micro-economics.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Micro Economics",
-      "url": "/micro-economics"
-    },
-    "/mind-at-work": {
-      "description": "I have a problem, an addiction, an addiction so detrimental to quality of life, it should be described as a disease. This disease is not being present. There are many symptoms of the disease, but today I’m going to talk about my most frequent symptoms, my body at home, but my mind at work.\n\n",
-      "doc_size": 19000,
-      "file_path": "_site/mind-at-work.html",
-      "incoming_links": [
-        "/addiction",
-        "/timeoff",
-        "/timeoff-2022-11",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/2016-2-10-body-at-home-mind-at-work.md",
-      "outgoing_links": [
-        "/addiction",
-        "/d/habits",
-        "/emotional-health",
-        "/psychic-weight",
-        "/timeoff",
-        "/work-satisfaction"
-      ],
-      "redirect_url": "",
-      "title": "Body at home, mind at work",
-      "url": "/mind-at-work"
-    },
-    "/mind-monsters": {
-      "description": "Last night I was having trouble sleeping so I plopped down on the couch to watch infomercials. The infomercial I picked was religious in nature, and was talking about mind monsters.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/mind-monsters.html",
-      "incoming_links": [
-        "/being-a-great-manager",
-        "/idle",
-        "/psychic-shadows",
-        "/psychic-weight",
-        "/siy"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_d/2015-11-11-mind-monsters.md",
-      "outgoing_links": [
-        "/mental-pain",
-        "/pride",
-        "/siy",
-        "/voices"
-      ],
-      "redirect_url": "",
-      "title": "Mind monsters",
-      "url": "/mind-monsters"
-    },
-    "/ml": {
-      "description": "It used to be that software was eating the world. Now ML is eating software. ML is computers building algorithms by only looking at the data. This is powerful as the computer can find patterns in large data sets that are too complicated for humans to find and express via algorithms. In human terms programming is following a check list which someone else provided (E.g. bake a cake by following the recipe). ML is following your intuition. (E.g making a stir fry from stuff in the fridge). As with ML, you can’t articulate your intuition as it built through countless experiences, but it mostly works (E.g. you never put a banana in your stirfry).\n\n",
-      "doc_size": 52000,
-      "file_path": "_site/ml.html",
-      "incoming_links": [
-        "/ai",
-        "/manager-book",
-        "/td/stats"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/machine-learning.md",
-      "outgoing_links": [
-        "/ai-testing",
-        "/gpt",
-        "/nlp",
-        "/pandas",
-        "/recommend"
-      ],
-      "redirect_url": "",
-      "title": "Machine learning for regular programmers.",
-      "url": "/ml"
-    },
-    "/modal": {
-      "description": "Modal seems like a system custom built for ML, giving it a shot\n\n",
-      "doc_size": 12000,
-      "file_path": "_site/modal.html",
-      "incoming_links": [],
-      "last_modified": "2023-05-21T06:34:43-07:00",
-      "markdown_path": "_td/modal.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Modal - A tool to play with ML",
-      "url": "/modal"
-    },
-    "/moments": {
-      "description": "Take a few seconds to close your eyes and think back on an important memory. In that moment, did you feel a sense of elevation? Did you experience insight? Have a sense of pride? Make a connection? In the power of moments, the attributes of powerful moments are understood so that they can be better engineered.\n\n",
-      "doc_size": 26000,
-      "file_path": "_site/moments.html",
-      "incoming_links": [
-        "/balance",
-        "/chasing-daylight",
-        "/happy",
-        "/moments-at-work",
-        "/random-idea",
-        "/timeoff-2022-12",
-        "/timeoff-2023-04",
-        "/timeoff-2023-08",
-        "/timeoff-2023-11",
-        "/timeoff-2024-08",
-        "/timeoff-2025-08"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/2018-04-03-moments.md",
-      "outgoing_links": [
-        "/moments-at-work"
-      ],
-      "redirect_url": "",
-      "title": "Engineering Moments",
-      "url": "/moments"
-    },
-    "/moments-at-work": {
-      "description": "Of all the places we spend our time, work is the one that dominates. However, when we look back on our lives, work is often the thing we remember least. Why? Because we remember our lives through peak moments, and there are few of those, especially positive peak moments, at work. Luckily, peak moments can be created and managers can be taught how to create them. This post explores opportunities and techniques to create these moments.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/moments-at-work.html",
-      "incoming_links": [
-        "/being-a-great-manager",
-        "/job",
-        "/manager-book",
-        "/moments",
-        "/random-idea"
-      ],
-      "last_modified": "2020-06-17T07:39:28-07:00",
-      "markdown_path": "_posts/2018-04-09-moments-at-work.md",
-      "outgoing_links": [
-        "/coaching",
-        "/moments"
-      ],
-      "redirect_url": "",
-      "title": "Moments at work",
-      "url": "/moments-at-work"
-    },
-    "/monetize": {
-      "description": "Let’s talk money. Whether you’re a content creator dreaming of YouTube riches or a brand trying to understand the advertising landscape, this guide breaks down the reality of monetization - spoiler alert: it’s harder than you think, but not impossible.\n\n",
-      "doc_size": 28000,
-      "file_path": "_site/monetize.html",
-      "incoming_links": [
-        "/advertising",
-        "/content-creation"
-      ],
-      "last_modified": "2025-07-30T10:50:40-07:00",
-      "markdown_path": "_d/monetization.md",
-      "outgoing_links": [
-        "/advertising",
-        "/content-creation",
-        "/gap-year",
-        "/retire"
-      ],
-      "redirect_url": "",
-      "title": "Creator Monetization: From Dreams to Reality",
-      "url": "/monetize"
-    },
-    "/money": {
-      "description": "Most of the tax information on the web is a mess. It’s confusing as it tries to apply to everyone, with varying situations, and is often written by non-engineers for non-engineers. I think my tax situation is common to people who have been in software engineering companies for most of their careers, and here are my notes.\n\n",
-      "doc_size": 67000,
-      "file_path": "_site/money.html",
-      "incoming_links": [
-        "/gap-year",
-        "/gap-year-igor",
-        "/operating-manual",
-        "/parkinson",
-        "/retire",
-        "/stock-concentration",
-        "/timeoff-2020-03"
-      ],
-      "last_modified": "2025-08-25T10:19:14-07:00",
-      "markdown_path": "_d/taxes.md",
-      "outgoing_links": [
-        "/parkinson",
-        "/partner-trouble",
-        "/stock-concentration"
-      ],
-      "redirect_url": "",
-      "title": "Tax and Saving",
-      "url": "/money"
-    },
-    "/mood": {
-      "description": "Let me ask an easy question: “How are you feeling?”. How long did it take you to answer? Less then a second? Impressive. Now a harder question “What makes you say that?”, or even harder “How do you ‘compute’ how are you feeling?” What is going on? Human’s have a super fast heuristic called mood giving them an insant assessment of their sujective reality. Mood is critical to understand as it drives our behaviors, has an outsized influence on our subjective experience, can be in conflict to our pursuit of happiness, and most importantly has several bugs which can be exploited by the resistance and other bad actors.\n\n",
-      "doc_size": 28000,
-      "file_path": "_site/mood.html",
-      "incoming_links": [
-        "/energy",
-        "/happy",
-        "/timeoff-2024-08",
-        "/timeoff-2025-08"
-      ],
-      "last_modified": "2025-08-24T10:29:13-07:00",
-      "markdown_path": "_d/mood.md",
-      "outgoing_links": [
-        "/anger",
-        "/depression",
-        "/energy",
-        "/happy",
-        "/joy",
-        "/mania",
-        "/regrets",
-        "/slow"
-      ],
-      "redirect_url": "",
-      "title": "Mood - Our blazing fast heuristic for subjective experience",
-      "url": "/mood"
-    },
-    "/mortality-software": {
-      "description": "Mortality is a word avoided. But, earlier or later, we all face it. Life is finite, time is limited. Mortality software helps us understand and then ensure we are using our precious time well. It helps us create our future and reflect on our past. Why must we do this? Because A)”first you’ve lost a day and the day becomes a week and a week becomes a month and before you know it you’ve lost a year” and B) “At the point change is obvious it’s too late - it means the need for change is long since past”\n\n",
-      "doc_size": 32000,
-      "file_path": "_site/mortality-software.html",
-      "incoming_links": [
-        "/balance",
-        "/goals"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/2018-04-29-mortality-software.md",
-      "outgoing_links": [
-        "/affirmations",
-        "/checklist",
-        "/death"
-      ],
-      "redirect_url": "",
-      "title": "Time.ltd - Mortality Software",
-      "url": "/mortality-software"
-    },
-    "/negotiate": {
-      "description": "Negotiation is the heart of collaboration. It is what makes conflict potentially meaningful and productive for all parties. Getting To Yes is the seminal book on negotiation. It’s the deep dive into win win or no deal and seek first to understand. The formal, be hard on problems and soft on people, then focus on the desired outcomes not the positions, next get more options on the table, and make sure you measure by objective criteria - lastly know your BATNA.Several years later a new book came out by a hostage negotiator. Instead of being analytic focus, it’s all about influencing the elephant.\n\n",
-      "doc_size": 22000,
-      "file_path": "_site/negotiate.html",
-      "incoming_links": [
-        "/curious",
-        "/getting-to-yes-with-yourself",
-        "/happy",
-        "/productive",
-        "/regrets",
-        "/sell",
-        "/synergize",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/gty.md",
-      "outgoing_links": [
-        "/curious",
-        "/first-understand",
-        "/switch",
-        "/win-win"
-      ],
-      "redirect_url": "",
-      "title": "Getting to yes",
-      "url": "/negotiate"
-    },
-    "/neovim": {
-      "description": "Long ago a fork from vim emerged. Neovim! I avoided it for a long time, but when Bram (the inventor of vim) died, I decided it was time to switch. Now that I’ve sucked up the 20-40 hours in the conversion, I’m thrilled I did. Turns out all the “kids” have been using and developing on neovim. This results in 1, good tools, and nice best practices.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/neovim.html",
-      "incoming_links": [
-        "/vim"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/nvim.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Neovim",
-      "url": "/neovim"
-    },
-    "/new-skills": {
-      "description": "Magic, Kettle Bells, Public Speaking - every skill I’ve acquired follows the same immutable laws. These laws govern how we learn, progress, and master new abilities. It’s possible these laws don’t apply to you, but I doubt it.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/new-skills.html",
-      "incoming_links": [
-        "/about",
-        "/operating-manual",
-        "/physical-health",
-        "/physical-pain",
-        "/recent"
-      ],
-      "last_modified": "2025-02-09T09:50:07-08:00",
-      "markdown_path": "_d/laws-of-new-skills.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "The Immutable Laws of New Skills",
-      "url": "/new-skills"
-    },
-    "/nlp": {
-      "description": "My explorations of NLP, mostly using my corpus of journal entries and other writing. My intent is twofold: 1) learning about NLP and sentiment analysis 2) finding latent meaning in my writing, ideally to help me better understand my own psychological processes. I’ve had much more success with the former than the latter.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/nlp.html",
-      "incoming_links": [
-        "/ml",
-        "/tools"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_td/nlp.md",
-      "outgoing_links": [
-        "/gpt"
-      ],
-      "redirect_url": "",
-      "title": "Sentiment Analysis and NLP",
-      "url": "/nlp"
-    },
-    "/nurture": {
-      "description": "In “Nurturing Love,” the Heath Brothers distill the wisdom of renowned relationship experts Drs. John and Julie Gottman into a concise and actionable guide for couples seeking to strengthen their relationships. Using their signature storytelling approach and evidence-based insights, the Heath Brothers create an engaging and accessible roadmap to the Gottman Method.\n\n",
-      "doc_size": 42000,
-      "file_path": "_site/nurture.html",
-      "incoming_links": [
-        "/gpt"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/nurture.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "NURTURE: The Gottman Method",
-      "url": "/nurture"
-    },
-    "/operating-manual": {
-      "description": "I’ve learned what I like, how I want to spend my energy, and how I want to be thinking about my life. I’ve learned my roles, reasonable expectations, and healthy ways to operate given my personality, behaviors, and frequently occurring situations. This post is a summary of those learnings - an operating manual if you will, reminding me how to think about, respond to and behave, so I can operate at maximum effectiveness and efficiency. Super important: You don’t rise to the level of your goals, you fall to the level of your systems.\n\n",
-      "doc_size": 39000,
-      "file_path": "_site/operating-manual.html",
-      "incoming_links": [
-        "/energy",
-        "/energy-abundance",
-        "/life-as-business"
-      ],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/operating-manual-2.md",
-      "outgoing_links": [
-        "/Immutable-Laws-Of-Hard",
-        "/affirmations",
-        "/anxiety",
-        "/bike",
-        "/blueprint",
-        "/covid",
-        "/curious",
-        "/d/habits",
-        "/diet",
-        "/emotional-health",
-        "/eulogy",
-        "/hobby",
-        "/ig66/587",
-        "/magic",
-        "/manager-book-appendix",
-        "/money",
-        "/new-skills",
-        "/parkinson",
-        "/physical-health",
-        "/process-journal",
-        "/siy",
-        "/sleight-of-mouth",
-        "/strengths",
-        "/tesla",
-        "/timeoff-2022-07",
-        "/todo_enjoy",
-        "/tony",
-        "/voices",
-        "/writing"
-      ],
-      "redirect_url": "",
-      "title": "Igor the operating manual",
-      "url": "/operating-manual"
-    },
-    "/osx": {
-      "description": "\nCheck out my [Mac install script](https://github.com/idvorkin/Settings/blob/master/mac/install.sh) for automated setup of my Mac environment.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/osx.html",
-      "incoming_links": [
-        "/tools"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/osx.md",
-      "outgoing_links": [
-        "/screencast"
-      ],
-      "redirect_url": "",
-      "title": "Igor's OSX Tools",
-      "url": "/osx"
-    },
-    "/outsourcing": {
-      "description": "Time is my precious resource - I have a limited number of hours in my life, and once I’ve used them, I never get them back. However, I can preserve my time by outsourcing activities that don’t have high enough return on investment. This post reminds me to outsource by enumerating my position on outsourcing, and the things I have outsourced.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/outsourcing.html",
-      "incoming_links": [
-        "/gtd"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_d/2015-11-18-Outsourcing.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "On outsourcing",
-      "url": "/outsourcing"
-    },
-    "/overload": {
-      "description": "We all get to a point where our boss (*) gives us more work than we can handle. This spikes our anxiety and we’ll end up in one of three conversations: 1) I’ve got too much on my plate, 2) I can’t get this done; 3) I quit. Which do you think your boss would rather have?\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/overload.html",
-      "incoming_links": [
-        "/manager-book",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_d/handling-overwork.md",
-      "outgoing_links": [
-        "/anxiety",
-        "/essentialism",
-        "/sustainable-work"
-      ],
-      "redirect_url": "",
-      "title": "Dealing with Task Overload",
-      "url": "/overload"
-    },
-    "/pandas": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/pandas.html",
-      "incoming_links": [
-        "/ml",
-        "/timeoff-2020-12"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/pandas-tutorial.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Pandas + IPython + Jupyter Incantations",
-      "url": "/pandas"
-    },
-    "/parkinson": {
-      "description": "Work expands to fill the resources available. The more you make, the more you spend. Stuff accumulates to fill the available storage space. And if you want something done, give it to a busy person.\n\n",
-      "doc_size": 22000,
-      "file_path": "_site/parkinson.html",
-      "incoming_links": [
-        "/balance",
-        "/gap-year-igor",
-        "/manager-book-appendix",
-        "/money",
-        "/operating-manual",
-        "/timeoff"
-      ],
-      "last_modified": "2025-03-11T06:05:27-07:00",
-      "markdown_path": "_d/resource-paradox.md",
-      "outgoing_links": [
-        "/amazon",
-        "/d/resistance",
-        "/dip",
-        "/essentialism",
-        "/frog",
-        "/goals",
-        "/gtd",
-        "/money",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Parkinson's Law: The Paradox of Plenty",
-      "url": "/parkinson"
-    },
-    "/partner-trouble": {
-      "description": "There are two types of couples in the world. Those who fight, and those you don’t know. Your life partnership is the most impactful relationship you have, are you investing sufficiently?\n\n",
-      "doc_size": 30000,
-      "file_path": "_site/partner-trouble.html",
-      "incoming_links": [
-        "/gap-year",
-        "/money",
-        "/tori"
-      ],
-      "last_modified": "2025-08-31T06:37:16-07:00",
-      "markdown_path": "_d/partner-trouble.md",
-      "outgoing_links": [
-        "/essentialism"
-      ],
-      "redirect_url": "",
-      "title": "Double Trouble: From Lust to Love to Lost",
-      "url": "/partner-trouble"
-    },
-    "/physical-health": {
-      "description": "Physical health is not bought, it’s rented and rent is due every day. Physical health is the basis of energy, and thus the source of success, and a key saw to sharpen. Physical health requires weight, fitness, and sleep.\n\n",
-      "doc_size": 28000,
-      "file_path": "_site/physical-health.html",
-      "incoming_links": [
-        "/42",
-        "/depression",
-        "/diet",
-        "/essentialism",
-        "/eulogy",
-        "/gap-year",
-        "/gap-year-igor",
-        "/irl",
-        "/operating-manual",
-        "/retire",
-        "/sharpen-the-saw",
-        "/tech-health-toys"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_posts/2017-10-07-physical-health.md",
-      "outgoing_links": [
-        "/d/habits",
-        "/diet",
-        "/insomnia",
-        "/irl",
-        "/kettlebell",
-        "/new-skills",
-        "/sharpen-the-saw",
-        "/sleep",
-        "/tech-health-toys",
-        "/terzepatide"
-      ],
-      "redirect_url": "",
-      "title": "Physical Health Lets you look good in your jeans, and wrestle bears",
-      "url": "/physical-health"
-    },
-    "/physical-pain": {
-      "description": "Physical pain is a universal experience, yet it remains one of the least understood aspects of human health. Whether it’s a stubbed toe or chronic back pain, understanding the nature of physical pain can empower us to manage it effectively and improve our quality of life.\n\n",
-      "doc_size": 31000,
-      "file_path": "_site/physical-pain.html",
-      "incoming_links": [
-        "/mental-pain"
-      ],
-      "last_modified": "2025-09-01T09:31:18-07:00",
-      "markdown_path": "_d/physical-pain.md",
-      "outgoing_links": [
-        "/coe",
-        "/mental-pain",
-        "/new-skills"
-      ],
-      "redirect_url": "",
-      "title": "Physical Pain: Understanding and Managing It",
-      "url": "/physical-pain"
-    },
-    "/podcast": {
-      "description": "To my amazement, I listen to podcasts. I think they’re pretty interesting, here are my notes on them.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/podcast.html",
-      "incoming_links": [
-        "/enable"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/podcast.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Podcasting",
-      "url": "/podcast"
-    },
-    "/pride": {
-      "description": "“That is Pride Fucking With You” is the only scene I can quote from any movie. It’s a powerful scene, and the advice is timeless. Two thousand years ago when a Roman emperor had a victory parade, he was required to have a slave standing behind him holding his helmet high in the air and whispering continuously: “You are mortal. You are mortal”. Pride and ego are serious foes that must be kept in check.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/pride.html",
-      "incoming_links": [
-        "/being-a-great-manager",
-        "/coaching",
-        "/comp",
-        "/enemy",
-        "/manager-book",
-        "/mental-pain",
-        "/mind-monsters",
-        "/psychic-weight"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_posts/2018-01-01-fuck-pride.md",
-      "outgoing_links": [
-        "/decisive"
-      ],
-      "redirect_url": "",
-      "title": "That is pride fucking with you",
-      "url": "/pride"
-    },
-    "/process-journal": {
-      "description": "I’ve been doing daily stream of consciousness journaling since 2011, writing over a million words. Here’s how I think about processing and analyzing my journal entries. While I don’t always achieve this perfectly, this represents my aspirational process that I strive towards.\n\n",
-      "doc_size": 19000,
-      "file_path": "_site/process-journal.html",
-      "incoming_links": [
-        "/chop",
-        "/eulogy",
-        "/operating-manual",
-        "/y24",
-        "/y25"
-      ],
-      "last_modified": "2025-03-02T19:25:33-08:00",
-      "markdown_path": "_d/process-journal.md",
-      "outgoing_links": [
-        "/affirmations",
-        "/be-proactive",
-        "/chop",
-        "/emotional-health",
-        "/grateful",
-        "/psychic-weight"
-      ],
-      "redirect_url": "",
-      "title": "Daily Journaling: From Psychic Diarrhea to Polished Turds",
-      "url": "/process-journal"
-    },
-    "/produce-consume": {
-      "description": "Remember when you finished binge-watching that entire series and felt… empty? Now remember the last time you made something — anything — even if it sucked. Which memory makes you smile? Yeah, me too. We live in the golden age of consumption, where infinite content is one thumb-swipe away, yet we’re more anxious and less satisfied than ever. Here’s the thing: you’re not meant to be a consumer. You’re meant to be a producer.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/produce-consume.html",
-      "incoming_links": [
-        "/slow"
-      ],
-      "last_modified": "2025-08-24T08:45:07-07:00",
-      "markdown_path": "_d/produce-consume.md",
-      "outgoing_links": [
-        "/activation"
-      ],
-      "redirect_url": "",
-      "title": "The Producer's Paradox: Why Creating Beats Consuming Every Time",
-      "url": "/produce-consume"
-    },
-    "/product": {
-      "description": "From creating a vision that inspires to laying out the strategies to get there, product work requires a range of skills—and a good dose of creativity. Putting the puzzle pieces together is essential to creating a product that appeals to its customers. With the right combination of vision, strategy, product design and execution, anyone can create something truly remarkable. With this in mind, let’s start building the future we want to create!\n\n",
-      "doc_size": 38000,
-      "file_path": "_site/product.html",
-      "incoming_links": [
-        "/manager-book"
-      ],
-      "last_modified": "2024-10-27T17:27:54-07:00",
-      "markdown_path": "_d/product.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Building products",
-      "url": "/product"
-    },
-    "/productive": {
-      "description": "At the core of balance, energy, wlb, habits is being productive.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/productive.html",
-      "incoming_links": [
-        "/balance",
-        "/energy",
-        "/timeoff-2022-02"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/productive2.md",
-      "outgoing_links": [
-        "/addiction",
-        "/anxiety",
-        "/balance",
-        "/d/habits",
-        "/d/resistance",
-        "/end-in-mind",
-        "/energy",
-        "/frog",
-        "/negotiate",
-        "/switch"
-      ],
-      "redirect_url": "",
-      "title": "Productive",
-      "url": "/productive"
-    },
-    "/prompts": {
-      "description": "A prompt will kick start a great conversation, a great insight, and a great relationship. Here are lots of prompts. For fun, pick a prompt at random and ask it to someone else, or answer it yourself. However, it takes a lot of trust and vulnerability to answer these questions, so make sure the person feels very empowered to not answer a question.\n\n",
-      "doc_size": 45000,
-      "file_path": "_site/prompts.html",
-      "incoming_links": [
-        "/coaching",
-        "/first-understand",
-        "/manager-book"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/prompt.md",
-      "outgoing_links": [
-        "/coaching"
-      ],
-      "redirect_url": "",
-      "title": "Prompts, your guide to starting a conversation",
-      "url": "/prompts"
-    },
-    "/psychic-shadows": {
-      "description": "It’s 3am and your brain is replaying that conversation from six months ago, calculating worst-case financial scenarios, or imagining all the ways you’ll fail at that thing you haven’t even started yet. These aren’t just ordinary worries - they’re psychic shadows, specific thought patterns that loop endlessly in your mind like restless spirits. If you’re tired of being held hostage by these ruminating thoughts, this post will teach you how to craft personalized spells that banish each shadow the moment it appears, giving you a mystical toolkit for transforming persistent mental loops into single-word circuit breakers that actually work.\n\n",
-      "doc_size": 31000,
-      "file_path": "_site/psychic-shadows.html",
-      "incoming_links": [
-        "/anxiety-management",
-        "/caring",
-        "/depression",
-        "/idle",
-        "/psychic-weight",
-        "/siy"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/psychic-shadows.md",
-      "outgoing_links": [
-        "/addiction",
-        "/anxiety-management",
-        "/d/resistance",
-        "/mental-pain",
-        "/mind-monsters",
-        "/psychic-weight",
-        "/todo_enjoy"
-      ],
-      "redirect_url": "",
-      "title": "Psychic Shadows: Crafting Spells to Banish Ruminating Thoughts",
-      "url": "/psychic-shadows"
-    },
-    "/psychic-weight": {
-      "description": "Imagine a weight tied around your body, imagine it dragging behind you, slowing down your motions, preventing you from going where you want to go. Imagine never taking it off, and getting no relief regardless of when you sit or sleep. Now imagine that’s not a physical weight, but instead a mental weight, a psychic weight if you will. Psychic weight are the thoughts that prevent your mind and emotions from being fluid and light.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/psychic-weight.html",
-      "incoming_links": [
-        "/depression",
-        "/gtd",
-        "/mind-at-work",
-        "/process-journal",
-        "/psychic-shadows"
-      ],
-      "last_modified": "2025-07-18T07:57:44-07:00",
-      "markdown_path": "_d/psychic-weight.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/addiction",
-        "/curious",
-        "/d/habits",
-        "/d/resistance",
-        "/death",
-        "/frog",
-        "/gtd",
-        "/idle",
-        "/mental-pain",
-        "/mind-monsters",
-        "/pride",
-        "/psychic-shadows",
-        "/shame",
-        "/siy"
-      ],
-      "redirect_url": "",
-      "title": "Psychic Weight",
-      "url": "/psychic-weight"
-    },
-    "/quip": {
-      "description": "My group lives in QUIP. Here are some tips for my quip usage.\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/quip.html",
-      "incoming_links": [],
-      "last_modified": "2020-05-23T10:50:45-07:00",
-      "markdown_path": "_td/quip.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Quip tips and tricks",
-      "url": "/quip"
-    },
-    "/random": {
-      "description": "Igor's Blog",
-      "doc_size": 11000,
-      "file_path": "_site/random.html",
-      "incoming_links": [],
-      "last_modified": "2025-07-27T15:35:40-07:00",
-      "markdown_path": "random.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Random Page",
-      "url": "/random"
-    },
-    "/random-idea": {
-      "description": "There are lots of rough ideas I have that are not yet categorized, or good enough to be a thought. This will be a\nplace to store them.\n\n",
-      "doc_size": 28000,
-      "file_path": "_site/random-idea.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T10:48:49-07:00",
-      "markdown_path": "_d/2010-2-15-2016-Misc-Uncategorized.md",
-      "outgoing_links": [
-        "/decisive",
-        "/moments",
-        "/moments-at-work",
-        "/switch"
-      ],
-      "redirect_url": "",
-      "title": "Random Uncategorized Notes",
-      "url": "/random-idea"
-    },
-    "/rapport": {
-      "description": "In today’s fast-paced and interconnected world, building and maintaining strong relationships is essential for personal and professional success. POWER is a five-step process that will help you establish rapport and create meaningful connections with people from all walks of life. The POWER acronym stands for: Proximity Observation, Warmth, Empathy, Revelation\n\n",
-      "doc_size": 33000,
-      "file_path": "_site/rapport.html",
-      "incoming_links": [
-        "/gpt"
-      ],
-      "last_modified": "2025-08-25T10:46:49-07:00",
-      "markdown_path": "_d/rapport.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "How to build rapport",
-      "url": "/rapport"
-    },
-    "/recent": {
-      "description": "This page shows the most recently modified content across the site, helping you discover what’s been updated lately.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/recent.html",
-      "incoming_links": [
-        "/about"
-      ],
-      "last_modified": "2025-07-27T15:35:40-07:00",
-      "markdown_path": "_d/recent.md",
-      "outgoing_links": [
-        "/new-skills"
-      ],
-      "redirect_url": "",
-      "title": "Recently Modified Content",
-      "url": "/recent"
-    },
-    "/recommend": {
-      "description": "My explorations of recommender and ranking systems, heavly based on the superb book Practical Recommender Systems\n\n",
-      "doc_size": 34000,
-      "file_path": "_site/recommend.html",
-      "incoming_links": [
-        "/ai",
-        "/ml",
-        "/timeoff-2022-07"
-      ],
-      "last_modified": "2025-08-24T09:03:19-07:00",
-      "markdown_path": "_td/recommender.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Recommender Systems",
-      "url": "/recommend"
-    },
-    "/reflect-tool": {
-      "description": "Igor's Blog",
-      "doc_size": 12000,
-      "file_path": "_site/reflect-tool.html",
-      "incoming_links": [],
-      "last_modified": "2023-12-17T18:51:48+00:00",
-      "markdown_path": "self-reflect.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Self Reflection Tool",
-      "url": "/reflect-tool"
-    },
-    "/regrets": {
-      "description": "Regrets, both ours and others, are a powerful tools to shape our present and future. four main types: foundation regrets related to not laying a proper base for life; boldness regrets stemming from missed opportunities and risks; moral regrets from not doing the right thing; and connection regrets from neglecting or damaging relationships. May you fin dinsights into how we can better navigate our choices to minimize regret and enhance our sense of fulfillment.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/regrets.html",
-      "incoming_links": [
-        "/emotions",
-        "/mood"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/regrets.md",
-      "outgoing_links": [
-        "/be-proactive",
-        "/curious",
-        "/mental-pain",
-        "/negotiate",
-        "/sustainable-work"
-      ],
-      "redirect_url": "",
-      "title": "Regrets",
-      "url": "/regrets"
-    },
-    "/remote-work": {
-      "description": "In March 2020, the world shut down from Covid-19. In May 2020, I started a new job as a remote manager at FB. Here are my thoughts.\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/remote-work.html",
-      "incoming_links": [
-        "/manager-book"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/remotework.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Remote Work",
-      "url": "/remote-work"
-    },
-    "/retire": {
-      "description": "When we ponder retirement - we’re masters at planning our exit, but surprisingly vague about what happens after. We’re so focused on what we’re retiring from rather than what we’re retiring to. The real goal isn’t the escape itself - it’s creating a life of genuine freedom, growth, and meaning on the other side. And here’s the plot twist - much of this post isn’t about retirement at all. It’s about what to do while you’re still working.\n\n",
-      "doc_size": 26000,
-      "file_path": "_site/retire.html",
-      "incoming_links": [
-        "/42",
-        "/gap-year",
-        "/gap-year-igor",
-        "/monetize",
-        "/stock-concentration"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/retire.md",
-      "outgoing_links": [
-        "/42",
-        "/chapters",
-        "/diet",
-        "/enemy",
-        "/eulogy",
-        "/gap-year",
-        "/hobby",
-        "/last-year",
-        "/manager-book",
-        "/money",
-        "/physical-health",
-        "/static/idvorkin-linked-in-feedback-lastest.pdf",
-        "/sustainable-work",
-        "/work-satisfaction"
-      ],
-      "redirect_url": "",
-      "title": "Retirement: Stop Planning the Exit, Start Planning the Life",
-      "url": "/retire"
-    },
-    "/roblox-dev": {
-      "description": "Zach and Amelia are roblox fans, so it’s fun to be able to create things in there playgrounds. With Zach (and maybe Amelia in a while) it’s even more fun to get to program. Here’s some stuff I’ve learned about programming robolox.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/roblox-dev.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/roblox2.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Developing on roblox",
-      "url": "/roblox-dev"
-    },
-    "/save-the-soup": {
-      "description": "“Are you insane?” I half shouted at Biff, my college roommate. We had just finished our Operating Systems midterm and were lounging at “The Bomber,” our college pub. Biff suggested we both do our last internship at Microsoft.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/save-the-soup.html",
-      "incoming_links": [],
-      "last_modified": "2020-04-12T19:50:58+00:00",
-      "markdown_path": "_posts/2018-11-04-save-the-soup.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Save the Soup",
-      "url": "/save-the-soup"
-    },
-    "/save-the-souse": {
-      "description": "Internships are best approached as a long-term field trip. You should plan to be exposed to new things, spend some time out of your comfort zone, and, by all means – use the buddy system.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/save-the-souse.html",
-      "incoming_links": [],
-      "last_modified": "2020-04-12T19:50:58+00:00",
-      "markdown_path": "_posts/2018-11-05-save-the-souse.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Save the Souse",
-      "url": "/save-the-souse"
-    },
-    "/screencast": {
-      "description": "Screencasting has become an essential tool for content creators, educators, and professionals alike. In this post, I’ll share my experiences and insights on screencasting on macOS, covering various tools, techniques, and tips I’ve discovered along the way. From recording software to post-production enhancements, this guide aims to help you navigate the world of screencasting on your Mac.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/screencast.html",
-      "incoming_links": [
-        "/content-creation",
-        "/osx"
-      ],
-      "last_modified": "2025-01-04T12:24:44-08:00",
-      "markdown_path": "_td/screencast.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Screencasting on OSX",
-      "url": "/screencast"
-    },
-    "/seattle": {
-      "description": "Seattle is my home, I want to die here, though not soon. If you’re visiting, here’s a list of fun things you can try. But here’s the deal, give me feedback on stuff to add/remove from this list\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/seattle.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/seattle.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Seattle",
-      "url": "/seattle"
-    },
-    "/sell": {
-      "description": "Selling matters - it’s pitching, convincing, negotiating, hiring. Selling has a bad rap, because the seller often puts their needs ahead of the buyer - a win/lose paradigm. You should make selling win/win or no deal by needing to answer yes to these questions. 1/ If the buyer agrees, will their life improve? 2/ When the deal is done, will the world be a better place than when you began?\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/sell.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/2017-2-5-To-Sell-Is-Human.md",
-      "outgoing_links": [
-        "/first-understand",
-        "/negotiate",
-        "/win-win"
-      ],
-      "redirect_url": "",
-      "title": "To Sell Is Human",
-      "url": "/sell"
-    },
-    "/shame": {
-      "description": "Shame and guilt are often confused emotions caused by self judgments that lead to contrasting behaviors. Shame drives people to hide or deny their wrongdoings while guilt, properly applied drives people to the correct behaviors. These are both examples of mental-pain and when the pain is phantom or cronic, are often well served by grandmother mind.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/shame.html",
-      "incoming_links": [
-        "/90days",
-        "/curious",
-        "/depression",
-        "/emotions",
-        "/insecure",
-        "/psychic-weight",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/shame.md",
-      "outgoing_links": [
-        "/curious",
-        "/mental-pain"
-      ],
-      "redirect_url": "",
-      "title": "Shame",
-      "url": "/shame"
-    },
-    "/sharpen-the-saw": {
-      "description": "A young man saw a woodcutter cutting down a tree and asked “What are you doing?” “Are you blind?” the woodcutter replied. “I’m cutting down this tree.” The young man continued. “You look exhausted! Take a break. Sharpen your saw.” The woodcutter explained he’d been sawing for hours and did not have time to take a break. The young man pushed back… “If you sharpen the saw, you would cut down the tree much faster.” The woodcutter said “I don’t have time to sharpen the saw. Don’t you see I’m too busy. These are my insights based on the 7 habits Chapter 7.\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/sharpen-the-saw.html",
-      "incoming_links": [
-        "/7-habits",
-        "/emotional-health",
-        "/physical-health"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/7h-c7.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/d/habits",
-        "/diet",
-        "/emotional-health",
-        "/physical-health",
-        "/siy"
-      ],
-      "redirect_url": "",
-      "title": "Sharpen the saw",
-      "url": "/sharpen-the-saw"
-    },
-    "/sicp": {
-      "description": "LISP, and SICP\n\n",
-      "doc_size": 33000,
-      "file_path": "_site/sicp.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/sicp.md",
-      "outgoing_links": [
-        "/static/roots_of_lisp.pdf"
-      ],
-      "redirect_url": "",
-      "title": "Structure and Design of Computer Programs",
-      "url": "/sicp"
-    },
-    "/siy": {
-      "description": "Training Emotional Intelligence through mindfulness. Search inside yourself is a meditation training manual for engineers. It’s also a pun as the author works at google, and built the program internally at Google. Joy on demand by the same author, is less engineer focused, and uses joy as a path to medatitive bliss.\n\n",
-      "doc_size": 61000,
-      "file_path": "_site/siy.html",
-      "incoming_links": [
-        "/anxiety-management",
-        "/be-proactive",
-        "/books-that-defined-me",
-        "/coaching",
-        "/curious",
-        "/depression",
-        "/emotional-health",
-        "/eulogy",
-        "/first-understand",
-        "/gap-year-igor",
-        "/idle",
-        "/irl",
-        "/mind-monsters",
-        "/operating-manual",
-        "/psychic-weight",
-        "/sharpen-the-saw",
-        "/slow",
-        "/timeoff",
-        "/timeoff-2020-03"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/siy.md",
-      "outgoing_links": [
-        "/be-proactive",
-        "/emotional-health",
-        "/end-in-mind",
-        "/happy",
-        "/ig66/685",
-        "/mind-monsters",
-        "/psychic-shadows",
-        "/sublime",
-        "/what-makes-a-leader"
-      ],
-      "redirect_url": "",
-      "title": "Search inside yourself",
-      "url": "/siy"
-    },
-    "/sleep": {
-      "description": "Bryan Johnson says sleep is like life on easy mode. He has lots to say on this, and it gets technical, and I think I agree:\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/sleep.html",
-      "incoming_links": [
-        "/energy",
-        "/gap-year-igor",
-        "/insomnia",
-        "/physical-health"
-      ],
-      "last_modified": "2025-08-13T07:43:13-07:00",
-      "markdown_path": "_d/sleep.md",
-      "outgoing_links": [
-        "/blueprint",
-        "/insomnia"
-      ],
-      "redirect_url": "",
-      "title": "Keep life on easy mode - Prioritize Sleep",
-      "url": "/sleep"
-    },
-    "/sleeping-bag-sacrifices": {
-      "description": "I started in Windows Azure in 2007. Back then, the name “Azure” wasn’t invented, and Azure was still called “Reddog.” I started on the OS team, drawn in by my dream of changing the world, and getting to be Dave Cutler’s lackey. I didn’t get to work with Cutler, but I still may change the world - now that I’ve learned it’s OK to wake sleeping giants. My giant was named Jay.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/sleeping-bag-sacrifices.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-25T10:46:49-07:00",
-      "markdown_path": "_posts/2018-11-06-sleeping-bag-sacrifices.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Sleeping bag sacrifices",
-      "url": "/sleeping-bag-sacrifices"
-    },
-    "/sleight-of-mouth": {
-      "description": "Language, often unknown to us, creates our mental models, our reality, and defines our meaning. But the model is not the terrain, and by engaging with the language we can change mental models. Sleight of mouth (SoM) is a series of techniques for changing our models, reality and meanings and thus our experiences. Our mental models are a frame, and we need help going from a ‘problem frame’ to a ‘desired outcome frame’ , a ‘failure frame’, to a ‘feedback frame’ and an ‘impossible frame ‘ to an ‘as if’ frame. To experience the power of language, find anything that is invisible to you, and name it. Now as you’ve given it a name, see how you perceive it, and become aware of it.\n\n",
-      "doc_size": 26000,
-      "file_path": "_site/sleight-of-mouth.html",
-      "incoming_links": [
-        "/7h-concepts",
-        "/operating-manual",
-        "/timeoff-2022-02"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/2016-3-12-sleight-of-mouth.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Sleight Of Mouth",
-      "url": "/sleight-of-mouth"
-    },
-    "/slow": {
-      "description": "Fight or flight, the sympathetic nervous system, gets all the attention, but its twin sister “Rest and Digest” or the parasympathetic nervous system is equally important. These are the two divisions of the Autonomic Nervous system — the stuff that operates without conscious control. While everyone’s obsessed with productivity and hustle, your body’s crying out for balance. Here’s the thing: you can’t sprint a marathon, and life’s definitely a marathon.\n\n",
-      "doc_size": 29000,
-      "file_path": "_site/slow.html",
-      "incoming_links": [
-        "/anxiety",
-        "/balance",
-        "/energy",
-        "/mood"
-      ],
-      "last_modified": "2025-08-25T08:36:03-07:00",
-      "markdown_path": "_d/slow.md",
-      "outgoing_links": [
-        "/activation",
-        "/anxiety",
-        "/balance",
-        "/d/habits",
-        "/d/resistance",
-        "/emotions",
-        "/energy",
-        "/produce-consume",
-        "/siy"
-      ],
-      "redirect_url": "",
-      "title": "Rest and Digest - Sometimes you'd rather go slow ",
-      "url": "/slow"
-    },
-    "/smilebox": {
-      "description": "Way back in 2012 I had this idea to make a Smilebox. The tech wasn’t good enough, but in 2023 tech is right ready. Here’s quoting the original blog post … Nothing makes me happier then seeing someone smile. In fact, seeing others smile makes me smile. As a result, I’m creating a box that captures smiles, which I’m calling a smile box. If you look at the smile box, you’ll see the smiles that are already captured . If you smile at the box, it’ll capture your smile and add it to the box.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/smilebox.html",
-      "incoming_links": [
-        "/joy"
-      ],
-      "last_modified": "2023-02-20T13:23:02-08:00",
-      "markdown_path": "_td/smilebox.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Smilebox",
-      "url": "/smilebox"
-    },
-    "/snjb": {
-      "description": "Zach built Steve’s Night Jungle and Bar in twee, here’s our port to python!\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/snjb.html",
-      "incoming_links": [
-        "/timeoff-2021-11"
-      ],
-      "last_modified": "2021-11-25T22:54:03-08:00",
-      "markdown_path": "_d/snjb_.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Welcome to Steve's jungle and bar!",
-      "url": "/snjb"
-    },
-    "/software-leadership-roles": {
-      "description": "The line between a technical lead and architect (and product manager and engineering manager) is fuzzy and subjective. The best articulation of the difference I’ve found is inline from Quora. In this classification I like to run a team small enough that I can be the engineering manager and step in as the software architect as required.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/software-leadership-roles.html",
-      "incoming_links": [
-        "/job",
-        "/manager-book"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_posts/2018-01-14-software-leadership-roles.md",
-      "outgoing_links": [
-        "/manager-book"
-      ],
-      "redirect_url": "",
-      "title": "Tech leads, software architects and engineering managers - oh my!",
-      "url": "/software-leadership-roles"
-    },
-    "/stock-concentration": {
-      "description": "When you work at a tech company and receive RSUs, it’s easy to accidentally become dangerously concentrated in your company’s stock. You didn’t mean to bet your entire future on one company, but here you are - watching every earnings call with your stomach in knots because a 30% drop would devastate your net worth. This guide explains the risks and strategies for managing concentrated stock positions - from tax-efficient selling strategies to protective options that cost you nothing, and exchange funds that diversify without triggering taxes.\n\n",
-      "doc_size": 37000,
-      "file_path": "_site/stock-concentration.html",
-      "incoming_links": [
-        "/gap-year-igor",
-        "/money"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/stock-concentration.md",
-      "outgoing_links": [
-        "/gap-year",
-        "/gap-year-igor",
-        "/money",
-        "/retire"
-      ],
-      "redirect_url": "",
-      "title": "Stock Concentration: How I Learned to Stop Worrying and Love the Capital Gains Tax",
-      "url": "/stock-concentration"
-    },
-    "/strategy": {
-      "description": "As competition in the market intensifies, companies must find ways to differentiate themselves in order to have a successful business - and that means strategic positioning. If they want to get the buyers money they have to choose a strategy that works for them and make sure it has sustainable competitive advantages. From offering a different value, to providing the same value using different activities - the possibilities for positioning are endless. Ultimately, it’s all about creating trade offs and making sure those trade offs give a sustainable competitive advantage!\n\n",
-      "doc_size": 28000,
-      "file_path": "_site/strategy.html",
-      "incoming_links": [
-        "/energy-abundance",
-        "/life-as-business",
-        "/manager-book"
-      ],
-      "last_modified": "2025-02-01T18:47:48-08:00",
-      "markdown_path": "_d/2015-11-18-what-is-strategy.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "On strategy",
-      "url": "/strategy"
-    },
-    "/strengths": {
-      "description": "Developing you strengths is 3 times as effective as improving your weakness, so find your strengths and double down. To bootstrap the discovery of my strengths, I used a tool called StrengthFinder and it discovered my strengths are Activator, Communication, Problem Solving (Resolver in StrengthFinder speak) Adaptability, and Ideation.\n\n",
-      "doc_size": 21000,
-      "file_path": "_site/strengths.html",
-      "incoming_links": [
-        "/operating-manual"
-      ],
-      "last_modified": "2025-08-22T10:48:49-07:00",
-      "markdown_path": "_posts/2018-05-25-strength-finder.md",
-      "outgoing_links": [
-        "/static/StrengthFinderIgor.pdf",
-        "/static/igor-enneagram.pdf"
-      ],
-      "redirect_url": "",
-      "title": "My Strengths from Strength Finder",
-      "url": "/strengths"
-    },
-    "/structure": {
-      "description": "What if structure could be kind? You already know what you want to do. You know exercise is good for you. You know journaling helps. You know you should call your mom more often. The problem isn’t knowing—it’s the gap between intention and action, especially when life gets messy. Most of us recoil from the word “structure” because we’ve only experienced harsh management-style systems that treat humans like machines. But there’s another way: humane structure that works with your nature, not against it. Humane structure starts with a core assumption: You’re not broken, you just need better support. You don’t need more willpower, discipline, or motivation. You need systems that help you remember what you care about and make it easier to act on those values, especially when you’re struggling.\n\n",
-      "doc_size": 30000,
-      "file_path": "_site/structure.html",
-      "incoming_links": [
-        "/gap-year-igor"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/structure.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Humane Structure -  A Gentle Framework for Wild Minds",
-      "url": "/structure"
-    },
-    "/sublime": {
-      "description": "Emotional health is pretty important. Western folks don’t have a lot of words to support this. Luckily, the Buddhists have the sublime states: Loving-kindness, Compassion, Altruistic Joy, and Equanimity. Give ‘em a try. Most of this post is based on “The Joy of Happiness”.\n\n",
-      "doc_size": 19000,
-      "file_path": "_site/sublime.html",
-      "incoming_links": [
-        "/affirmations",
-        "/emotional-health",
-        "/emotions",
-        "/siy",
-        "/timeoff-2024-02"
-      ],
-      "last_modified": "2024-05-22T16:40:30-07:00",
-      "markdown_path": "_d/sublime.md",
-      "outgoing_links": [
-        "/emotional-health",
-        "/joy",
-        "/touching"
-      ],
-      "redirect_url": "",
-      "title": "Training the sublime states",
-      "url": "/sublime"
-    },
-    "/suicide": {
-      "description": "“Igor, what advice would you give a 20-year-old that just found out their dad killed themselves?” Sadly, when I was 20, I got a call from a family friend saying “Igor, you want to sit down, this isn’t going to be fun to hear.” My dad had taken his own life.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/suicide.html",
-      "incoming_links": [],
-      "last_modified": "2024-11-09T06:51:11-08:00",
-      "markdown_path": "_d/suicide.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Brain Attacks: A Better Model for Suicide",
-      "url": "/suicide"
-    },
-    "/sustainable-work": {
-      "description": "I don’t want to die knowing I spent too much time at work and I bet you don’t either. As a result I want to work with people who value a culture encouraging them to balance their family, health, hobbies, and work - aka work-life balance. To make a culture real leaders needs to walk the talk, and I’ll describe how I model a work-life balance, and the mechanisms I use to help team members achieve their own balance.\n\n",
-      "doc_size": 29000,
-      "file_path": "_site/sustainable-work.html",
-      "incoming_links": [
-        "/42",
-        "/balance",
-        "/being-a-great-manager",
-        "/depression",
-        "/gap-year-igor",
-        "/overload",
-        "/regrets",
-        "/retire",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2025-02-15T10:13:03-08:00",
-      "markdown_path": "_posts/2020-01-04-sustainable-work.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "I don't want to die knowing I spent too much time at work, and I bet you don't either",
-      "url": "/sustainable-work"
-    },
-    "/switch": {
-      "description": "Human action can be modeled by an elephant, a rider, and the path. Our emotional side is the Elephant and our rational side is the Rider. Perched atop the Elephant, the Rider holds the reins and seems to be the leader. But the Rider’s control is precarious because the Rider is so small relative to the Elephant. Anytime the six-ton Elephant and the Rider disagree about which direction to go, the Rider is going to lose. He’s completely overmatched. Lastly, the path is the structural elements that nudge your elephant and your rider in a direction, without effort.\n\n",
-      "doc_size": 25000,
-      "file_path": "_site/switch.html",
-      "incoming_links": [
-        "/enable",
-        "/first-things-first",
-        "/negotiate",
-        "/productive",
-        "/random-idea",
-        "/timeoff-2022-02"
-      ],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_d/switch.md",
-      "outgoing_links": [
-        "/coe",
-        "/d/habits"
-      ],
-      "redirect_url": "",
-      "title": "Switch",
-      "url": "/switch"
-    },
-    "/synergize": {
-      "description": "We’ve all got stuff we’re good at, and stuff we’re bad at. We can combine these in ways that make the system greater then the sum of its parts.\n\n",
-      "doc_size": 27000,
-      "file_path": "_site/synergize.html",
-      "incoming_links": [
-        "/7-habits"
-      ],
-      "last_modified": "2025-03-07T11:21:07-08:00",
-      "markdown_path": "_d/7h-c6.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/negotiate",
-        "/win-win"
-      ],
-      "redirect_url": "",
-      "title": "Creating Synergy: Making 1+1 = 3!",
-      "url": "/synergize"
-    },
-    "/system-design": {
-      "description": "As a technologist I love system designs. I like to tell interview candidates you don’t need to practice them, it’s what you do every day. In fact, it’s one of the favorite parts of my technical role. I never liked crossword puzzles, but I could totally do system design problems instead. Here’s a great list ..\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/system-design.html",
-      "incoming_links": [
-        "/job-hunt-stress"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/system-design.md",
-      "outgoing_links": [
-        "/design",
-        "/td/better-security-design",
-        "/td/cloud-first-applications",
-        "/td/data-systems"
-      ],
-      "redirect_url": "",
-      "title": "System Design Questions",
-      "url": "/system-design"
-    },
-    "/taas": {
-      "description": "Transportation as a service is the third transportation revolution. The first revolution was the addition of 20,000 miles of track which led to the emergence of cities. The second revolution was the assembly line which mass produced cars. The third revolution is ride sharing which is a different transport option. The Fourth transportation revolution will be the human to autonomous transition. The fifth revolution will be the redefining of our cities.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/taas.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/2016-09-18-transportation-as-a-service.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Transportation as a Service",
-      "url": "/taas"
-    },
-    "/td/alexa-skill": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/td/alexa-skill.html",
-      "incoming_links": [],
-      "last_modified": "2020-04-11T16:32:11+00:00",
-      "markdown_path": "_td/alexa-skill.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Make an Alexa Skill",
-      "url": "/td/alexa-skill"
-    },
-    "/td/back_ref": {
-      "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/td/back_ref.html",
-      "incoming_links": [],
-      "last_modified": "2022-04-16T15:22:43-07:00",
-      "markdown_path": "_td/back_ref.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Adding back references to my blog",
-      "url": "/td/back_ref"
-    },
-    "/td/better-security-design": {
-      "description": "I used to do security in a former life, and here are some musings on the topic, which will eventually be dissected into various essays. For now it’ll be confusing as I’m brain dumping to various audiences with various knowledge (end users, architects, CEOs, designers)\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/td/better-security-design.html",
-      "incoming_links": [
-        "/system-design"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/better-security-design.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Security Notes",
-      "url": "/td/better-security-design"
-    },
-    "/td/cloud-first-applications": {
-      "description": "The world is now on the cloud, here are my random notes on the topic.\n\n",
-      "doc_size": 25000,
-      "file_path": "_site/td/cloud-first-applications.html",
-      "incoming_links": [
-        "/amazon",
-        "/design",
-        "/manager-book",
-        "/system-design"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/cloud-first-applications.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Cloud First Applications",
-      "url": "/td/cloud-first-applications"
-    },
-    "/td/data-systems": {
-      "description": "This page contains my knowledge of data systems. Mostly just a summary of Designing Data-Intensive Applications: The Big Ideas Behind Reliable, Scalable, and Maintainable Systems\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/td/data-systems.html",
-      "incoming_links": [
-        "/amazon",
-        "/chow",
-        "/system-design"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_td/data-systems.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Data Systems",
-      "url": "/td/data-systems"
-    },
-    "/td/dump_imessage_history": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/td/dump_imessage_history.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/dump_imessage_history.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Accessing iMessage history",
-      "url": "/td/dump_imessage_history"
-    },
-    "/td/fix_ssh": {
-      "description": "For some reason, SSH is just hanging out of no where. To debug on the server, be sure to open your firewall\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/td/fix_ssh.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T10:48:49-07:00",
-      "markdown_path": "_td/fix_ssh.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "SSH Client Commands Timing Out from Some Clients Sometimes",
-      "url": "/td/fix_ssh"
-    },
-    "/td/hack-web": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 29000,
-      "file_path": "_site/td/hack-web.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/hack-web.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Hacking the web for fun and profit",
-      "url": "/td/hack-web"
-    },
-    "/td/ios": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/td/ios.html",
-      "incoming_links": [
-        "/tools",
-        "/writing"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/ios.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "iOS and iPadOS tips",
-      "url": "/td/ios"
-    },
-    "/td/ios-nomad": {
-      "description": "So you want to be an iPad Developer Nomad. A person who can do all their development on the iPad. I’m not sure why you’d want to be such a character, in fact, I’m not sure why I want to be such a character, but I do, and here’s how I do it. To be a developer nomad, you better already be a command line wiz. If you’re not at an expert at the terminal, vim or Emacs and TMUX - don’t even try.\n\n",
-      "doc_size": 25000,
-      "file_path": "_site/td/ios-nomad.html",
-      "incoming_links": [
-        "/tools",
-        "/writing"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/ios-nomad.md",
-      "outgoing_links": [
-        "/irl"
-      ],
-      "redirect_url": "",
-      "title": "iOS Software Engineer Nomad How-To",
-      "url": "/td/ios-nomad"
-    },
-    "/td/linqpad_from_redshift": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/td/linqpad_from_redshift.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T10:48:49-07:00",
-      "markdown_path": "_td/linqpad_from_redshift.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Make LINQPad Work with Redshift",
-      "url": "/td/linqpad_from_redshift"
-    },
-    "/td/minecraft": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/td/minecraft.html",
-      "incoming_links": [],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_td/minecraft.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Minecraft Notes",
-      "url": "/td/minecraft"
-    },
-    "/td/mosh": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/td/mosh.html",
-      "incoming_links": [],
-      "last_modified": "2020-04-11T16:32:11+00:00",
-      "markdown_path": "_td/mosh.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Mosh",
-      "url": "/td/mosh"
-    },
-    "/td/private_web_site": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/td/private_web_site.html",
-      "incoming_links": [],
-      "last_modified": "2020-04-11T16:32:11+00:00",
-      "markdown_path": "_td/private_web_site.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Private Web Site",
-      "url": "/td/private_web_site"
-    },
-    "/td/ring-video-download": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/td/ring-video-download.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/ring-video-download.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Ring Video Doorbell",
-      "url": "/td/ring-video-download"
-    },
-    "/td/slow_zsh": {
-      "description": "All of the sudden, hititng enter in zsh took seconds - took me a while, but I realized if I kiled tmux (not just a window), then it would be fast again (well, that’s better then a reboot I guess. Sigh, this drove me nuts and I just switched to Atuin instead\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/td/slow_zsh.html",
-      "incoming_links": [
-        "/timeoff-2024-08"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/slow_zsh.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Slow ZSH prompts",
-      "url": "/td/slow_zsh"
-    },
-    "/td/sqlalchemy-redshift": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/td/sqlalchemy-redshift.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/sqlalchemy-redshift.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "SQLAlchemy with Redshift",
-      "url": "/td/sqlalchemy-redshift"
-    },
-    "/td/stats": {
-      "description": "Statistics is a tool which lets us summarize data, and make inferences from it.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/td/stats.html",
-      "incoming_links": [],
-      "last_modified": "2024-10-05T21:35:59-07:00",
-      "markdown_path": "_td/stats.md",
-      "outgoing_links": [
-        "/ml"
-      ],
-      "redirect_url": "",
-      "title": "Statistics",
-      "url": "/td/stats"
-    },
-    "/td/streaks": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/td/streaks.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/streaks.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Habit tracking app",
-      "url": "/td/streaks"
-    },
-    "/td/usbtech": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/td/usbtech.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T10:48:49-07:00",
-      "markdown_path": "_td/usbtech.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "USB Tech",
-      "url": "/td/usbtech"
-    },
-    "/td/virtual-desktops": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/td/virtual-desktops.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/virtual-desktops.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Virtual desktops in Wox",
-      "url": "/td/virtual-desktops"
-    },
-    "/td/visual-vocabulary": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/td/visual-vocabulary.html",
-      "incoming_links": [
-        "/viz"
-      ],
-      "last_modified": "2020-04-11T16:32:11+00:00",
-      "markdown_path": "_td/visual-vocabulary.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Visual Thinking Notes",
-      "url": "/td/visual-vocabulary"
-    },
-    "/td/windbg": {
-      "description": "Copied from my GitHub techdiary\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/td/windbg.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T10:48:49-07:00",
-      "markdown_path": "_td/windbg.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "WinDbg Notes",
-      "url": "/td/windbg"
-    },
-    "/tech-health-toys": {
-      "description": "Physical health is the basis of my energy, so it’s a place I’m happy spending money and energy. I’ve been buying lots of technology to help me understand and measure my health and fitness and this post will track my favorite toys.\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/tech-health-toys.html",
-      "incoming_links": [
-        "/d/2016-02-03-positive-computing-survey",
-        "/physical-health"
-      ],
-      "last_modified": "2020-02-15T17:30:47+00:00",
-      "markdown_path": "_posts/2017-10-06-tech-health-toys.md",
-      "outgoing_links": [
-        "/physical-health"
-      ],
-      "redirect_url": "",
-      "title": "Tech for health",
-      "url": "/tech-health-toys"
-    },
-    "/tech-rituals": {
-      "description": "There is so much change in tech it’s important to check in on what has changed to make sure you’re still using the latest. You can do this at an ad-hoc basis, but you’re probably better off having it on a calendar.\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/tech-rituals.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/tech-ritual.md",
-      "outgoing_links": [
-        "/chop"
-      ],
-      "redirect_url": "",
-      "title": "Tech Rituals",
-      "url": "/tech-rituals"
-    },
-    "/terzepatide": {
-      "description": "“You know Igor, weight loss is a solved problem” - my bestie, texted me when I complained about my pants no longer fitting. Remember - Diet dominates weight, as weight is simple arithmetic -“calories in” minus “calories out”. For me, will power dominates diet, and terzepatide dominates will power when stuffing things in my mouth. I started Terzepatide in February 2024, and so far it’s been great.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/terzepatide.html",
-      "incoming_links": [
-        "/42",
-        "/diet",
-        "/eulogy",
-        "/physical-health",
-        "/timeoff",
-        "/timeoff-2024-04",
-        "/voices"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/terzepatide.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Terzepatide: The magic weight loss shot",
-      "url": "/terzepatide"
-    },
-    "/tesla": {
-      "description": "I don’t like to drive. I don’t like to drive so much that I have it in my eulogy. Luckily, Elon Musk made a car that’s optimized for driving you. In August 2023, I treated myself to a Tesla Model Y. It has lots of trade-offs, but the key for me is its Autopilot (e.g., it driving me).\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/tesla.html",
-      "incoming_links": [
-        "/eulogy",
-        "/irl",
-        "/kayak",
-        "/mania",
-        "/operating-manual",
-        "/timeoff-2024-02"
-      ],
-      "last_modified": "2024-11-28T13:20:09-08:00",
-      "markdown_path": "_d/tesla.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Tony (Tessie) the Tesla",
-      "url": "/tesla"
-    },
-    "/test-auto-sunburst": {
-      "description": "This page demonstrates the auto-generated sunburst functionality that extracts the tree structure from H2 and H3 elements.\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/test-auto-sunburst.html",
-      "incoming_links": [],
-      "last_modified": "2025-07-25T07:05:52-07:00",
-      "markdown_path": "_d/test-auto-sunburst.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Test Auto-Generated Sunburst",
-      "url": "/test-auto-sunburst"
-    },
-    "/testing": {
-      "description": "If it’s not tested, it doesn’t work. When your tests passing lets you deploy without any concerns, your tests are good enough. Otherwise, you’ve got more work to do.\n\n",
-      "doc_size": 29000,
-      "file_path": "_site/testing.html",
-      "incoming_links": [
-        "/chop",
-        "/design",
-        "/manager-book"
-      ],
-      "last_modified": "2024-12-31T07:15:11-08:00",
-      "markdown_path": "_td/testing.md",
-      "outgoing_links": [
-        "/ai-testing",
-        "/design"
-      ],
-      "redirect_url": "",
-      "title": "Testing and Quality",
-      "url": "/testing"
-    },
-    "/the-recruiter-does-not-think-you-are-hot": {
-      "description": "I’ve only had one truly unbearable job. It was awful - The code base sucked, the boss had pointed hair, and to top it off I got a terrible review.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/the-recruiter-does-not-think-you-are-hot.html",
-      "incoming_links": [],
-      "last_modified": "2020-04-12T19:50:58+00:00",
-      "markdown_path": "_posts/2020-01-01-the-recruiter-does-not-think-you-are-hot.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "The recruiter does not think you're hot",
-      "url": "/the-recruiter-does-not-think-you-are-hot"
-    },
-    "/time-traveler": {
-      "description": "What would Past Igor say if he met Future Igor? Would he be impressed by the wisdom, disappointed by the waistline, or wonder how we developed such an intense relationship with pastries? While we can’t physically time travel, we can use mental time travel as a powerful tool - imagining conversations across our past, present, and future selves. Think of it as a group chat between Past Igor (that idealistic youngster), Present Igor (hello!), and Future Igor (who’s probably shaking his head at both of us). Let’s explore how these three versions of ourselves are constantly chatting, arguing, and occasionally giving each other virtual fist bumps across the space-time continuum.\n\n\n\n",
-      "doc_size": 16000,
-      "file_path": "_site/time-traveler.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-24T09:03:19-07:00",
-      "markdown_path": "_d/time-traveler.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "When Past Igor Meets Future Igor",
-      "url": "/time-traveler"
-    },
-    "/timeoff": {
-      "description": "Time off is critical, it’s how we renew our energy, find our creativity, etc. Many people think of time off as synonymous with turning your 1 week off into an action-packed tour of Disneyland. But, there are other kinds of time off that we’ll discuss too. Like most things, time off is a skill that can be improved by studying and applying your learnings. This post includes mine - note to self - read them!!\n\n",
-      "doc_size": 37000,
-      "file_path": "_site/timeoff.html",
-      "incoming_links": [
-        "/balance",
-        "/energy",
-        "/energy-abundance",
-        "/gap-year",
-        "/gap-year-igor",
-        "/life-as-business",
-        "/mind-at-work",
-        "/parkinson",
-        "/timeoff-2020-03",
-        "/timeoff-2020-12",
-        "/timeoff-2021-11",
-        "/timeoff-2021-12",
-        "/timeoff-2022-02",
-        "/timeoff-2022-07",
-        "/timeoff-2022-11",
-        "/timeoff-2022-12",
-        "/timeoff-2023-04",
-        "/timeoff-2023-08",
-        "/timeoff-2023-11",
-        "/timeoff-2024-08",
-        "/timeoff-2025-08"
-      ],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time_off.md",
-      "outgoing_links": [
-        "/addiction",
-        "/balloon",
-        "/d/resistance",
-        "/diet",
-        "/energy",
-        "/essentialism",
-        "/eulogy",
-        "/frog",
-        "/happy",
-        "/kettlebell",
-        "/magic",
-        "/mind-at-work",
-        "/parkinson",
-        "/siy",
-        "/terzepatide",
-        "/timeoff-2020-03",
-        "/timeoff-2024-02"
-      ],
-      "redirect_url": "",
-      "title": "Getting the most out of time off",
-      "url": "/timeoff"
-    },
-    "/timeoff-2020-03": {
-      "description": "In March 2020, I took a 2 month sabatical between leaving Amazon and joining Facebook. Given it was a substantial amount of time, I came up with some big plans, and wrote them down. It was a great plan, BUT my time off correlated perfectly to the Corona Virus and as a result I wasted lots of my mental energy thinking about the Corona Virus, and adjusting to being in pseudo-quarantine. Took me a while, but I finally realized I should ignore corona virus, or at least minimize my time thinking about it.\n\n",
-      "doc_size": 30000,
-      "file_path": "_site/timeoff-2020-03.html",
-      "incoming_links": [
-        "/timeoff"
-      ],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2020-03.md",
-      "outgoing_links": [
-        "/frog",
-        "/money",
-        "/siy",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Adventures March and April 2020",
-      "url": "/timeoff-2020-03"
-    },
-    "/timeoff-2020-12": {
-      "description": "It’s Corona virus X-mas, and I’ve got 2 weeks off. In an attempt to maximize my personal development and satisfaction during my timeoff, by staying balanced, and minimizing my vegetation I’m going to pre-write what I want to get done, and adjust it as I go.\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/timeoff-2020-12.html",
-      "incoming_links": [
-        "/timeoff-2021-12"
-      ],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2020-12.md",
-      "outgoing_links": [
-        "/7-habits",
-        "/happy",
-        "/mental-pain",
-        "/pandas",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Time off X-mas 2020",
-      "url": "/timeoff-2020-12"
-    },
-    "/timeoff-2021-11": {
-      "description": "I should have written up a plan before this time off so I’d have been more deliberate. As it stands, I did what I wanted, got a tonne done, but missed some things that bring me a lot of energy.\n\n",
-      "doc_size": 19000,
-      "file_path": "_site/timeoff-2021-11.html",
-      "incoming_links": [
-        "/timeoff-2021-12"
-      ],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2021-11.md",
-      "outgoing_links": [
-        "/adblocker-trojan",
-        "/brython",
-        "/ig66/591",
-        "/snjb",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Time off Turkey Day 2021",
-      "url": "/timeoff-2021-11"
-    },
-    "/timeoff-2021-12": {
-      "description": "It’s Corona virus X-mas 2021, the not so bad edition, and I’ve got 2 weeks off. In an attempt to maximize my personal development and satisfaction during my time off, by staying balanced, and minimizing my vegetation I’m going to pre-write what I want to get done, and adjust it as I go.\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/timeoff-2021-12.html",
-      "incoming_links": [
-        "/timeoff-2022-12"
-      ],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2021-12.md",
-      "outgoing_links": [
-        "/activation",
-        "/balance",
-        "/happy",
-        "/timeoff",
-        "/timeoff-2020-12",
-        "/timeoff-2021-11"
-      ],
-      "redirect_url": "",
-      "title": "Time off X-mas 2021",
-      "url": "/timeoff-2021-12"
-    },
-    "/timeoff-2022-02": {
-      "description": "It’mid winter break and I’ve got a week off. In an attempt to maximize my personal development and satisfaction during my time off, by staying balanced, and minimizing my vegetation I’m going to pre-write what I want to get done, and adjust it as I go.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/timeoff-2022-02.html",
-      "incoming_links": [],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2022-02.md",
-      "outgoing_links": [
-        "/happy",
-        "/productive",
-        "/sleight-of-mouth",
-        "/switch",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Time off Mid winter break 2022",
-      "url": "/timeoff-2022-02"
-    },
-    "/timeoff-2022-07": {
-      "description": "It’s FISM (olympics of magic), and I’m going to Quebec city to reenergize my love of magic, since I’m already in Canada I’ll also spend time with My Mom, Sister, and college room mate.\n\n",
-      "doc_size": 27000,
-      "file_path": "_site/timeoff-2022-07.html",
-      "incoming_links": [
-        "/operating-manual"
-      ],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2022-07.md",
-      "outgoing_links": [
-        "/essentialism",
-        "/happy",
-        "/recommend",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Time off July 2022 - FISM and Canada.",
-      "url": "/timeoff-2022-07"
-    },
-    "/timeoff-2022-11": {
-      "description": "It’s just about thanksgiving 2022, and after 2 years of not being able to go to Oregon, we’re on our away! Through unexpected timing, before going to Oregon, I’m going to New York City with Ammon, and through even more unexpected timing, we just had lay offs at work, and have a major re-organization. Instead of being able to fully take the time off, I’ll be working several days, so having clarity on my priorities is critical.\n\n",
-      "doc_size": 26000,
-      "file_path": "_site/timeoff-2022-11.html",
-      "incoming_links": [],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2022-11.md",
-      "outgoing_links": [
-        "/happy",
-        "/mind-at-work",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Time off November 2022 - New York with Ammon, and Then Maureen and Brian for Thanksgiving",
-      "url": "/timeoff-2022-11"
-    },
-    "/timeoff-2022-12": {
-      "description": "It’s X-mas 2022, quite the fall excitement edition! and I’ve got 1 and change weeks off in an attempt to maximize my personal development and satisfaction during my time off, by staying balanced, and minimizing my vegetation. I’m going to pre-write what I want to get done, and adjust it as I go.\n\n",
-      "doc_size": 24000,
-      "file_path": "_site/timeoff-2022-12.html",
-      "incoming_links": [],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2022-12.md",
-      "outgoing_links": [
-        "/happy",
-        "/moments",
-        "/timeoff",
-        "/timeoff-2021-12"
-      ],
-      "redirect_url": "",
-      "title": "Time off X-mas 2022",
-      "url": "/timeoff-2022-12"
-    },
-    "/timeoff-2023-04": {
-      "description": "It’s spring break 2023! The kids and I are going to Canada to see Baba, Yelena, Justin, Sam and Baltasar and Rada’s Family. Unfortunately Tori can’t come as she’s critical to her play opening and it’ll be opening that week.\n\n",
-      "doc_size": 19000,
-      "file_path": "_site/timeoff-2023-04.html",
-      "incoming_links": [],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2023-04.md",
-      "outgoing_links": [
-        "/happy",
-        "/moments",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Time off April Break 2023",
-      "url": "/timeoff-2023-04"
-    },
-    "/timeoff-2023-08": {
-      "description": "It’s summer break 2023! It’s late August and our last chance to get a vacation before the kids go back to school. We were going to go to Chilliwack to try a deli run by a small jewish cult, but alas it’s like 100 degrees so we’re going to to coast instead!\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/timeoff-2023-08.html",
-      "incoming_links": [],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2023-08.md",
-      "outgoing_links": [
-        "/happy",
-        "/moments",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Time off August 2023",
-      "url": "/timeoff-2023-08"
-    },
-    "/timeoff-2023-11": {
-      "description": "It’s time for our annual thanksgiving 2023 trip to Oregon!\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/timeoff-2023-11.html",
-      "incoming_links": [],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2023-11.md",
-      "outgoing_links": [
-        "/happy",
-        "/moments",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Ashland T-Day 2023",
-      "url": "/timeoff-2023-11"
-    },
-    "/timeoff-2024-02": {
-      "description": "It’s midwinter break and I’ve got a week off. Most of these I try to do as a big family adventure. Finding something everyone wants to do is super challenging, so this time we tried something new, divide and conquer: I had a 1-2 day mini-vacations with Amelia, Zach, and even Tori. It worked out very well, the time-off was packed, Stanley Park with Amelia, Yellow Deli with Zach, and a crazy hotel on the Peninsula with Tori. On top of that restarting magic, balloons, and kettlebells and meditation in between.\n\n",
-      "doc_size": 23000,
-      "file_path": "_site/timeoff-2024-02.html",
-      "incoming_links": [
-        "/bc",
-        "/timeoff"
-      ],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2024-02.md",
-      "outgoing_links": [
-        "/blueprint",
-        "/ig66/717",
-        "/sublime",
-        "/tesla"
-      ],
-      "redirect_url": "",
-      "title": "Time off Midwinter break 2024 - Divide and conquer",
-      "url": "/timeoff-2024-02"
-    },
-    "/timeoff-2024-04": {
-      "description": "It’s spring break 2024 and I’ve got a week off. The last few weeks have been a bit crazy at work trying to get some big features launched and into public testing, so very excited for the time off. I usually try to avoid too much tech, but I’m looking forward to making some tech investments as it’s been a while.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/timeoff-2024-04.html",
-      "incoming_links": [],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2024-04.md",
-      "outgoing_links": [
-        "/ai-testing",
-        "/terzepatide"
-      ],
-      "redirect_url": "",
-      "title": "Time off Spring break 2024 - Chillin",
-      "url": "/timeoff-2024-04"
-    },
-    "/timeoff-2024-08": {
-      "description": "I’m incredibly fortunate to be able to take 6 weeks off this summer! From when performance reviews finish to when the kids go back to school, it’ll be summer vacation.\n\n",
-      "doc_size": 28000,
-      "file_path": "_site/timeoff-2024-08.html",
-      "incoming_links": [
-        "/y24"
-      ],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2024-08.md",
-      "outgoing_links": [
-        "/happy",
-        "/moments",
-        "/mood",
-        "/td/slow_zsh",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Time off August 2024",
-      "url": "/timeoff-2024-08"
-    },
-    "/timeoff-2025-08": {
-      "description": "I’m incredibly fortunate to be able to take 6 weeks off this summer! After 5 years of service at Meta, you get 30 days (about 5 week) off!\n\n",
-      "doc_size": 34000,
-      "file_path": "_site/timeoff-2025-08.html",
-      "incoming_links": [],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/time-off-2025-08.md",
-      "outgoing_links": [
-        "/gap-year-igor",
-        "/happy",
-        "/moments",
-        "/mood",
-        "/terzepatie",
-        "/timeoff"
-      ],
-      "redirect_url": "",
-      "title": "Time off August 2025 - Meta Recharge",
-      "url": "/timeoff-2025-08"
-    },
-    "/todo_enjoy": {
-      "description": "It’s easy to forget the many, often tiny things that makes me happy. For when that happens, here’s some reminders:\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/todo_enjoy.html",
-      "incoming_links": [
-        "/operating-manual",
-        "/psychic-shadows"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/enjoy2.md",
-      "outgoing_links": [
-        "/eulogy"
-      ],
-      "redirect_url": "",
-      "title": "Things I enjoy",
-      "url": "/todo_enjoy"
-    },
-    "/tools": {
-      "description": "A collection of tips, tricks and pointers of the various tools i use\n\n",
-      "doc_size": 51000,
-      "file_path": "_site/tools.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_td/tool.md",
-      "outgoing_links": [
-        "/nlp",
-        "/osx",
-        "/td/ios",
-        "/td/ios-nomad"
-      ],
-      "redirect_url": "",
-      "title": "Igor's Tech, Tricks, and Tools",
-      "url": "/tools"
-    },
-    "/tori": {
-      "description": "\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/tori.html",
-      "incoming_links": [
-        "/eulogy",
-        "/gap-year-igor"
-      ],
-      "last_modified": "2025-08-19T10:23:51-07:00",
-      "markdown_path": "_d/tori.md",
-      "outgoing_links": [
-        "/partner-trouble"
-      ],
-      "redirect_url": "",
-      "title": "Tori",
-      "url": "/tori"
-    },
-    "/touching": {
-      "description": "It’s pretty easy to be overwhelmed by humanity sucking, but there is so much good in the world. Here are some great examples\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/touching.html",
-      "incoming_links": [
-        "/class-act",
-        "/end-in-mind",
-        "/joy",
-        "/sublime"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/touching2.md",
-      "outgoing_links": [
-        "/anxiety",
-        "/magic"
-      ],
-      "redirect_url": "",
-      "title": "Things that make me cry",
-      "url": "/touching"
-    },
-    "/toysfortots": {
-      "description": "One of the most satisfying (and fun) projects I worked on in my career was giving Alexa customers the ability to donate to charity and then have Amazon match their donations. What is most amazing about this project is we were able to go from zero to announcing our MVP live on Good Morning America in under 4 months which included all sorts of complexities, negotiations, and good luck.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/toysfortots.html",
-      "incoming_links": [
-        "/amazon",
-        "/eulogy"
-      ],
-      "last_modified": "2025-07-20T19:13:52-07:00",
-      "markdown_path": "_d/alexa-charity.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Donating to charity",
-      "url": "/toysfortots"
-    },
-    "/tribe": {
-      "description": "Finding your tribe is important - calling it a tribe makes it sound like I’m a contributing member of the community, perhaps this is more like things I’m a fanboy of.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/tribe.html",
-      "incoming_links": [],
-      "last_modified": "2024-11-10T16:13:17-08:00",
-      "markdown_path": "_d/tribe.md",
-      "outgoing_links": [
-        "/manager-book"
-      ],
-      "redirect_url": "",
-      "title": "My Tribe",
-      "url": "/tribe"
-    },
-    "/untangled": {
-      "description": "Parenting a teenage girl is like mastering the Turkish Get-Up – one of the most technically challenging kettlebell movements that requires patience, balance, and careful progression through distinct phases. Just when you think you’ve got one position figured out, it’s time to transition to the next, all while maintaining your stability and form (and not dropping a heavy weight on your head!). Lisa Damour’s “Untangled” is like having a master coach by your side, breaking down these intricate transitions into seven fundamental movements that take your daughter from childhood to adulthood.\n\n",
-      "doc_size": 67000,
-      "file_path": "_site/untangled.html",
-      "incoming_links": [],
-      "last_modified": "2025-02-02T09:46:23-08:00",
-      "markdown_path": "_d/untangled.md",
-      "outgoing_links": [
-        "/kettlebell"
-      ],
-      "redirect_url": "",
-      "title": "Untangled: Guiding Teenage Girls Through the Seven Transitions into Adulthood",
-      "url": "/untangled"
-    },
-    "/upstream": {
-      "description": "Imagine sitting enjoying a picnic with a friend at the side of a river. Suddenly you see a kid drowning, you and your friend dive in and save him. A few minutes later the same thing happens. When the third kid comes down river, your friend runs away. You scream at him - why the hell aren’t you helping. He replies, I’m running upstream to stop the bastard who’s throwing kids into the river. Upstream is the idea of solving problems before they start. It’s the basis of habit 3, First Things First, where we tackle the important not urgent.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/upstream.html",
-      "incoming_links": [
-        "/first-things-first"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/upstream.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Upstream - How to solve problems before they happen",
-      "url": "/upstream"
-    },
-    "/vibe": {
-      "description": "Vibe coding is the name for letting the ai write your code. The magic lies in AI’s ability to infer intent from vague input—say almost nothing, and it often gives you something surprisingly right. This works because you’re granting it wide degrees of freedom; as long as you’re flexible on the outcome, the model can generate plausible results from minimal cues. But that magic is fragile: on follow-up turns, or when you have a much tighter definition of correct, the inferred intent often changes, and the model applies a different set of constraints then you wanted or what it did previously, causing a cliff, or misery. Turns out this is the same as junior developers.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/vibe.html",
-      "incoming_links": [
-        "/ai",
-        "/chop"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/vibe.md",
-      "outgoing_links": [
-        "/chop"
-      ],
-      "redirect_url": "",
-      "title": "Vibe Coding: Best Practices for Flow, Fun, and Results",
-      "url": "/vibe"
-    },
-    "/vim": {
-      "description": "I used Vim for years, but have now transitioned to Neovim. While most of these tips work in both editors, some are Neovim-specific. Here’s my collection of tips I want to practice and remember.\n\n",
-      "doc_size": 13000,
-      "file_path": "_site/vim.html",
-      "incoming_links": [
-        "/enable"
-      ],
-      "last_modified": "2025-02-08T12:16:42-08:00",
-      "markdown_path": "_d/vim_tips.md",
-      "outgoing_links": [
-        "/neovim"
-      ],
-      "redirect_url": "",
-      "title": "Igors Vim Tips",
-      "url": "/vim"
-    },
-    "/vim-for-writing": {
-      "description": "VIM is great at lots of things, but free form writing has a few gaps in ‘line wrapping’ and ‘distraction free visual beauty’. These gaps can be closed with the plugins Pencil, Goyo and LimeLight.\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/vim-for-writing.html",
-      "incoming_links": [
-        "/enable",
-        "/writing"
-      ],
-      "last_modified": "2025-02-08T12:16:42-08:00",
-      "markdown_path": "_posts/2016-5-1-vim-for-writing.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Vim For Writing",
-      "url": "/vim-for-writing"
-    },
-    "/viz": {
-      "description": "Good visualizations transform data into insights and stories into understanding. They serve as a universal language that can communicate complex ideas quickly and clearly. Whether you’re creating diagrams for technical documentation or charts for business presentations, the key is matching your visual vocabulary to your message.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/viz.html",
-      "incoming_links": [
-        "/writing"
-      ],
-      "last_modified": "2025-07-20T19:13:52-07:00",
-      "markdown_path": "_d/viz.md",
-      "outgoing_links": [
-        "/td/visual-vocabulary"
-      ],
-      "redirect_url": "",
-      "title": "Data Visualizations and Visual Storytelling",
-      "url": "/viz"
-    },
-    "/vlc": {
-      "description": "IINA Player Keyboard Shortcuts\n\n",
-      "doc_size": 17000,
-      "file_path": "_site/vlc.html",
-      "incoming_links": [],
-      "last_modified": "2025-06-07T09:22:10-07:00",
-      "markdown_path": "_d/vlc_player.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "IINA Player Keyboard Shortcuts",
-      "url": "/vlc"
-    },
-    "/voices": {
-      "description": "The person that most frequently blocks your success is, wait for it, you! Often it’s your subconscious, and often your subconscious is a bunch of independent voices. It’s hard to deal with this hidden opposition because it’s so opaque. To help understand your feelings, you can name the voices in your head, and imagine asking each of them their positions and desired outcomes.\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/voices.html",
-      "incoming_links": [
-        "/anxiety",
-        "/blueprint",
-        "/depression",
-        "/emotional-health",
-        "/mind-monsters",
-        "/operating-manual"
-      ],
-      "last_modified": "2024-04-14T19:24:46-07:00",
-      "markdown_path": "_posts/2017-01-01-voices-in-my-head.md",
-      "outgoing_links": [
-        "/anxiety",
-        "/curious",
-        "/terzepatide",
-        "/win-win"
-      ],
-      "redirect_url": "",
-      "title": "Voices in my head - A survey of my personalities",
-      "url": "/voices"
-    },
-    "/warm": {
-      "description": "Staying warm is important, here’s the gear I use on and off the bike\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/warm.html",
-      "incoming_links": [
-        "/bike"
-      ],
-      "last_modified": "2023-02-17T15:52:23+00:00",
-      "markdown_path": "_posts/2017-9-29-staying-warm-and-biking.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Staying warm",
-      "url": "/warm"
-    },
-    "/weeks": {
-      "description": "\n\n",
-      "doc_size": 4314000,
-      "file_path": "_site/weeks.html",
-      "incoming_links": [
-        "/balance"
-      ],
-      "last_modified": "2024-04-09T09:09:21-07:00",
-      "markdown_path": "_d/weeks.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Life in Weeks",
-      "url": "/weeks"
-    },
-    "/welcome-to-holland": {
-      "description": "“Welcome to Holland” articulates expectation, blame, and acceptance in a heart warming easy to read story.\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/welcome-to-holland.html",
-      "incoming_links": [
-        "/getting-to-yes-with-yourself"
-      ],
-      "last_modified": "2018-12-25T15:32:00-08:00",
-      "markdown_path": "_posts/2015-12-26-welcome-to-holland.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Welcome to Holland",
-      "url": "/welcome-to-holland"
-    },
-    "/what-makes-a-leader": {
-      "description": "Emotional intelligence (EI) is the crux of leadership. EI is comprised of Self-Awareness, Self-Regulation, Motivation, Empathy and Social Skills. This is a summary of Dan Goleman’s What makes a leader. Before we begin, here’s a consulting 2x2 grid:\n\n",
-      "doc_size": 15000,
-      "file_path": "_site/what-makes-a-leader.html",
-      "incoming_links": [
-        "/manager-book",
-        "/siy"
-      ],
-      "last_modified": "2025-07-12T16:50:19-07:00",
-      "markdown_path": "_posts/2018-11-25-what-makes-a-leader-great.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "What makes a leader",
-      "url": "/what-makes-a-leader"
-    },
-    "/why-is-no-one-referring": {
-      "description": "Your customers don’t provide referrals because it’s a risk to their credibility. Remove the credibility risk, and your referrals will follow.\n\n",
-      "doc_size": 14000,
-      "file_path": "_site/why-is-no-one-referring.html",
-      "incoming_links": [],
-      "last_modified": "2025-08-22T10:48:49-07:00",
-      "markdown_path": "_posts/2015-3-13-why-is-no-one-referring.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "Why Is No One Referring My Project",
-      "url": "/why-is-no-one-referring"
-    },
-    "/win-win": {
-      "description": "Win/Win is a constantly seeking mutual benefit in all interactions. Win/Win means that agreements or solutions are mutually beneficial, mutually satisfying. With a Win/Win solution, all parties feel good about the decision and feel committed to the action plan. Win/Win sees life as a cooperative, not a competitive arena. Most people tend to think in terms of dichotomies: strong or weak, hardball or softball, win or lose. But that kind of thinking is fundamentally flawed. It’s based on power and position rather than on principle. Win/Win is based on the paradigm that there is plenty for everybody, that one person’s success is not achieved at the expense or exclusion of the success of others.\n\n",
-      "doc_size": 20000,
-      "file_path": "_site/win-win.html",
-      "incoming_links": [
-        "/7-habits",
-        "/curious",
-        "/negotiate",
-        "/sell",
-        "/synergize",
-        "/voices",
-        "/work-satisfaction"
-      ],
-      "last_modified": "2024-10-05T21:24:07-07:00",
-      "markdown_path": "_d/7h-c4.md",
-      "outgoing_links": [
-        "/7-habits"
-      ],
-      "redirect_url": "",
-      "title": "Win/win or no deal",
-      "url": "/win-win"
-    },
-    "/work-satisfaction": {
-      "description": "Love your work, and you’ll never work a day in your life. Sounds great, but work ain’t no Caribbean cruise - one you pay for, and the other pays you. Work should be satisfying (SAT). You should be enjoying solving hard problems, getting opportunities to talk with like-minded people, and even being forced to stretch and grow. Work should also cause you dissatisfaction (DSAT). Some days your boss will piss you off, your co-workers will misunderstand you, and you will be forced to do something you don’t want to. Satisfaction is not a lack of dissatisfaction; they are orthogonal experiences. DSAT is what makes you sleep poorly, and SAT is what makes you set your alarm early Monday morning so you can get back to your favorite project, and to hang out with your awesome team.  By understanding our SAT and DSAT, we can change them, and transform hours slogging into time at the fantasy cruise bar.\n\n",
-      "doc_size": 27000,
-      "file_path": "_site/work-satisfaction.html",
-      "incoming_links": [
-        "/manager-book",
-        "/mind-at-work",
-        "/retire"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/sat_dsat.md",
-      "outgoing_links": [
-        "/comp",
-        "/decisive",
-        "/dip",
-        "/eulogy",
-        "/first-understand",
-        "/insecure",
-        "/job-hunt-stress",
-        "/manager-book",
-        "/mental-pain",
-        "/mind-at-work",
-        "/negotiate",
-        "/overload",
-        "/shame",
-        "/sustainable-work",
-        "/win-win"
-      ],
-      "redirect_url": "",
-      "title": "Satisfaction is not the lack of dissatisfaction",
-      "url": "/work-satisfaction"
-    },
-    "/write-book": {
-      "description": "My notes on writing books, mostly from Write Useful Books\n\n",
-      "doc_size": 18000,
-      "file_path": "_site/write-book.html",
-      "incoming_links": [
-        "/y24"
-      ],
-      "last_modified": "2025-07-20T19:26:41-07:00",
-      "markdown_path": "_d/book-writing.md",
-      "outgoing_links": [],
-      "redirect_url": "",
-      "title": "How to write a book",
-      "url": "/write-book"
-    },
-    "/writing": {
-      "description": "Useful writing tells people (including, possibly most importantly you) something true and important that they didn’t already know in a way that leaves no doubt. Most writing is bad. Not due to spelling, punctuation or grammar, but due to lack of critical thinking. Critical thinking like analysis, synthesis, simplification, and presentation. To quote someone smart “If you’re thinking without writing, you’re only thinking about thinking”.\n\n",
-      "doc_size": 40000,
-      "file_path": "_site/writing.html",
-      "incoming_links": [
-        "/90days",
-        "/affirmations",
-        "/amazon",
-        "/chow",
-        "/enable",
-        "/manager-book",
-        "/manager-book-appendix",
-        "/operating-manual"
-      ],
-      "last_modified": "2025-08-22T11:54:12-07:00",
-      "markdown_path": "_d/writing.md",
-      "outgoing_links": [
-        "/7h-concepts",
-        "/90days",
-        "/amazon",
-        "/coaching",
-        "/coe",
-        "/enable",
-        "/td/ios",
-        "/td/ios-nomad",
-        "/vim-for-writing",
-        "/viz"
-      ],
-      "redirect_url": "",
-      "title": "Writing is Thinking",
-      "url": "/writing"
-    },
-    "/y24": {
-      "description": "I like to begin in mind, so let’s write a report for 2024. This hasn’t happened, but if I don’t write it out and focus on it, it certainly won’t.\n\n",
-      "doc_size": 25000,
-      "file_path": "_site/y24.html",
-      "incoming_links": [
-        "/gap-year",
-        "/gap-year-igor"
-      ],
-      "last_modified": "2025-09-13T12:56:01-07:00",
-      "markdown_path": "_d/y2024.md",
-      "outgoing_links": [
-        "/42",
-        "/ai-bestie",
-        "/chop",
-        "/kettlebell",
-        "/last-year",
-        "/manager-book",
-        "/mental-pain",
-        "/process-journal",
-        "/timeoff-2024-08",
-        "/write-book"
-      ],
-      "redirect_url": "",
-      "title": "Igor's plan for 2024",
-      "url": "/y24"
-    },
-    "/y25": {
-      "description": "I like to begin in mind, so let’s write a report for 2025. This hasn’t happened, but if I don’t write it out and focus on it, it certainly won’t.\n\n",
-      "doc_size": 19000,
-      "file_path": "_site/y25.html",
-      "incoming_links": [
-        "/gap-year",
-        "/gap-year-igor"
-      ],
-      "last_modified": "2025-06-19T08:16:44-07:00",
-      "markdown_path": "_d/y2025.md",
-      "outgoing_links": [
-        "/42",
-        "/chapters",
-        "/chop",
-        "/content-creation",
-        "/last-year",
-        "/manager-book",
-        "/process-journal"
-      ],
-      "redirect_url": "",
-      "title": "Igor's plan for 2025",
-      "url": "/y25"
+    "redirects": {
+        "/2024": "/y24",
+        "/2025": "/y25",
+        "/24": "/y24",
+        "/25": "/y25",
+        "/48-laws": "/laws-of-power",
+        "/50yo": "/40yo",
+        "/7h": "/7-habits",
+        "/7h-c0": "/7h-concepts",
+        "/7h-c1": "/be-proactive",
+        "/7h-c2": "/end-in-mind",
+        "/7h-c3": "/first-things-first",
+        "/7h-c4": "/win-win",
+        "/7h-c5": "/first-understand",
+        "/7h-c6": "/synergize",
+        "/7h-c7": "/sharpen-the-saw",
+        "/7habits": "/7-habits",
+        "/90": "/90days",
+        "/90-days": "/90days",
+        "/Business-Model-You": "/bmy",
+        "/Coaching-Questions": "/coaching",
+        "/Human-Meetings": "/human-meetings",
+        "/aGPT": "/ai-bestie",
+        "/activation-energy": "/activation",
+        "/addictions": "/addiction",
+        "/affirm": "/affirmations",
+        "/ai-coder": "/chop",
+        "/ai-papers": "/ai-paper",
+        "/ai-talk": "/genai-talk",
+        "/ai-training": "/ai-training",
+        "/alexa-charity": "/toysfortots",
+        "/anxious": "/anxiety",
+        "/architecture": "/design",
+        "/atomic-habits": "/d/habits",
+        "/augmentedreality": "/ar",
+        "/ballooning": "/balloon",
+        "/bbb": "/build-bubble-bike",
+        "/begin-with-the-end-in-mind": "/end-in-mind",
+        "/bells": "/kettlebell",
+        "/bespoke-everything": "/hyper-personal",
+        "/bestiegpt": "/ai-bestie",
+        "/bikes": "/bike",
+        "/biking": "/bike",
+        "/bmu": "/bmy",
+        "/book-writing": "/write-book",
+        "/books": "/books-that-defined-me",
+        "/boss": "/being-a-great-manager",
+        "/brain-attack": "/suicide",
+        "/brainattack": "/suicide",
+        "/breathe": "/breath",
+        "/breathing": "/breath",
+        "/bryan-johnson": "/blueprint",
+        "/care": "/caring",
+        "/centenarian": "/last-year",
+        "/chilliwack": "/bc",
+        "/classact": "/class-act",
+        "/coach": "/coaching",
+        "/cocaine": "/mania",
+        "/cold": "/warm",
+        "/compassion": "/curious",
+        "/compensation": "/comp",
+        "/concentration-risk": "/stock-concentration",
+        "/corona": "/covid",
+        "/correct-of-errors": "/coe",
+        "/couple-double-trouble": "/partner-trouble",
+        "/couples": "/partner-trouble",
+        "/covid19": "/covid",
+        "/create-consume": "/produce-consume",
+        "/creator": "/produce-consume",
+        "/cry": "/touching",
+        "/cv": "/covid",
+        "/d/2015-11-18-Outsourcing": "/outsourcing",
+        "/data-viz": "/viz",
+        "/dealjoy": "/joy",
+        "/decide": "/decisive",
+        "/decision": "/decisive",
+        "/delegation": "/delegate",
+        "/diagrams": "/viz",
+        "/don-juan": "/enemy",
+        "/double-trouble": "/partner-trouble",
+        "/dream-job": "/job",
+        "/dsat": "/work-satisfaction",
+        "/duck-pride": "/pride",
+        "/eat-that-frog": "/frog",
+        "/effectiveness": "/balance",
+        "/emotional-health-practices": "/emotional-health",
+        "/emotional-states": "/emotions",
+        "/enabling-environment": "/enable",
+        "/enemies": "/enemy",
+        "/enjoy": "/happy",
+        "/essential": "/essentialism",
+        "/exercise": "/physical-health",
+        "/failure": "/fail",
+        "/fatality": "/death",
+        "/feeling-meetings": "/human-meetings",
+        "/feelings": "/emotions",
+        "/first-thing-first": "/first-things-first",
+        "/first90days": "/90days",
+        "/forty-two": "/42",
+        "/fortytwo": "/42",
+        "/frugality": "/parkinson",
+        "/frustration": "/anger",
+        "/fuck-shame": "/shame",
+        "/future-igor": "/time-traveler",
+        "/future-self": "/time-traveler",
+        "/genai-intern": "/genai-talk",
+        "/getting-things-done": "/gtd",
+        "/getting-to-yes": "/negotiate",
+        "/goal": "/goals",
+        "/gopher": "/delegate",
+        "/grandma": "/curious",
+        "/grandmother": "/curious",
+        "/grandmother-mind": "/curious",
+        "/grandmothermind": "/curious",
+        "/gty": "/negotiate",
+        "/guilt": "/shame",
+        "/habit": "/d/habits",
+        "/habits": "/d/habits",
+        "/happiness": "/happy",
+        "/healthspan": "/last-year",
+        "/heap - potporri - potpori": "/random-idea",
+        "/heavy-club": "/kettlebell",
+        "/heavy-clubs": "/kettlebell",
+        "/high-energy": "/energy-abundance",
+        "/humanity": "/touching",
+        "/hyper-personalization": "/hyper-personal",
+        "/idle-loop": "/idle",
+        "/iina": "/vlc",
+        "/imposter": "/insecure",
+        "/in-real-life": "/irl",
+        "/insecurity": "/insecure",
+        "/intern-llm": "/genai-talk",
+        "/jupyter": "/pandas",
+        "/kb": "/kettlebell",
+        "/kettlebells": "/kettlebell",
+        "/life-chapters": "/chapters",
+        "/life-stages": "/chapters",
+        "/lisp": "/sicp",
+        "/llm-intern": "/genai-talk",
+        "/llm-security": "/ai-security",
+        "/llm-talk": "/genai-talk",
+        "/llm-training": "/ai-training",
+        "/loneliness": "/lonely",
+        "/machine-learning": "/ml",
+        "/machinelearning": "/ml",
+        "/makejoy": "/joy",
+        "/makes-me-cry": "/touching",
+        "/makesmile": "/joy",
+        "/manager": "/being-a-great-manager",
+        "/manic": "/mania",
+        "/mechanism": "/upstream",
+        "/meditate": "/siy",
+        "/meditation": "/siy",
+        "/mental-break-down": "/depression",
+        "/middleage": "/elder",
+        "/midlife": "/elder",
+        "/monsters": "/mind-monsters",
+        "/mortality": "/death",
+        "/mr": "/ar",
+        "/negotiation": "/negotiate",
+        "/nonjudgment": "/curious",
+        "/nvim": "/vim",
+        "/objective": "/goals",
+        "/okr": "/goals",
+        "/on-being-mortal": "/death",
+        "/overwork": "/overload",
+        "/pain": "/mental-pain",
+        "/parkinson-law": "/parkinson",
+        "/parkinsons-law": "/parkinson",
+        "/passion": "/caring",
+        "/pay": "/comp",
+        "/pd": "/timeoff",
+        "/perfect-job": "/job",
+        "/personal-development": "/timeoff",
+        "/phoney": "/insecure",
+        "/pm": "/product",
+        "/podcasting": "/podcast",
+        "/podcasts": "/podcast",
+        "/poh": "/happy",
+        "/proactive": "/be-proactive",
+        "/process": "/upstream",
+        "/procrastinate": "/frog",
+        "/procrastination": "/frog",
+        "/product-manager": "/product",
+        "/production-consumption": "/produce-consume",
+        "/productivity": "/productive",
+        "/psych-safety": "/insecure",
+        "/psychological-safety": "/insecure",
+        "/rage": "/anger",
+        "/ranking": "/recommend",
+        "/rca": "/coe",
+        "/recommender": "/recommend",
+        "/regret": "/regrets",
+        "/remote": "/remote-work",
+        "/remotework": "/remote-work",
+        "/resistance": "/d/resistance",
+        "/responsible": "/be-proactive",
+        "/retirement": "/retire",
+        "/retiring": "/retire",
+        "/rework": "/staysmallstaysmall",
+        "/root-cause-analysis": "/coe",
+        "/rsu-risk": "/stock-concentration",
+        "/sat": "/work-satisfaction",
+        "/satisfaction": "/happy",
+        "/satisfied": "/happy",
+        "/saving": "/money",
+        "/savings": "/money",
+        "/savor": "/happy",
+        "/search-inside-yourself": "/siy",
+        "/shadows": "/psychic-shadows",
+        "/simple-and-sinister": "/kettlebell",
+        "/sleepless": "/insomnia",
+        "/some": "/sleight-of-mouth",
+        "/stages": "/chapters",
+        "/stewardship": "/delegate",
+        "/strong": "/physical-health",
+        "/sublime-state": "/sublime",
+        "/sublime-states": "/sublime",
+        "/taxes": "/money",
+        "/td/advertising": "/advertising",
+        "/td/design": "/design",
+        "/td/machine-learning": "/ml",
+        "/tech-ritual": "/tech-rituals",
+        "/tft": "/toysfortots",
+        "/the-dip": "/dip",
+        "/the-manager-book": "/manager-book",
+        "/the-saw": "/sharpen-the-saw",
+        "/thedip": "/dip",
+        "/think": "/writing",
+        "/thinking": "/writing",
+        "/thought-spells": "/psychic-shadows",
+        "/time-off": "/timeoff",
+        "/time-off-2024-02": "/timeoff-2024-02",
+        "/time-off-2024-04": "/timeoff-2024-04",
+        "/time-off-2024-08": "/timeoff-2024-08",
+        "/time-off-2025-08": "/timeoff-2025-08",
+        "/time-off-next": "/timeoff-2024-08",
+        "/time-off-now": "/timeoff-2024-08",
+        "/todo": "/todo_enjoy",
+        "/todo-enjoy": "/todo_enjoy",
+        "/tolerance": "/anger",
+        "/too-busy": "/overload",
+        "/training": "/ai-training",
+        "/tribes": "/tribe",
+        "/twenty-two": "/22",
+        "/twentytwo": "/22",
+        "/uncategorized": "/random-idea",
+        "/untangled-book": "/untangled",
+        "/vacation": "/timeoff",
+        "/vancouver": "/bc",
+        "/video-player": "/vlc",
+        "/videoplayer": "/vlc",
+        "/virus": "/covid",
+        "/visualizations": "/viz",
+        "/voices-in-my-head": "/voices",
+        "/vr": "/ar",
+        "/warmth": "/warm",
+        "/what-i-wish-i-knew-at-22": "/22",
+        "/win-win-or-no-deal": "/win-win",
+        "/wizard-book": "/sicp",
+        "/wlb": "/sustainable-work",
+        "/wlb-manifesto": "/sustainable-work",
+        "/work-life-balance": "/sustainable-work",
+        "/workload": "/overload",
+        "/write": "/writing",
+        "/y2024": "/y24",
+        "/y2025": "/y25",
+        "/yellow-deli": "/ig66/717",
+        "/zero": "/blueprint"
+    },
+    "url_info": {
+        "/22": {
+            "description": "In 2019 I created a program for 15 fantastic interns! A program highlight was my talk titled “What I wish I knew at 22, and so might you”. The talk received a 94% overall rating from over 15 interns, 10 SDE-IIs, and 1 senior developer. Even though the talk focuses on how to live the good life, a big chunk of life is work, so there’s good coverage on how to optimize your career.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/22.html",
+            "incoming_links": [
+                "/chapters",
+                "/manager-book"
+            ],
+            "last_modified": "2024-05-05T08:25:00-07:00",
+            "markdown_path": "_d/22.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "What I wish I knew at 22 and so might you!",
+            "url": "/22"
+        },
+        "/40yo": {
+            "description": "In 2002, I started programming at MSFT with lots of other 20-year-olds. I don’t recall the age distributions, but maybe 90% of the programmers I knew were under 40. In 2020, at 41, I’m no longer a programmer, and the majority of programmers are much younger than me. This begs the question, where do all the programmers go as they get older? I’m very curious about the answer. Here are some of my theories….\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/40yo.html",
+            "incoming_links": [
+                "/elder"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/40-yo-programmer.md",
+            "outgoing_links": [
+                "/chop",
+                "/elder"
+            ],
+            "redirect_url": "",
+            "title": "Age Before Beauty: The Vanishing Act of Older Coders",
+            "url": "/40yo"
+        },
+        "/42": {
+            "description": "You survived young kids, marriage, house, some easy crises, and now it’s time for remember , a healthy woman has a thousand wishes, a sick woman - just one: Things i wish I knew at 42\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/42.html",
+            "incoming_links": [
+                "/chapters",
+                "/retire",
+                "/y24",
+                "/y25"
+            ],
+            "last_modified": "2025-07-20T19:13:52-07:00",
+            "markdown_path": "_d/42.md",
+            "outgoing_links": [
+                "/chapters",
+                "/diet",
+                "/last-year",
+                "/physical-health",
+                "/retire",
+                "/sustainable-work",
+                "/terzepatide"
+            ],
+            "redirect_url": "",
+            "title": "What I wish I knew at 42",
+            "url": "/42"
+        },
+        "/4dx": {
+            "description": "The 4 Disciplines of Execution (4DX) is a proven framework for executing your most important strategic priorities in the midst of the whirlwind of day-to-day demands. This framework has been tested and refined by hundreds of organizations and thousands of teams over many years.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/4dx.html",
+            "incoming_links": [
+                "/goals"
+            ],
+            "last_modified": "2025-02-17T10:16:11-08:00",
+            "markdown_path": "_d/4dx.md",
+            "outgoing_links": [
+                "/end-in-mind",
+                "/essentialism",
+                "/first-things-first",
+                "/goals",
+                "/gtd"
+            ],
+            "redirect_url": "",
+            "title": "The 4 Disciplines of Execution (4DX)",
+            "url": "/4dx"
+        },
+        "/7-habits": {
+            "description": "Need a user manual for life? For me, that’s The 7 Habits of Highly Effective People. From dependent, to independent to interdependent, and then rinse and repeat for the different roles in your life. Like other self-help books? Excellent chance it’s a reframe or deep dive into these concepts.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/7-habits.html",
+            "incoming_links": [
+                "/7h-concepts",
+                "/balance",
+                "/be-proactive",
+                "/books-that-defined-me",
+                "/depression",
+                "/end-in-mind",
+                "/eulogy",
+                "/first-things-first",
+                "/first-understand",
+                "/psychic-weight",
+                "/sharpen-the-saw",
+                "/synergize",
+                "/timeoff-2020-12",
+                "/win-win"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_posts/2018-01-04-7-habits.md",
+            "outgoing_links": [
+                "/7h-concepts",
+                "/balance",
+                "/be-proactive",
+                "/end-in-mind",
+                "/eulogy",
+                "/first-things-first",
+                "/first-understand",
+                "/sharpen-the-saw",
+                "/synergize",
+                "/win-win"
+            ],
+            "redirect_url": "",
+            "title": "Seven Habits: A manual for life",
+            "url": "/7-habits"
+        },
+        "/7h-concepts": {
+            "description": "To discuss the 7 habits we need some foundational ideas, P/PC, paradigms, etc. These are my insights based on the 7 habits Chapter 0.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/7h-concepts.html",
+            "incoming_links": [
+                "/7-habits",
+                "/advice",
+                "/writing"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/7h-c0.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/balance",
+                "/sleight-of-mouth"
+            ],
+            "redirect_url": "",
+            "title": "7 habits concepts",
+            "url": "/7h-concepts"
+        },
+        "/90days": {
+            "description": "The first 90 days is a how to manual for starting a new job. While it’s focused on executive roles, it’s applicable to lower levels as well. It’s also the best written business book from a structural perspective. I highly recommend it.\n\n",
+            "doc_size": 50000,
+            "file_path": "_site/90days.html",
+            "incoming_links": [
+                "/manager-book",
+                "/writing"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_d/90days.md",
+            "outgoing_links": [
+                "/amazon",
+                "/curious",
+                "/first-things-first",
+                "/insecure",
+                "/shame",
+                "/writing"
+            ],
+            "redirect_url": "",
+            "title": "The first 90 days",
+            "url": "/90days"
+        },
+        "/Canadian-Spotting": {
+            "description": "“I bet you the bill that dude by the window is Canadian,” I challenged.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/Canadian-Spotting.html",
+            "incoming_links": [],
+            "last_modified": "2022-04-06T13:56:34-07:00",
+            "markdown_path": "_posts/2017-01-10-Canadian-Spotting.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Canadian Spotting",
+            "url": "/Canadian-Spotting"
+        },
+        "/Immutable-Laws-Of-Hard": {
+            "description": "Exercise, Diet, Personal Development, each of these is governed by the immutable laws of hard things. It’s possible these laws don’t apply to you, but I doubt it.\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/Immutable-Laws-Of-Hard.html",
+            "incoming_links": [
+                "/frog",
+                "/operating-manual"
+            ],
+            "last_modified": "2018-12-25T15:32:00-08:00",
+            "markdown_path": "_posts/2016-6-30-Immutable-Laws-Of-Hard.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "The Immutable Laws of Hard Things",
+            "url": "/Immutable-Laws-Of-Hard"
+        },
+        "/The-Genesis-Node": {
+            "description": "Igor, you know the odds of shipping Azure on time are slim to none.”\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/The-Genesis-Node.html",
+            "incoming_links": [
+                "/eulogy"
+            ],
+            "last_modified": "2020-05-06T21:46:45-07:00",
+            "markdown_path": "_posts/2018-11-03-The-Genesis-Node.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Microsoft Azure - The Genesis Node",
+            "url": "/The-Genesis-Node"
+        },
+        "/about": {
+            "description": "Igor's Blog",
+            "doc_size": 20000,
+            "file_path": "_site/about.html",
+            "incoming_links": [],
+            "last_modified": "2025-07-27T15:35:40-07:00",
+            "markdown_path": "about.md",
+            "outgoing_links": [
+                "/new-skills",
+                "/recent"
+            ],
+            "redirect_url": "",
+            "title": "Where am I?",
+            "url": "/about"
+        },
+        "/activation": {
+            "description": "Doing activities requires will power, addictions and procrastination require negative will power, while positive habits, especially new ones require high will power. Here’s a model for these things.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/activation.html",
+            "incoming_links": [
+                "/addiction",
+                "/balance",
+                "/energy",
+                "/energy-abundance",
+                "/produce-consume",
+                "/slow",
+                "/timeoff-2021-12"
+            ],
+            "last_modified": "2025-08-30T09:57:08-07:00",
+            "markdown_path": "_d/activation.md",
+            "outgoing_links": [
+                "/addiction",
+                "/blueprint",
+                "/d/habits",
+                "/d/resistance",
+                "/insomnia"
+            ],
+            "redirect_url": "",
+            "title": "Activation Energy",
+            "url": "/activation"
+        },
+        "/adblocker-trojan": {
+            "description": "Out of the blue I started seeing ads in my google search. They were especially prominent due to the fact they were white, and I use a back background. It was caused by a trojan running in my chrome extension, which I suspect was installed by a name-jacked NPM plugin.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/adblocker-trojan.html",
+            "incoming_links": [
+                "/timeoff-2021-11"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_td/adblocker_trojan.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "The Mystery of the google ads",
+            "url": "/adblocker-trojan"
+        },
+        "/addiction": {
+            "description": "Addiction is not about drugs or alcohol - it is about escape. Quoting “Do the Work”: When we can’t stand the fear, the shame, and the self-reproach that we feel, we obliterate it with an addiction. The addiction becomes the shadow version, the evil twin of our calling to service or to art. That’s why addicts are so interesting and so boring at the same time. They’re interesting because they’re called to something — something new, something unique, something that we, watching, can’t wait to see them bring forth into manifestation. At the same time, they’re boring because they never do the work. The addiction becomes his purpose, his novel, his adventure, his great love. The work of art or service that might have been produced is replaced by the drama, conflict, and suffering of the addict’s crazy, haunted, shattered life.\n\n",
+            "doc_size": 22000,
+            "file_path": "_site/addiction.html",
+            "incoming_links": [
+                "/activation",
+                "/anxiety-management",
+                "/d/resistance",
+                "/first-things-first",
+                "/happy",
+                "/idle",
+                "/mental-pain",
+                "/mind-at-work",
+                "/productive",
+                "/psychic-shadows",
+                "/psychic-weight",
+                "/timeoff"
+            ],
+            "last_modified": "2025-09-01T09:23:45-07:00",
+            "markdown_path": "_d/addiction.md",
+            "outgoing_links": [
+                "/activation",
+                "/covid",
+                "/elder",
+                "/mental-pain",
+                "/mind-at-work"
+            ],
+            "redirect_url": "",
+            "title": "Escape Artists: The True Face of Addiction",
+            "url": "/addiction"
+        },
+        "/advertising": {
+            "description": "Advertising is 155 billion business in the USA. Of that 155B, 85B is Digital and 70B is TV(digital platforms are invest ing in video to capture the TV spend. This post captures my understanding of that world.\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/advertising.html",
+            "incoming_links": [
+                "/monetize"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/advertising.md",
+            "outgoing_links": [
+                "/monetize"
+            ],
+            "redirect_url": "",
+            "title": "Advertising",
+            "url": "/advertising"
+        },
+        "/advice": {
+            "description": "Welcome to The Advice Lab! Think of advice like software - some versions are stable, others are still in beta, and what works perfectly on one system might crash another. Here we’ll explore the art and science of giving and receiving life’s most valuable patches and updates.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/advice.html",
+            "incoming_links": [],
+            "last_modified": "2025-01-26T15:44:57-08:00",
+            "markdown_path": "_d/advice.md",
+            "outgoing_links": [
+                "/7h-concepts",
+                "/first-understand"
+            ],
+            "redirect_url": "",
+            "title": "The Advice Lab: Where Wisdom Gets Beta Tested",
+            "url": "/advice"
+        },
+        "/affirmations": {
+            "description": "Every day I write out my affirmations. These positive statements help me challenge and overcome my self-sabotaging and negative thoughts and behaviors. Repeating them reinforces them, helping me be the person I want to be. My affirmations have power to me and have evolved over time. You’ll want to find the ones that speak best to you. Oh and bonus points if beyond just writing out your daily affirmations you reflect on how you can/will and have applied them.\n\n",
+            "doc_size": 22000,
+            "file_path": "_site/affirmations.html",
+            "incoming_links": [
+                "/gap-year-igor",
+                "/mortality-software",
+                "/operating-manual",
+                "/process-journal"
+            ],
+            "last_modified": "2025-06-17T07:29:01-07:00",
+            "markdown_path": "_d/affirmations2.md",
+            "outgoing_links": [
+                "/anxiety",
+                "/appreciate",
+                "/be-proactive",
+                "/class-act",
+                "/curious",
+                "/end-in-mind",
+                "/essentialism",
+                "/first-things-first",
+                "/first-understand",
+                "/insecure",
+                "/joy",
+                "/sublime",
+                "/writing"
+            ],
+            "redirect_url": "",
+            "title": "Affirmations",
+            "url": "/affirmations"
+        },
+        "/ai": {
+            "description": "AI becomes the\nThe transition from A landing page for all my ai pages - a nice jumping off point (especially from the graph).\n\n",
+            "doc_size": 26000,
+            "file_path": "_site/ai.html",
+            "incoming_links": [
+                "/ai-developer"
+            ],
+            "last_modified": "2025-05-19T09:09:26-07:00",
+            "markdown_path": "_d/ai.md",
+            "outgoing_links": [
+                "/ai-art",
+                "/ai-bestie",
+                "/ai-bm",
+                "/ai-developer",
+                "/ai-image",
+                "/ai-journal",
+                "/ai-paper",
+                "/ai-security",
+                "/ai-testing",
+                "/chop",
+                "/chow",
+                "/ml",
+                "/recommend",
+                "/vibe"
+            ],
+            "redirect_url": "",
+            "title": "All posts on AI",
+            "url": "/ai"
+        },
+        "/ai-art": {
+            "description": "Creativity is a critical aspect of art, and that’s something which I think AI can be really good at. Some very random ideas\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/ai-art.html",
+            "incoming_links": [
+                "/ai",
+                "/ai-journal"
+            ],
+            "last_modified": "2025-09-07T17:04:01-07:00",
+            "markdown_path": "_d/ai-art.md",
+            "outgoing_links": [
+                "/ai-image",
+                "/gpt"
+            ],
+            "redirect_url": "",
+            "title": "AI and art",
+            "url": "/ai-art"
+        },
+        "/ai-bestie": {
+            "description": "My best friend and I communicate over chat lots (33,60,101 messages/day P50, P75, P95). I have years of chat history, and so this seemed like a super fun way to get deeper into ML. This is created and shared with his permission.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/ai-bestie.html",
+            "incoming_links": [
+                "/ai",
+                "/y24"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/ai-bestie.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Igor's AI Bestie Simulator",
+            "url": "/ai-bestie"
+        },
+        "/ai-bm": {
+            "description": "Business Models drive the world, and they’ll drive the world of AI too.\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/ai-bm.html",
+            "incoming_links": [
+                "/ai"
+            ],
+            "last_modified": "2024-12-05T09:18:22-08:00",
+            "markdown_path": "_d/ai-business-model.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "AI Security",
+            "url": "/ai-bm"
+        },
+        "/ai-developer": {
+            "description": "ML Engineer is a hot new job. It’s the boys and girls who train and deploy models. I heard the word AI developer the other day, and I’ll refer to it as AI application engineers. People who use AI to solve use cases. NOTE: This is not what most developers do today. What most developers do today is ask how can AI do the things I would have done (e.g. write the function).\n\n",
+            "doc_size": 40000,
+            "file_path": "_site/ai-developer.html",
+            "incoming_links": [
+                "/ai"
+            ],
+            "last_modified": "2025-07-20T19:13:52-07:00",
+            "markdown_path": "_d/ai-developer.md",
+            "outgoing_links": [
+                "/ai"
+            ],
+            "redirect_url": "",
+            "title": "AI Developer",
+            "url": "/ai-developer"
+        },
+        "/ai-image": {
+            "description": "Everyone talks about GPT, but you can also generate images. Lately, I’ve been playing with Flux, which is an image generator. You can generate images of me using the idvorkin with this lora on replicate.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/ai-image.html",
+            "incoming_links": [
+                "/ai",
+                "/ai-art"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/ai-imagegen.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "AI Image Generation",
+            "url": "/ai-image"
+        },
+        "/ai-journal": {
+            "description": "A journal of random explorations in AI. Keeping track of them so I don’t get super lost\n\n",
+            "doc_size": 63000,
+            "file_path": "_site/ai-journal.html",
+            "incoming_links": [
+                "/ai"
+            ],
+            "last_modified": "2025-09-14T00:21:33.584805",
+            "markdown_path": "_d/ai-journal.md",
+            "outgoing_links": [
+                "/ai-art",
+                "/ai-security",
+                "/ai-talk",
+                "/eulogy",
+                "/gpt",
+                "/hyper-personal",
+                "/mental-pain"
+            ],
+            "redirect_url": "",
+            "title": "Igor's AI Journal",
+            "url": "/ai-journal"
+        },
+        "/ai-paper": {
+            "description": "The original AI papers were all about training, super technical, and not that usable as a practitioner. Nowadays papers are less “mathy” and more applicable to practitioners. Here are some worth reading\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/ai-paper.html",
+            "incoming_links": [
+                "/ai"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/ai-paper.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Seminal AI Papers",
+            "url": "/ai-paper"
+        },
+        "/ai-security": {
+            "description": "Security is super interesting, AI is super interesting, the combination, is super-duper interesting!\n\n",
+            "doc_size": 27000,
+            "file_path": "_site/ai-security.html",
+            "incoming_links": [
+                "/ai",
+                "/ai-journal"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/ai-security.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "AI Security",
+            "url": "/ai-security"
+        },
+        "/ai-testing": {
+            "description": "Testing math is easy, it’s right or wrong. Testing spelling is easy too, but testing if a joke is funny - now that’s tough. Let’s talk about how to test AI.\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/ai-testing.html",
+            "incoming_links": [
+                "/ai",
+                "/chop",
+                "/genai-talk",
+                "/ml",
+                "/testing",
+                "/timeoff-2024-04"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/ai-testing.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Testing AI",
+            "url": "/ai-testing"
+        },
+        "/amazon": {
+            "description": "I spent 4 years working at Amazon, some things I loved, some not so much. Amazon is a huge company and the variation of behavior within a company exceeds the variation between the “median” behavior between companies. Even within the two teams I was on at Amazon I saw the exact opposite behaviors. When I talk about the good, I’ll talk about the ideal good, and when I talk about the bad, I’ll talk to some issues I saw that were systemically bad. As a result you’ll often see me describing something as both good and bad, as it’s done differently in different parts of the company.\n\n",
+            "doc_size": 29000,
+            "file_path": "_site/amazon.html",
+            "incoming_links": [
+                "/90days",
+                "/manager-book-appendix",
+                "/parkinson",
+                "/writing"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/amazon.md",
+            "outgoing_links": [
+                "/coe",
+                "/design",
+                "/manager-book",
+                "/td/cloud-first-applications",
+                "/td/data-systems",
+                "/toysfortots",
+                "/writing"
+            ],
+            "redirect_url": "",
+            "title": "My thoughts on Amazon",
+            "url": "/amazon"
+        },
+        "/anger": {
+            "description": "It’s 8 am; The normal rush, the kids are late to school, we’re yelling at them to eat their breakfast, pack their lunch, brush their teeth, get ready for school. 30 minutes earlier, I’d decided I’d bike Amelia, my 7 year old daughter, to school. I told Tori, my wife, who normally drives the kids to school. Tori didn’t acknowledge me. As I got my bike helmet Tori put the kids in the car. I ran out and tried to get her attention, waving frantically and running to the car. (In my head), Tori ignored me, wouldn’t look at me, even as I ran to the car and gesticulated wildly. I really had my heart set on biking Amelia to school, and I went into a rage, as Tori pulled off, I flipped her off. Adulting fail - not my best moment.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/anger.html",
+            "incoming_links": [
+                "/emotions",
+                "/mood"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_d/anger.md",
+            "outgoing_links": [
+                "/depression",
+                "/mental-pain"
+            ],
+            "redirect_url": "",
+            "title": "Anger is the enemy",
+            "url": "/anger"
+        },
+        "/anxiety": {
+            "description": "Anxiety is the difference between reality and expectations. It is the pain, while stress is the suffering. The pain of anxiety is designed for threatening circumstances drawing your attention to a problem requiring urgent attention. This narrows your perspective allowing you to focus on a resolution. However, like many autonomous systems anxiety can be over-triggered, and handled poorly without deliberate action.\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/anxiety.html",
+            "incoming_links": [
+                "/affirmations",
+                "/anxiety-management",
+                "/depression",
+                "/fail",
+                "/gtd",
+                "/happy",
+                "/operating-manual",
+                "/overload",
+                "/productive",
+                "/slow",
+                "/touching",
+                "/voices"
+            ],
+            "last_modified": "2025-08-24T10:29:13-07:00",
+            "markdown_path": "_d/anxiety.md",
+            "outgoing_links": [
+                "/anxiety-management",
+                "/be-proactive",
+                "/idle",
+                "/slow",
+                "/voices"
+            ],
+            "redirect_url": "",
+            "title": "Anxiety, the gap between reality and expectations",
+            "url": "/anxiety"
+        },
+        "/anxiety-management": {
+            "description": "When your emotions aren’t serving you well, it’s helpful to have a solid protocol. First you need to rebuild perspective, and then you need to focus on maximizing your influence.\n\n",
+            "doc_size": 22000,
+            "file_path": "_site/anxiety-management.html",
+            "incoming_links": [
+                "/anxiety",
+                "/fail",
+                "/psychic-shadows"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/anxiety_management.md",
+            "outgoing_links": [
+                "/addiction",
+                "/anxiety",
+                "/frog",
+                "/mental-pain",
+                "/psychic-shadows",
+                "/siy"
+            ],
+            "redirect_url": "",
+            "title": "Anxiety Management",
+            "url": "/anxiety-management"
+        },
+        "/appreciate": {
+            "description": "Think of the last time you were appreciated: How did you feel? Think about the last hour: How many things could you have appreciated? It takes 7 positive experiences to make up for 1 negative experience - what can you appreciate?\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/appreciate.html",
+            "incoming_links": [
+                "/affirmations",
+                "/class-act"
+            ],
+            "last_modified": "2022-03-20T09:28:13-07:00",
+            "markdown_path": "_d/appreciate2.md",
+            "outgoing_links": [
+                "/grateful"
+            ],
+            "redirect_url": "",
+            "title": "Appreciate",
+            "url": "/appreciate"
+        },
+        "/ar": {
+            "description": "My notes on AR\n\n",
+            "doc_size": 19000,
+            "file_path": "_site/ar.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/ar.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Augmented Reality",
+            "url": "/ar"
+        },
+        "/asciinema": {
+            "description": "Lets clean this up and see what it looks like …\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/asciinema.html",
+            "incoming_links": [],
+            "last_modified": "2024-04-08T15:04:01-07:00",
+            "markdown_path": "_td/asciinema.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "asciinema",
+            "url": "/asciinema"
+        },
+        "/ast-grep": {
+            "description": "Sometimes you need to search/replace but on code, so let’s use ASTs for that. The tool is called ast-grep (which you invoke with sg).\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/ast-grep.html",
+            "incoming_links": [],
+            "last_modified": "2024-09-22T16:18:28-07:00",
+            "markdown_path": "_td/ast-grep.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "AST Grep",
+            "url": "/ast-grep"
+        },
+        "/balance": {
+            "description": "I’m good at a lot of things, but balance is really hard for me. Hard for everyone I bet. I think this would be an area that can really benefit from mortality software. TODO: decide if this post should fork into energy and balance\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/balance.html",
+            "incoming_links": [
+                "/7-habits",
+                "/7h-concepts",
+                "/energy-abundance",
+                "/life-as-business",
+                "/productive",
+                "/slow",
+                "/timeoff-2021-12"
+            ],
+            "last_modified": "2025-08-24T10:29:13-07:00",
+            "markdown_path": "_d/balance2.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/activation",
+                "/energy",
+                "/essentialism",
+                "/eulogy",
+                "/moments",
+                "/mortality-software",
+                "/parkinson",
+                "/productive",
+                "/slow",
+                "/sustainable-work",
+                "/timeoff",
+                "/weeks"
+            ],
+            "redirect_url": "",
+            "title": "Balance - The Holy Grail",
+            "url": "/balance"
+        },
+        "/balloon": {
+            "description": "Want to plaster a huge smile on someone’s face with 10 cents of material and 20 seconds of work? Make them a balloon! In 2022, I discovered ballooning, and have used it in my joy-delivering arsenal ever since.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/balloon.html",
+            "incoming_links": [
+                "/eulogy",
+                "/joy",
+                "/timeoff"
+            ],
+            "last_modified": "2025-04-04T06:53:08-07:00",
+            "markdown_path": "_d/balloon.md",
+            "outgoing_links": [
+                "/joy"
+            ],
+            "redirect_url": "",
+            "title": "Being a Ballooner",
+            "url": "/balloon"
+        },
+        "/bc": {
+            "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/bc.html",
+            "incoming_links": [],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/bc-vacation.md",
+            "outgoing_links": [
+                "/ig66/718",
+                "/ig66/749",
+                "/timeoff-2024-02"
+            ],
+            "redirect_url": "",
+            "title": "BC Vacation Guide: Vancouver & Chilliwack Adventures",
+            "url": "/bc"
+        },
+        "/be-proactive": {
+            "description": "I choose ‘.’ I am responsible for my own life ‘.’ My behavior is a function of my decisions, not my conditions ‘.’ I can subordinate feelings to values ‘.’ I have the initiative and the responsibility to make things happen. These are my insights from 7 habits Chapter 1.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/be-proactive.html",
+            "incoming_links": [
+                "/7-habits",
+                "/affirmations",
+                "/anxiety",
+                "/d/habits",
+                "/emotions",
+                "/frog",
+                "/idle",
+                "/process-journal",
+                "/regrets",
+                "/siy"
+            ],
+            "last_modified": "2025-04-02T22:07:54-07:00",
+            "markdown_path": "_d/7h-c1.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/essentialism",
+                "/frog",
+                "/siy"
+            ],
+            "redirect_url": "",
+            "title": "Be Proactive",
+            "url": "/be-proactive"
+        },
+        "/being-a-great-manager": {
+            "description": "I aspire to be the best manager I can be. I’ll often fall short of my goal, but through continuous practice I will get closer. This post will gather my research on being a great manager, enumerate some of my learnings, and inspire me to be my best. Few things make me prouder than this public feedback on LinkedIn from people who worked with me over several years. I’m also writing a manager guidebook, which goes into much more depth on management.\n\n",
+            "doc_size": 22000,
+            "file_path": "_site/being-a-great-manager.html",
+            "incoming_links": [
+                "/bmy",
+                "/eulogy",
+                "/job",
+                "/manager-book"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_posts/2018-03-18-being-a-great-manager.md",
+            "outgoing_links": [
+                "/books-that-defined-me",
+                "/coaching",
+                "/curious",
+                "/decisive",
+                "/human-meetings",
+                "/manager-book",
+                "/mind-monsters",
+                "/moments-at-work",
+                "/pride",
+                "/static/idvorkin-linked-in-feedback-lastest.pdf",
+                "/sustainable-work"
+            ],
+            "redirect_url": "",
+            "title": "Being the best manager I can be",
+            "url": "/being-a-great-manager"
+        },
+        "/bike": {
+            "description": "Biking, is something that make my very happy. I have multiple bikes, here are my notes.\n\n",
+            "doc_size": 22000,
+            "file_path": "_site/bike.html",
+            "incoming_links": [
+                "/eulogy",
+                "/irl",
+                "/operating-manual"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_posts/2017-03-01-bike.md",
+            "outgoing_links": [
+                "/brompton-toys",
+                "/warm"
+            ],
+            "redirect_url": "",
+            "title": "Biking",
+            "url": "/bike"
+        },
+        "/blueprint": {
+            "description": "So there’s this guy who measures his nightly erections, doesn’t go out into the sun, and strives to delegate all his decision making to an algorithm called blue print. Certainly a nut job, but a nut job who has explored many of the thoughts I’m very interested in. Depression, purpose, sleep, exercise. Here are my notes.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/blueprint.html",
+            "incoming_links": [
+                "/activation",
+                "/operating-manual",
+                "/sleep",
+                "/timeoff-2024-02"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/blueprint.md",
+            "outgoing_links": [
+                "/ig66/663",
+                "/voices"
+            ],
+            "redirect_url": "",
+            "title": "Bryan Johnson - A 50 year old 18 year old",
+            "url": "/blueprint"
+        },
+        "/bmy": {
+            "description": "The business model canvas is a tool for understanding how a company makes money. This same model can be applied to a person’s career. While job hunting this was helpful figuring out my dream job. I suppose it should also prioritize my work energy, and probably how to prioritize my life energy. But that’s to come.\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/bmy.html",
+            "incoming_links": [
+                "/job-hunt-stress"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/bmu.md",
+            "outgoing_links": [
+                "/being-a-great-manager",
+                "/eulogy",
+                "/job",
+                "/job-hunt-stress"
+            ],
+            "redirect_url": "",
+            "title": "Business Model You",
+            "url": "/bmy"
+        },
+        "/books-that-defined-me": {
+            "description": "Books allow great thoughts to enter our mind and mold us into who we want to become. These are the books that are molding me.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/books-that-defined-me.html",
+            "incoming_links": [
+                "/being-a-great-manager",
+                "/manager-book",
+                "/manager-book-appendix"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_posts/2015-11-02-books-that-defined-me.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/d/resistance",
+                "/essentialism",
+                "/getting-to-yes-with-yourself",
+                "/gtd",
+                "/humans-are-underrated",
+                "/siy"
+            ],
+            "redirect_url": "",
+            "title": "Books that defined me",
+            "url": "/books-that-defined-me"
+        },
+        "/breath": {
+            "description": "Breathing, an act so simple yet so crucial, harbors the potential to transform our health, mind, and life. This blog post is a deep dive into the world of breathing techniques, exploring a range of practices from Box Breathing and Victory Breath to Sitali Breath and the Breath Focus Technique. Each technique is detailed with its benefits and step-by-step instructions. In addition, the scientific perspective on breathing is explored. Whether you’re seeking to reduce stress, improve focus, or simply understand the science of breathing, this post is your comprehensive guide. Join us as we explore the art of breathing, its techniques, and the science behind it.\n\n",
+            "doc_size": 27000,
+            "file_path": "_site/breath.html",
+            "incoming_links": [],
+            "last_modified": "2025-03-02T20:00:19-08:00",
+            "markdown_path": "_d/breath.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Breathing as if your life depends on it",
+            "url": "/breath"
+        },
+        "/brompton-toys": {
+            "description": "I LOVE my Brompton, and have spent much time researching accessories for it. Here are the accoutraments I’ve bought for my Brompton, and hopefully it’ll save other Brompton owners time, and/or make them aware of accessories they don’t known about.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/brompton-toys.html",
+            "incoming_links": [
+                "/bike"
+            ],
+            "last_modified": "2018-12-25T15:32:00-08:00",
+            "markdown_path": "_posts/2016-4-9-brompton-toys.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "My Brompton and its accoutrements",
+            "url": "/brompton-toys"
+        },
+        "/brython": {
+            "description": "This page is built with brython, a python running in browser via WASM. This is my playground to try interesting things with brython.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/brython.html",
+            "incoming_links": [
+                "/timeoff-2021-11"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/brython_.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "A playground for brython and pystory",
+            "url": "/brython"
+        },
+        "/build-bubble-bike": {
+            "description": "What the heck is a bubble bike? Ah, you see, bringing joy for others is my thing. As they say in Buddhism there are many vehicles to bring joy, and my vehicle is the bubble bike.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/build-bubble-bike.html",
+            "incoming_links": [
+                "/joy"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/build-bubble-bike.md",
+            "outgoing_links": [
+                "/joy"
+            ],
+            "redirect_url": "",
+            "title": "Building a bubble bike",
+            "url": "/build-bubble-bike"
+        },
+        "/cache": {
+            "description": "Internal incubations are fun, but I love shipping products. In the case of Microsoft Cache, before I joined, the team had been incubating OneClip, and needed help bringing it to market. My self and a top tier product manager joined the team to help them ship. We immediately got to work, recruiting senior talent, and closing the gaps. We tackled the technical, product market fit, and logistical issues required to bring the product to market.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/cache.html",
+            "incoming_links": [
+                "/eulogy",
+                "/job"
+            ],
+            "last_modified": "2023-12-17T18:53:39+00:00",
+            "markdown_path": "_posts/2018-1-1-cache.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Shipping incubations: Cache",
+            "url": "/cache"
+        },
+        "/caring": {
+            "description": "Let’s define caring, as the intensity of our emotions, critical given a lack of emotional intensity is depression. Intense emotions are synonymous with interest and mental energy, which is a double edged sword: Good caring (commitment to our identity, positive habits) charges us up, but bad caring (attachment, anger, anxiety, focus on things we don’t control), brings us down. When bad caring manifests as repetitive, ruminating thought patterns, they become psychic shadows requiring specialized techniques:\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/caring.html",
+            "incoming_links": [
+                "/depression"
+            ],
+            "last_modified": "2025-07-18T07:57:44-07:00",
+            "markdown_path": "_d/caring.md",
+            "outgoing_links": [
+                "/depression",
+                "/psychic-shadows"
+            ],
+            "redirect_url": "",
+            "title": "Caring - The story of emotional intensity",
+            "url": "/caring"
+        },
+        "/cert-error": {
+            "description": "Dad the website isn’t secure! You’re the security expert fix it! Zach, my 10 year old at the time son, runs a web site, and it got an occasional this website is not secure message. I tried to debug, but couldn’t get a consistent enough repro to debug, so had to move on. It stayed in this state for 6 months, at which point Zach told me the certificate had expired. Now i had a 100% repro so went to work.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/cert-error.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T10:48:49-07:00",
+            "markdown_path": "_td/fix_cert_error.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "The Case of the Cert Validation Error",
+            "url": "/cert-error"
+        },
+        "/chapters": {
+            "description": "Our lives are stories, containing many different chapters. However, regardless of what is in the chapters, we all go through life stages, being young, growing up, getting old, etc. What you need as a 22-year-old, and what you need as a 42-year-old sure are different. I think our lives are both chapters in terms of the plot, but also in terms of the stages of life.\n\n",
+            "doc_size": 22000,
+            "file_path": "_site/chapters.html",
+            "incoming_links": [
+                "/42",
+                "/gap-year",
+                "/gap-year-igor",
+                "/lonely",
+                "/retire",
+                "/y25"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/chapters.md",
+            "outgoing_links": [
+                "/22",
+                "/42",
+                "/enemy"
+            ],
+            "redirect_url": "",
+            "title": "The chapters of our lives",
+            "url": "/chapters"
+        },
+        "/chasing-daylight": {
+            "description": "Monday morning: You’re Eugene O’Kelly, CEO of KPMG, reviewing next quarter’s strategy. Your calendar is packed with board meetings, your daughter’s college visits are scheduled for fall, and you’re planning that anniversary trip for next summer. Tuesday afternoon: You’re sitting in a doctor’s office, trying to process the words “terminal brain cancer” and “three months to live.” In an instant, your calendar becomes meaningless - all those carefully planned years collapse into a countdown of just 100 days. This was O’Kelly’s reality, and his response was remarkable: he chose to approach his death with the same clarity and purpose that had marked his life. This is what I learned from his story.\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/chasing-daylight.html",
+            "incoming_links": [
+                "/gap-year-igor",
+                "/last-year"
+            ],
+            "last_modified": "2025-02-23T06:32:12-08:00",
+            "markdown_path": "_d/chasing-daylight.md",
+            "outgoing_links": [
+                "/death",
+                "/happy",
+                "/last-year",
+                "/moments"
+            ],
+            "redirect_url": "",
+            "title": "Chasing Daylight: Imagine you're gonna die in less then 100 days",
+            "url": "/chasing-daylight"
+        },
+        "/chop": {
+            "description": "Welcome to The CHOP Shop! CHOP - or Chat-Oriented Programming - is revolutionizing how we write code. Think of those old-school auto shops: AI started as the shop hand, fetching tools and cleaning parts. Then it became an apprentice mechanic, helping diagnose problems and suggesting fixes. Now? It’s a master mechanic, capable of rebuilding entire engines from your high-level specs. Our AIs are getting smarter by the day, and we’ll explore how to make the most of this evolution.\n\n",
+            "doc_size": 59000,
+            "file_path": "_site/chop.html",
+            "incoming_links": [
+                "/40yo",
+                "/ai",
+                "/chow",
+                "/gtd",
+                "/process-journal",
+                "/tech-rituals",
+                "/vibe",
+                "/y24",
+                "/y25"
+            ],
+            "last_modified": "2025-09-10T09:24:52-07:00",
+            "markdown_path": "_d/ai-coder.md",
+            "outgoing_links": [
+                "/ai-testing",
+                "/humans-are-underrated",
+                "/process-journal",
+                "/testing",
+                "/vibe"
+            ],
+            "redirect_url": "",
+            "title": "The CHOP Shop: Where AI Meets Code",
+            "url": "/chop"
+        },
+        "/chow": {
+            "description": "Welcome to The CHOW Kitchen! CHOW - or Chat-Oriented Writing - is transforming how we create content. Think of those bustling restaurant kitchens: AI started as the prep cook, chopping vegetables and measuring ingredients. Then it became a line cook, helping with recipes and plating. Now? It’s becoming a sous chef, capable of crafting entire dishes from your creative vision. Our AIs are getting more sophisticated daily, and we’ll explore how to make the most of this culinary revolution in writing.\n\n",
+            "doc_size": 28000,
+            "file_path": "_site/chow.html",
+            "incoming_links": [
+                "/ai"
+            ],
+            "last_modified": "2025-02-16T07:25:27-08:00",
+            "markdown_path": "_d/chow.md",
+            "outgoing_links": [
+                "/chop",
+                "/enable",
+                "/td/data-systems",
+                "/writing"
+            ],
+            "redirect_url": "",
+            "title": "The CHOW Kitchen: Where AI Meets Writing",
+            "url": "/chow"
+        },
+        "/class-act": {
+            "description": "Be a class act. Fantatic advice.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/class-act.html",
+            "incoming_links": [
+                "/affirmations"
+            ],
+            "last_modified": "2024-11-30T08:42:37-08:00",
+            "markdown_path": "_d/classact2.md",
+            "outgoing_links": [
+                "/appreciate",
+                "/curious",
+                "/first-understand",
+                "/touching"
+            ],
+            "redirect_url": "",
+            "title": "Be a class act",
+            "url": "/class-act"
+        },
+        "/coaching": {
+            "description": "Coaching is like midwifery. A midwife can not give birth to the baby, she facilitates the birth. Similarly, a coach can not give a solution, she must give birth to the insight from within the coachee. Coaching is asking questions, guiding, and facilitating understanding, and this post collects my studies on the topic.\n\n",
+            "doc_size": 30000,
+            "file_path": "_site/coaching.html",
+            "incoming_links": [
+                "/being-a-great-manager",
+                "/first-understand",
+                "/insecure",
+                "/job",
+                "/manager-book",
+                "/moments-at-work",
+                "/prompts",
+                "/writing"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_d/coaching.md",
+            "outgoing_links": [
+                "/curious",
+                "/decisive",
+                "/manager-book",
+                "/pride",
+                "/prompts",
+                "/siy"
+            ],
+            "redirect_url": "",
+            "title": "Coaching - How to help others find insight",
+            "url": "/coaching"
+        },
+        "/coe": {
+            "description": "Everyone can make a mistake once, that’s totally fine. Repeating mistakes is unacceptable. Correction of Errors (COE) is the name Amazon gives it’s mechanism for correcting errors. Microsoft uses the term Root cause analysis (RCA), it’s the same concept. This mechanism originated with service outages but can be applied for any “error”, like missing your sons kindergarten graduation, or getting fired.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/coe.html",
+            "incoming_links": [
+                "/amazon",
+                "/fail",
+                "/manager-book",
+                "/physical-pain",
+                "/switch",
+                "/writing"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/correction-of-errors.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Learning from mistakes",
+            "url": "/coe"
+        },
+        "/comp": {
+            "description": "Different companies use different compensation models. To compare models, use total compensation, not salary. The compensation models are arbitrary and complicated. For example, Amazon caps salary at 160K$/yr and doesn’t have bonuses. Google vests stocks monthly. Facebook bonuses have a company performance multiplier. At some companies, signing bonuses can be over 100% of salary!\n\n",
+            "doc_size": 29000,
+            "file_path": "_site/comp.html",
+            "incoming_links": [
+                "/job-hunt-stress",
+                "/manager-book",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_posts/2017-11-16-understandingtechcompensation.md",
+            "outgoing_links": [
+                "/job-hunt-stress",
+                "/pride"
+            ],
+            "redirect_url": "",
+            "title": "Care about Total Compensation",
+            "url": "/comp"
+        },
+        "/content-audience": {
+            "description": "When I started creating content — okay, let’s be honest, when I started uploading random videos to YouTube and TikTok — I didn’t have a plan. I’d record something, maybe clean it up in post, and toss it online. No real story, no strategy, and usually… no good. Looking back, I realize I never stopped to ask the two questions that actually matter: Who is this for? And why am I doing it? This blog is me trying to answer those questions — and maybe help you ask them too.\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/content-audience.html",
+            "incoming_links": [
+                "/content-creation"
+            ],
+            "last_modified": "2025-09-08T09:25:35-07:00",
+            "markdown_path": "_d/content-audience.md",
+            "outgoing_links": [
+                "/end-in-mind",
+                "/manager-book"
+            ],
+            "redirect_url": "",
+            "title": "Content Audience",
+            "url": "/content-audience"
+        },
+        "/content-creation": {
+            "description": "Ah, content creation! Remember when it meant awkwardly holding your phone at arm’s length, hoping your thumb wouldn’t photobomb your masterpiece? We’ve come a long way, baby! Whether you’re aiming to be the next TikTok sensation or just want to share your magic tricks without accidentally revealing them, this guide will help you level up from “my mom’s my only viewer” to “wait, is that video going viral?”\n\n",
+            "doc_size": 27000,
+            "file_path": "_site/content-creation.html",
+            "incoming_links": [
+                "/monetize",
+                "/y25"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/content-creation.md",
+            "outgoing_links": [
+                "/content-audience",
+                "/monetize",
+                "/screencast"
+            ],
+            "redirect_url": "",
+            "title": "Content Creation: From Shaky Selfies to Social Superstar",
+            "url": "/content-creation"
+        },
+        "/covid": {
+            "description": "Corona Virus (CV) may be the defining moment in our lives. In such times, lets remember three things 1) Keep your circle of concern within your circle of influence 2) Don’t feed mind monsters - see the positive 3) In crisis, you see both the best and worse. Focus on the best.\n\n",
+            "doc_size": 27000,
+            "file_path": "_site/covid.html",
+            "incoming_links": [
+                "/addiction",
+                "/facebook",
+                "/operating-manual"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/covid19.md",
+            "outgoing_links": [
+                "/death"
+            ],
+            "redirect_url": "",
+            "title": "Notes from Covid 19",
+            "url": "/covid"
+        },
+        "/curious": {
+            "description": "Lead with curiosity, not judgment. This applies to yourself and to others. Think of a grandmother - a grandmother is full of love and compassion for her grandchildren. She loves them without conditions, no strings attached.She takes care of her grandchildren without needing anything in return. She cares selflessly and she has only the children’s best interest in mind. As she loves her grandchildren, she won’t allow self-destructive behavior and will step in when necessary. But she will always do this with the utmost care and love.\n\n",
+            "doc_size": 19000,
+            "file_path": "_site/curious.html",
+            "incoming_links": [
+                "/90days",
+                "/affirmations",
+                "/being-a-great-manager",
+                "/class-act",
+                "/coaching",
+                "/emotions",
+                "/essentialism",
+                "/first-understand",
+                "/getting-to-yes-with-yourself",
+                "/happy",
+                "/negotiate",
+                "/operating-manual",
+                "/psychic-weight",
+                "/regrets",
+                "/shame",
+                "/voices"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/grandmother.md",
+            "outgoing_links": [
+                "/first-understand",
+                "/mental-pain",
+                "/negotiate",
+                "/shame",
+                "/siy",
+                "/win-win"
+            ],
+            "redirect_url": "",
+            "title": "Isn't that curious",
+            "url": "/curious"
+        },
+        "/d/2016-02-03-positive-computing-survey": {
+            "description": "Positive computing is the software branch focused on increasing human well being. Similar to positive psychology, it is a brand new field and our industry has barely begun. I’ll use this post to gather my half baked thoughts on the various applications I’ve seen. For now it’ll be confusing as I’m brain dumping to various audiences with various knowledge.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/d/2016-02-03-positive-computing-survey.html",
+            "incoming_links": [],
+            "last_modified": "2018-12-25T15:34:24-08:00",
+            "markdown_path": "_d/2016-02-03-positive-computing-survey.md",
+            "outgoing_links": [
+                "/tech-health-toys"
+            ],
+            "redirect_url": "",
+            "title": "Positive computing a whirlwind tour",
+            "url": "/d/2016-02-03-positive-computing-survey"
+        },
+        "/d/2016-05-09-lost-interview": {
+            "description": "Uneditted notes on a Q+A with Steve Jobs.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/d/2016-05-09-lost-interview.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/2016-05-09-lost-interview.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Steve Jobs -- The Lost Interview",
+            "url": "/d/2016-05-09-lost-interview"
+        },
+        "/d/2016-2-14-Health-In-The-Head": {
+            "description": "Fit in my head, isn’t fit in reality. In the last few years I’ve learned this lesson for physical health, and now I’m learning it for emotional health.\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/d/2016-2-14-Health-In-The-Head.html",
+            "incoming_links": [],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_d/2016-2-14-Health-In-The-Head.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Emotional Health In My Head",
+            "url": "/d/2016-2-14-Health-In-The-Head"
+        },
+        "/d/2016-2-15-Seth-Godin-Notes": {
+            "description": "Seth godin has many ideas that are critical in the new world. Ideas include: Choosing yourself, Tribes, The limited value of cogs, connection, and the dip.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/d/2016-2-15-Seth-Godin-Notes.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-24T09:03:19-07:00",
+            "markdown_path": "_d/2016-2-15-Seth-Godin-Notes.md",
+            "outgoing_links": [
+                "/dip"
+            ],
+            "redirect_url": "",
+            "title": "Seth Godin- Ideas",
+            "url": "/d/2016-2-15-Seth-Godin-Notes"
+        },
+        "/d/2016-7-14-Customer-Service": {
+            "description": "Customer obsession, manifest in customer service, can be a key differentiator. This post explores the benefits, and business model impact of a customer obsessed organization.\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/d/2016-7-14-Customer-Service.html",
+            "incoming_links": [],
+            "last_modified": "2018-12-25T15:34:24-08:00",
+            "markdown_path": "_d/2016-7-14-Customer-Service.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Companies with customer obsession",
+            "url": "/d/2016-7-14-Customer-Service"
+        },
+        "/d/2016-8-1-Twelve-Tech-Forces": {
+            "description": "The digital revolution has gone through 3 changes: the copy of the industrial age, the link age, and the streaming age. This is a summary of the concepts representing the new age.\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/d/2016-8-1-Twelve-Tech-Forces.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-24T09:03:19-07:00",
+            "markdown_path": "_d/2016-8-1-Twelve-Tech-Forces.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "12 Tech forces that will shape our future",
+            "url": "/d/2016-8-1-Twelve-Tech-Forces"
+        },
+        "/d/2017-07-22-vacationphotos": {
+            "description": "Vacation photos are great, they remind you of the good times you’ve had, the people you’ve had them with and the places you’ve had them at. Here are my tips for vacation photos, and “reminiscing” type photos in general.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/d/2017-07-22-vacationphotos.html",
+            "incoming_links": [],
+            "last_modified": "2019-01-12T22:04:24+00:00",
+            "markdown_path": "_d/2017-07-22-vacationphotos.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Vacation Photos",
+            "url": "/d/2017-07-22-vacationphotos"
+        },
+        "/d/2017-09-10-software-rot": {
+            "description": "After a year of not working on one of my hobby software projects, I decided it’d be fun to make a minor change - should only be few lines of code. Should be easier still since I followed all the project best practices: I had full unit tests, and a fully automated command line build but boy was I wrong.\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/d/2017-09-10-software-rot.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T10:48:49-07:00",
+            "markdown_path": "_d/2017-09-10-software-rot.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Software Rot",
+            "url": "/d/2017-09-10-software-rot"
+        },
+        "/d/2017-11-04-clean-architecture": {
+            "description": "Architecture is the highest level of abstraction that models a software system. The architecture is composed from modules, which are composed of objects, which are composed of functions. Design is applied to each of these layers, and when executed successfully results in a system that is easy to build and maintain. Clean architecture discusses designs at a high level, which like architecture is highly useful. On the topic of architecture, the software industry’s use of the word architect is confusing. The construction analog of a “software architect” is a “structural engineer” and the software equivalent of a “construction architect” is a product manager.\n\n",
+            "doc_size": 50000,
+            "file_path": "_site/d/2017-11-04-clean-architecture.html",
+            "incoming_links": [
+                "/design"
+            ],
+            "last_modified": "2022-02-20T20:01:29-08:00",
+            "markdown_path": "_d/2017-11-04-clean-architecture.md",
+            "outgoing_links": [
+                "/design"
+            ],
+            "redirect_url": "",
+            "title": "Clean Architecture",
+            "url": "/d/2017-11-04-clean-architecture"
+        },
+        "/d/2018-02-10-you-do-want-your-favorite-app-to-be-a-service": {
+            "description": "When selling subscription software, a publisher needs to continue to prove the value of their software, or users will not renew their contracts. This is very beneficial to the users and to the publisher.\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/d/2018-02-10-you-do-want-your-favorite-app-to-be-a-service.html",
+            "incoming_links": [],
+            "last_modified": "2025-07-12T16:50:19-07:00",
+            "markdown_path": "_d/2018-02-10-you-do-want-your-favorite-app-to-be-a-service.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Software as a service is good for users",
+            "url": "/d/2018-02-10-you-do-want-your-favorite-app-to-be-a-service"
+        },
+        "/d/2018-09-23-mind-lines": {
+            "description": "Mind Lines\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/d/2018-09-23-mind-lines.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/2018-09-23-mind-lines.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Mind-Lines",
+            "url": "/d/2018-09-23-mind-lines"
+        },
+        "/d/apollo": {
+            "description": "The original Kenedy speech\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/d/apollo.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/apollo.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Quality",
+            "url": "/d/apollo"
+        },
+        "/d/habits": {
+            "description": "Habits are the automatic actions, both positive and negative, you take through your life. Atomic Habits describes how to change habits, it’s the how-to manual for “Sharpening the Saw”.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/d/habits.html",
+            "incoming_links": [
+                "/activation",
+                "/d/resistance",
+                "/energy-abundance",
+                "/hobby",
+                "/idle",
+                "/life-as-business",
+                "/manager-book",
+                "/mind-at-work",
+                "/operating-manual",
+                "/physical-health",
+                "/productive",
+                "/psychic-weight",
+                "/sharpen-the-saw",
+                "/slow",
+                "/switch"
+            ],
+            "last_modified": "2025-08-13T07:43:13-07:00",
+            "markdown_path": "_d/habits.md",
+            "outgoing_links": [
+                "/be-proactive"
+            ],
+            "redirect_url": "",
+            "title": "Atomic habits - How to add and remove habits",
+            "url": "/d/habits"
+        },
+        "/d/management_interviews": {
+            "description": "FACEBOOK MANAGEMENT INTERVIEWING 101\n\n",
+            "doc_size": 34000,
+            "file_path": "_site/d/management_interviews.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/management_interviews.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Types of interviews ",
+            "url": "/d/management_interviews"
+        },
+        "/d/resistance": {
+            "description": "Stop. Take an ice cold shower right now. You didn’t, did you? Trust me, even if you tried, you wouldn’t. Before you turned on the water, you’d have this irrational fear of stepping in and you wouldn’t do it. The force that stops you is the resistance. The resistance is the personification of the force that stops you from doing the important. The resistance lies, telling us things are hard when they are not. The resistance adds suffering when there is minimal pain and that confuses us, stopping us from doing things which give us the most value, joy and positive identity. The resistance is the enemy of progress.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/d/resistance.html",
+            "incoming_links": [
+                "/activation",
+                "/books-that-defined-me",
+                "/enemy",
+                "/energy",
+                "/energy-abundance",
+                "/fail",
+                "/first-things-first",
+                "/frog",
+                "/gap-year",
+                "/gap-year-igor",
+                "/mental-pain",
+                "/parkinson",
+                "/productive",
+                "/psychic-shadows",
+                "/psychic-weight",
+                "/slow",
+                "/timeoff"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/resistance.md",
+            "outgoing_links": [
+                "/addiction",
+                "/d/habits",
+                "/end-in-mind",
+                "/frog",
+                "/gtd",
+                "/magic",
+                "/mental-pain"
+            ],
+            "redirect_url": "",
+            "title": "Resistance: Why you can't make yourself take an ice cold shower",
+            "url": "/d/resistance"
+        },
+        "/d/where-have-all-the-bugs-gone": {
+            "description": "I’ve been a software developer since 2001, and back then we used to have lots of bugs. Nowadays, it seems we don’t have bugs, and I’ve wondered why. Now we have tickets which we get from our systems running in production, but that’s quite different. What’s going on?\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/d/where-have-all-the-bugs-gone.html",
+            "incoming_links": [],
+            "last_modified": "2022-08-13T08:09:48-07:00",
+            "markdown_path": "_d/where-have-all-the-bugs-gone.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Where have all the bugs gone",
+            "url": "/d/where-have-all-the-bugs-gone"
+        },
+        "/dad": {
+            "description": "\n\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/dad.html",
+            "incoming_links": [],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/gpt-dad.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Being a Good Dad - A Guide to Fatherhood",
+            "url": "/dad"
+        },
+        "/death": {
+            "description": "Bad news, you’re dying, so is everyone else. Good news, if we didn’t die we’d run out of resources, and our kids would be screwed. Bad news, our health care system is optimized for keeping you alive, not for maximizing the enjoyable time you have on earth. Good news, knowing is half the battle - armed with this knowledge you can decide how you want to die, which is ultimately how you want to live.\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/death.html",
+            "incoming_links": [
+                "/chasing-daylight",
+                "/covid",
+                "/elder",
+                "/gap-year-igor",
+                "/last-year",
+                "/mortality-software",
+                "/psychic-weight"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/on-being-mortal.md",
+            "outgoing_links": [
+                "/last-year"
+            ],
+            "redirect_url": "",
+            "title": "On being Mortal - Guess what? You're dying",
+            "url": "/death"
+        },
+        "/debug": {
+            "description": "Igor's Blog",
+            "doc_size": 23000,
+            "file_path": "_site/debug.html",
+            "incoming_links": [],
+            "last_modified": "2025-03-16T16:15:36+00:00",
+            "markdown_path": "debug.html",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Debug the page",
+            "url": "/debug"
+        },
+        "/decisive": {
+            "description": "Decisions are hard because we have Narrow Framing, Confirmation Bias, Short Term Emotion and Overconfidence. We can overcome this by Widening our Options, Reality-Testing our Assumptions, Attaining Distance before Deciding and Preparing to Be Wrong.\n\n",
+            "doc_size": 45000,
+            "file_path": "_site/decisive.html",
+            "incoming_links": [
+                "/being-a-great-manager",
+                "/coaching",
+                "/gap-year",
+                "/job-hunt-stress",
+                "/manager-book",
+                "/pride",
+                "/random-idea",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2025-06-20T08:56:14-07:00",
+            "markdown_path": "_posts/2019-09-21-decisive.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Decision making 201",
+            "url": "/decisive"
+        },
+        "/defi": {
+            "description": "Finance has existed for as long as civilization. And like most things before the Internet age was based on the trust of centralized law and authority (like banks and governments). Decentralized Finance (DeFi) is the movement that asks could we perform our financial transaction with out centralized trust. Finance has evolved many instruments to meet the needs of civilization, all of which are based on trust (store of value, currency, loans), de-fi will search for equivalences of each of these.\n\n",
+            "doc_size": 31000,
+            "file_path": "_site/defi.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/defi.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Decentralized Finance",
+            "url": "/defi"
+        },
+        "/delegate": {
+            "description": "At some point you need to scale out, and that’s called delegation! Stewardship delegation is the form of delegation where the responsibility for the delegated task is transferred to the delegatee. Stewardship delegation requires upfront effort, but results in long-term effectiveness. For stewardship delegation, you need agreement on the following 5 things: The desired results, the operating parameters, the available resources, the measurement system, and the consequences of their stewardship.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/delegate.html",
+            "incoming_links": [
+                "/first-things-first"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/delegate.md",
+            "outgoing_links": [
+                "/first-things-first"
+            ],
+            "redirect_url": "",
+            "title": "Stewardship Delegation 101",
+            "url": "/delegate"
+        },
+        "/depression": {
+            "description": "When you’re depressed you don’t think you’ve put on a gray veil - seeing the world through the haze of a bad mood. You think that a veil has been taken away. The veil of happiness, and you believe you’re seeing the world as it truly is: alone, petrifying, and painful. But the truth lies. The depressed say “No one loves me.” And you say, “I love you, your wife loves you, your mother loves you.” and the depressed ignore you. The depressed will continue, “None of this matters, we’re just going to die in the end.” To which you have to say, “That’s true, but I think right now should focus on what to have for breakfast.”\n\n",
+            "doc_size": 22000,
+            "file_path": "_site/depression.html",
+            "incoming_links": [
+                "/anger",
+                "/caring",
+                "/mental-pain",
+                "/mood"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_d/depression.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/anxiety",
+                "/caring",
+                "/eulogy",
+                "/getting-to-yes-with-yourself",
+                "/gtd",
+                "/idle",
+                "/insecure",
+                "/insomnia",
+                "/physical-health",
+                "/psychic-shadows",
+                "/psychic-weight",
+                "/shame",
+                "/siy",
+                "/sustainable-work",
+                "/voices"
+            ],
+            "redirect_url": "",
+            "title": "Depression is the opposite of vitality",
+            "url": "/depression"
+        },
+        "/design": {
+            "description": "Software is measured in two dimensions: use cases (end user behavior) and malleability. End user behavior is the delivery of use cases, while malleability is the ease with which the software can modify the existing use cases, or add new ones. Software malleability is the evaluation function for an architecture. Malleability is the more important of these dimensions because over time there will be far more changes to the software then the original use case (e.g. the cost of maintenance far exceeds the software writing cost). A key property of software architecture is it’s obvious there is one place to make changes, and where that place is.\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/design.html",
+            "incoming_links": [
+                "/amazon",
+                "/d/2017-11-04-clean-architecture",
+                "/system-design",
+                "/testing"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/design.md",
+            "outgoing_links": [
+                "/d/2017-11-04-clean-architecture",
+                "/td/cloud-first-applications",
+                "/testing"
+            ],
+            "redirect_url": "",
+            "title": "Software Design and Architecture",
+            "url": "/design"
+        },
+        "/diet": {
+            "description": "Diet dominates weight, as weight is simple arithmetic -“calories in” minus “calories out”. Weight is essential because it reduces the effort required to do physical activities, and because it reduces the risk of many diseases. Exercise, while critical to energy, is mostly a red herring for weight loss. A great way to see this is comparing what you eat to physical Activity. A side of fries adds 500 calories to your day, but running for 30 minutes only burns 300 calories.\n\n",
+            "doc_size": 19000,
+            "file_path": "_site/diet.html",
+            "incoming_links": [
+                "/42",
+                "/operating-manual",
+                "/physical-health",
+                "/retire",
+                "/sharpen-the-saw",
+                "/timeoff"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/diet.md",
+            "outgoing_links": [
+                "/physical-health",
+                "/terzepatide"
+            ],
+            "redirect_url": "",
+            "title": "Diet",
+            "url": "/diet"
+        },
+        "/dip": {
+            "description": "New things start fun, but once the new wears off they are hard because of the Dip. The Dip is the long slog between starting and mastery. Unlike Dips, cul-de-sacs are places you can put in a lot of energy and nothing will come of it. You need to quit cul-de-sacs and lean into dips. Much of our failure comes from being distracted by tasks we don’t have the guts to quit. Winners quit all the time. They quit the right stuff, so their energy can be saved to cross the Dip.\n\n",
+            "doc_size": 32000,
+            "file_path": "_site/dip.html",
+            "incoming_links": [
+                "/d/2016-2-15-Seth-Godin-Notes",
+                "/end-in-mind",
+                "/gtd",
+                "/manager-book",
+                "/parkinson",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/2017-11-12-thedip.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "The Dip - Should you fold or double down",
+            "url": "/dip"
+        },
+        "/docker": {
+            "description": "Docker has 2 values, isolation and repeatable setup. Here are my notes\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/docker.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/docker_.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Docker tools",
+            "url": "/docker"
+        },
+        "/e1": {
+            "description": "\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/e1.html",
+            "incoming_links": [],
+            "last_modified": "2025-05-25T10:09:41-07:00",
+            "markdown_path": "_d/e1.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Igor's Identity",
+            "url": "/e1"
+        },
+        "/elder": {
+            "description": "Midlife has a marketing problem, it’s always followed by the word crisis. Honestly, for good reason: Midlife is the chapter of your life where the things you and society value decline. E.g. you’re getting weaker and dumber. Embrace and optimize for this reality or suffer. Luckily there is a good formula here: both to embrace it, and to find new strengths to focus on.\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/elder.html",
+            "incoming_links": [
+                "/40yo",
+                "/addiction"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/elder.md",
+            "outgoing_links": [
+                "/40yo",
+                "/death",
+                "/end-in-mind",
+                "/essentialism"
+            ],
+            "redirect_url": "",
+            "title": "Wrinkles and Wisdom: A Guide to Aging Like Fine Wine (Not Milk)",
+            "url": "/elder"
+        },
+        "/emotional-health": {
+            "description": "Emotionally healthy folks can let it go, empathize with others, and most importantly, sleep well at night. Just like physically healthy folks do physical practices, like walking daily, stretching, biking, there are also emotional practices. Here are the ones I’ve been exploring.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/emotional-health.html",
+            "incoming_links": [
+                "/essentialism",
+                "/gap-year-igor",
+                "/irl",
+                "/mania",
+                "/mind-at-work",
+                "/operating-manual",
+                "/process-journal",
+                "/sharpen-the-saw",
+                "/siy",
+                "/sublime"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/emotional-health-hold.md",
+            "outgoing_links": [
+                "/sharpen-the-saw",
+                "/siy",
+                "/sublime",
+                "/voices"
+            ],
+            "redirect_url": "",
+            "title": "Emotional Health Practices",
+            "url": "/emotional-health"
+        },
+        "/emotions": {
+            "description": "Ever notice how emotions are like that one friend who shows up uninvited and fucks up your perfectly planned party? Sometimes they bring cake and make everything awesome, other times they’re drunk and knocking over your carefully arranged furniture while screaming “YOLO!” Well, here’s your guide to that emotional party crasher living rent-free in your head, because let’s face it - they’re not moving out anytime soon.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/emotions.html",
+            "incoming_links": [
+                "/slow"
+            ],
+            "last_modified": "2024-12-25T17:59:13-08:00",
+            "markdown_path": "_d/emotions.md",
+            "outgoing_links": [
+                "/anger",
+                "/be-proactive",
+                "/curious",
+                "/happy",
+                "/joy",
+                "/regrets",
+                "/shame",
+                "/sublime"
+            ],
+            "redirect_url": "",
+            "title": "Emotions",
+            "url": "/emotions"
+        },
+        "/enable": {
+            "description": "Imagine the place you do your best work. Andy Matuschak defined this, and as someone who aspires to effectiveness, I fell in love with the concept. As a techie who loves efficiency, I also set about building my own. From Andy: An enabling environment significantly expands its participants’ capacity to do things they find meaningful and important. This blog is the consumption environment for mine. When we talk about an AI enabling environment the key is not to figure out how you can prompt the AI, but how the AI can prompt you.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/enable.html",
+            "incoming_links": [
+                "/chow",
+                "/writing"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/enabling-environment.md",
+            "outgoing_links": [
+                "/podcast",
+                "/switch",
+                "/vim",
+                "/vim-for-writing",
+                "/writing"
+            ],
+            "redirect_url": "",
+            "title": "Enabling Environment",
+            "url": "/enable"
+        },
+        "/end-in-mind": {
+            "description": "All things are created twice, once in the design phase, and then again in the implementation phase. If you don’t perform the first creation, someone else will. At the extreme, imagine your eulogy, that’s the end too.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/end-in-mind.html",
+            "incoming_links": [
+                "/4dx",
+                "/7-habits",
+                "/affirmations",
+                "/content-audience",
+                "/d/resistance",
+                "/elder",
+                "/gap-year-igor",
+                "/manager-book",
+                "/productive",
+                "/siy"
+            ],
+            "last_modified": "2025-05-12T09:24:30-07:00",
+            "markdown_path": "_d/7h-c2.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/dip",
+                "/essentialism",
+                "/eulogy",
+                "/joy",
+                "/touching"
+            ],
+            "redirect_url": "",
+            "title": "Begin with the end in mind",
+            "url": "/end-in-mind"
+        },
+        "/enemy": {
+            "description": "Fear, Arrogance, Authority, and Apathy are the four enemies of satisfaction as described in Don Juan’s teachings.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/enemy.html",
+            "incoming_links": [
+                "/chapters",
+                "/retire"
+            ],
+            "last_modified": "2023-12-30T11:50:51-08:00",
+            "markdown_path": "_d/don-juan2.md",
+            "outgoing_links": [
+                "/d/resistance",
+                "/pride"
+            ],
+            "redirect_url": "",
+            "title": "Four enemies",
+            "url": "/enemy"
+        },
+        "/energy": {
+            "description": "We often say we don’t have time, but usually we mean we don’t have energy. That’s great news because time is finite, and monotonically decreasing. Energy, by contrast, is dynamic. Activities and experiences can create and destroy energy. What’s amazing to me is how going to the gym can be energy positive.\n\n",
+            "doc_size": 19000,
+            "file_path": "_site/energy.html",
+            "incoming_links": [
+                "/balance",
+                "/energy-abundance",
+                "/mood",
+                "/productive",
+                "/slow",
+                "/timeoff"
+            ],
+            "last_modified": "2025-08-24T10:29:13-07:00",
+            "markdown_path": "_d/energy.md",
+            "outgoing_links": [
+                "/activation",
+                "/d/resistance",
+                "/joy",
+                "/mania",
+                "/mood",
+                "/operating-manual",
+                "/productive",
+                "/sleep",
+                "/slow",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Control your Energy",
+            "url": "/energy"
+        },
+        "/energy-abundance": {
+            "description": "I got asked that the other day, and thought, boy, there is a lot here, I need to think this through. Here’s my thinking so far.\n\n",
+            "doc_size": 27000,
+            "file_path": "_site/energy-abundance.html",
+            "incoming_links": [
+                "/life-as-business"
+            ],
+            "last_modified": "2025-03-08T09:45:30-08:00",
+            "markdown_path": "_d/energy-abundance.md",
+            "outgoing_links": [
+                "/activation",
+                "/balance",
+                "/d/habits",
+                "/d/resistance",
+                "/energy",
+                "/operating-manual",
+                "/strategy",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Igor - how do you have the time to complete all the stuff on your blog?",
+            "url": "/energy-abundance"
+        },
+        "/essentialism": {
+            "description": "Essentialism is deciding what goes on your todo list, not how many things you can cross off. Being an essentialist means you say ‘I choose to’ not ‘I have to’, ‘Only a few things matter’, not ‘all things matter’ and ‘I will do one thing’, not ‘I will do both’. The essential questions are ‘How do I know when I’m done?’, ‘If I didn’t own this, would I buy it?’, ‘If I didn’t have this opportunity what would I do to acquire it?’\n\n",
+            "doc_size": 41000,
+            "file_path": "_site/essentialism.html",
+            "incoming_links": [
+                "/4dx",
+                "/affirmations",
+                "/balance",
+                "/be-proactive",
+                "/books-that-defined-me",
+                "/elder",
+                "/end-in-mind",
+                "/first-things-first",
+                "/frog",
+                "/gtd",
+                "/overload",
+                "/parkinson",
+                "/partner-trouble",
+                "/timeoff",
+                "/timeoff-2022-07"
+            ],
+            "last_modified": "2025-08-24T09:03:19-07:00",
+            "markdown_path": "_posts/2015-11-28-essentialism.md",
+            "outgoing_links": [
+                "/curious",
+                "/emotional-health",
+                "/insomnia",
+                "/physical-health"
+            ],
+            "redirect_url": "",
+            "title": "Essentialism",
+            "url": "/essentialism"
+        },
+        "/eulogy": {
+            "description": "Wearing a silly hat or his zany $8 TEMU crazy shirt, his trusty folding bike at his feet, and using a purple fountain pen, Igor “Began with the end in mind” with the “important but not urgent” task of penning this eulogy, likely starting at 5am. Igor wanted this life, so he wrote it, he reviewed it, he lived it, and he worked with his family, friends, and multitude of mentors, to adjust and tweak it.\n\n",
+            "doc_size": 37000,
+            "file_path": "_site/eulogy.html",
+            "incoming_links": [
+                "/7-habits",
+                "/ai-journal",
+                "/balance",
+                "/bmy",
+                "/depression",
+                "/end-in-mind",
+                "/frog",
+                "/happy",
+                "/hobby",
+                "/irl",
+                "/joy",
+                "/operating-manual",
+                "/retire",
+                "/timeoff",
+                "/todo_enjoy",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2025-09-07T16:11:35-07:00",
+            "markdown_path": "_posts/2020-04-01-Igor-Eulogy.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/The-Genesis-Node",
+                "/balloon",
+                "/being-a-great-manager",
+                "/bike",
+                "/cache",
+                "/human-meetings",
+                "/ig66/687",
+                "/ig66/717",
+                "/ig66/732",
+                "/job",
+                "/kettlebell",
+                "/magic",
+                "/physical-health",
+                "/process-journal",
+                "/siy",
+                "/terzepatide",
+                "/tesla",
+                "/tori",
+                "/toysfortots"
+            ],
+            "redirect_url": "",
+            "title": "Igor's Eulogy - How I want to live",
+            "url": "/eulogy"
+        },
+        "/facebook": {
+            "description": "Facebook is a ‘social’ company; we value 1-1 time, fostering trust-driven relationships, and providing skip-level escalations and support. Here are my notes on Facebook\n\n",
+            "doc_size": 34000,
+            "file_path": "_site/facebook.html",
+            "incoming_links": [
+                "/manager-book-appendix"
+            ],
+            "last_modified": "2025-09-08T09:26:52-07:00",
+            "markdown_path": "_d/facebook.md",
+            "outgoing_links": [
+                "/covid"
+            ],
+            "redirect_url": "",
+            "title": "My thoughts on Facebook",
+            "url": "/facebook"
+        },
+        "/fail": {
+            "description": "Failure is not an option; it’s a necessity. Failure is not a person but an event. You can’t grow without failing, and you can’t beat yourself up over it. The key is to analyze without judgment, understand why it failed, and learn to move on.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/fail.html",
+            "incoming_links": [],
+            "last_modified": "2025-03-11T05:04:46-07:00",
+            "markdown_path": "_d/fail2.md",
+            "outgoing_links": [
+                "/anxiety",
+                "/anxiety-management",
+                "/coe",
+                "/d/resistance"
+            ],
+            "redirect_url": "",
+            "title": "Failure is not an option, it is a necessity",
+            "url": "/fail"
+        },
+        "/first-things-first": {
+            "description": "The key to effective management, is allocating energy through the lens of importance rather than urgency. E.g, ask yourself what one thing could you do that if you did on a regular basis, would make a tremendous positive difference in your life? Lemme guess, it’s important, but not urgent so you’re not doing it. These are my insights based on the 7 habits Chapter 3.\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/first-things-first.html",
+            "incoming_links": [
+                "/4dx",
+                "/7-habits",
+                "/90days",
+                "/affirmations",
+                "/delegate",
+                "/frog"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_d/7h-c3.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/addiction",
+                "/d/resistance",
+                "/delegate",
+                "/essentialism",
+                "/frog",
+                "/gtd",
+                "/switch",
+                "/upstream"
+            ],
+            "redirect_url": "",
+            "title": "First things first",
+            "url": "/first-things-first"
+        },
+        "/first-understand": {
+            "description": "Imagine going to the eye doctor. After hearing your complaint he takes off his glasses and hands them to you.\n“Put these on,” he says. “I’ve worn this pair of glasses for ten years now and they’ve really helped me. I have an extra pair at home; you can wear these.” So you put them on, but it only makes the problem worse. “This is terrible!” you exclaim. “I can’t see a thing!” “Well, what’s wrong?” he asks. “They work great for me. Try harder.” “I am trying,” you insist. “Everything is a blur.” “Well, what’s the matter with you? Think positively.” “Okay. I positively can’t see a thing.” “Boy, are you ungrateful!” he chides. “And after all I’ve done to help you!”\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/first-understand.html",
+            "incoming_links": [
+                "/7-habits",
+                "/advice",
+                "/affirmations",
+                "/class-act",
+                "/curious",
+                "/negotiate",
+                "/sell",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2021-10-30T10:02:27-07:00",
+            "markdown_path": "_d/7h-c5.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/coaching",
+                "/curious",
+                "/ig66/587",
+                "/prompts",
+                "/siy"
+            ],
+            "redirect_url": "",
+            "title": "Seek first to understand, then to be understood",
+            "url": "/first-understand"
+        },
+        "/frog": {
+            "description": "Procrastination is the success killer, a powerful manifestations of the resistance. Eat that frog gives 21 antidotes to procrastination. These are my re-framing of the concepts into my favorite mental models. Chapter titles come from the book.\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/frog.html",
+            "incoming_links": [
+                "/anxiety-management",
+                "/be-proactive",
+                "/d/resistance",
+                "/first-things-first",
+                "/gtd",
+                "/idle",
+                "/mental-pain",
+                "/parkinson",
+                "/productive",
+                "/psychic-weight",
+                "/timeoff",
+                "/timeoff-2020-03"
+            ],
+            "last_modified": "2025-04-02T21:53:46-07:00",
+            "markdown_path": "_d/frog.md",
+            "outgoing_links": [
+                "/Immutable-Laws-Of-Hard",
+                "/be-proactive",
+                "/d/resistance",
+                "/essentialism",
+                "/eulogy",
+                "/first-things-first",
+                "/gtd"
+            ],
+            "redirect_url": "",
+            "title": "Eat that frog",
+            "url": "/frog"
+        },
+        "/gap-year": {
+            "description": "Here’s a thought that’ll push back your retirement: Would you rather work until 65 and retire comfortably, or take a full year off at 50, return to work, and retire at 67 with less money? If you’re like most people, you immediately think “that’s crazy - I can’t afford to lose a year’s income!” But what if I told you that gap year might be the best investment you’ll ever make?\n\n",
+            "doc_size": 33000,
+            "file_path": "_site/gap-year.html",
+            "incoming_links": [
+                "/gap-year-igor",
+                "/monetize",
+                "/retire",
+                "/stock-concentration"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/gap-year.md",
+            "outgoing_links": [
+                "/chapters",
+                "/d/resistance",
+                "/decisive",
+                "/gap-year-igor",
+                "/money",
+                "/partner-trouble",
+                "/physical-health",
+                "/retire",
+                "/timeoff",
+                "/y24",
+                "/y25"
+            ],
+            "redirect_url": "",
+            "title": "The Gap Year Paradox: Why Taking a Year Off at 50 beats retiring at 65",
+            "url": "/gap-year"
+        },
+        "/gap-year-igor": {
+            "description": "Done right, a gap year isn’t a year off; it’s a year on — intentional investment in health, relationships, and mastery while you still have the capital to invest. Think of it as pursuing a PhD in Life Optimization, making deposits that compound for decades. A gap year is one of those uncharted spaces—seductive when discussed longingly over a beer, terrifying when holding a resignation letter outside your boss’s office. Early maps warned: “HC SVNT DRACONES.” Here be dragons. I’m mapping them in real time: the Scarcity Dragon whispering you can’t afford it, the Entropy Dragon promising you’ll decay without structure, and the Squander Dragon insisting you’ll waste this precious opportunity. But these dragons guard treasure — the chance to invest in what truly matters while you still have the capacity to do so. This is the map of how to tame them.\n\n",
+            "doc_size": 68000,
+            "file_path": "_site/gap-year-igor.html",
+            "incoming_links": [
+                "/gap-year",
+                "/stock-concentration",
+                "/timeoff-2025-08"
+            ],
+            "last_modified": "2025-09-06T12:12:27-07:00",
+            "markdown_path": "_d/igor-gap-year.md",
+            "outgoing_links": [
+                "/affirmations",
+                "/chapters",
+                "/chasing-daylight",
+                "/d/resistance",
+                "/death",
+                "/emotional-health",
+                "/end-in-mind",
+                "/gap-year",
+                "/kettlebell",
+                "/money",
+                "/parkinson",
+                "/physical-health",
+                "/retire",
+                "/siy",
+                "/sleep",
+                "/stock-concentration",
+                "/structure",
+                "/sustainable-work",
+                "/timeoff",
+                "/tori",
+                "/y24",
+                "/y25"
+            ],
+            "redirect_url": "",
+            "title": "Will Igor Take a Gap Year? Wrestling with Dragons and Dreams",
+            "url": "/gap-year-igor"
+        },
+        "/genai-talk": {
+            "description": "Generative AI (GenAI) is taking the world by storm, and it takes a new mindset to make use of it as a programmer. A good mental model of GenAI is interns!\n\n",
+            "doc_size": 38000,
+            "file_path": "_site/genai-talk.html",
+            "incoming_links": [
+                "/ai-journal"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/genai-talk.md",
+            "outgoing_links": [
+                "/ai-testing"
+            ],
+            "redirect_url": "",
+            "title": "Your new interns - GenAI for fun and profit",
+            "url": "/genai-talk"
+        },
+        "/getting-to-yes-with-yourself": {
+            "description": "Before you can negotiate with others, you need to be in sync with yourself. This book applies the negotiating principles to yourself. It’s an awkward application of the model, but this book is filled with good concepts regardless.\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/getting-to-yes-with-yourself.html",
+            "incoming_links": [
+                "/books-that-defined-me",
+                "/depression"
+            ],
+            "last_modified": "2025-08-24T09:03:19-07:00",
+            "markdown_path": "_posts/2015-12-23-getting-to-yes-with-yourself.md",
+            "outgoing_links": [
+                "/curious",
+                "/negotiate",
+                "/welcome-to-holland"
+            ],
+            "redirect_url": "",
+            "title": "Getting to yes with yourself",
+            "url": "/getting-to-yes-with-yourself"
+        },
+        "/goals": {
+            "description": "Goals are critical, there are multiple goal systems and they have consequences. They are mechanisms to deliver without micro management.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/goals.html",
+            "incoming_links": [
+                "/4dx",
+                "/parkinson"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/goals.md",
+            "outgoing_links": [
+                "/4dx",
+                "/mortality-software"
+            ],
+            "redirect_url": "",
+            "title": "Goals - How to define and ensure success",
+            "url": "/goals"
+        },
+        "/google-photos": {
+            "description": "I like having a blog, but honestly it’s faster to write it in google photos as that has a better WYSWIG viewer. But, I don’t get features like search, or previews, which matters to me. I also don’t trust Google not to break photos in the future. Of course exporting is a PITA, here are some hacks to export and make it into my blog format. NOTE: There is an API to extract photos, but it doesn’t include the text (which I like to have, as recall WYSWIG editor)\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/google-photos.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/scrape_google_photo_album.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Accessing Google Photos",
+            "url": "/google-photos"
+        },
+        "/gpt": {
+            "description": "Just like the search bar in google fills in what you’re typing when you say “Where can I ge .. “ GPT3 complete strings as well. Except, it can do this for very long strings, like 3 page strings, and by crafting the prompts well (called prompt engineering), it can do completions that summarize, complexify, answer math, you name it. But there’s a catch, GPT3 doesn’t do the same thing twice (non-deterministic), it’s like coaching a super intelligent cat into learning a new trick: you can ask it, and it will do the trick perfectly sometimes, which makes it all the more frustrating when it rolls over to lick its butt instead. You know the problem is not that it can’t but that it won’t(From Gwern).\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/gpt.html",
+            "incoming_links": [
+                "/ai-art",
+                "/ai-journal",
+                "/ml",
+                "/nlp"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/gpt2.md",
+            "outgoing_links": [
+                "/nurture",
+                "/rapport"
+            ],
+            "redirect_url": "",
+            "title": "GPT3 and language models",
+            "url": "/gpt"
+        },
+        "/gpt-7h": {
+            "description": "\n\n\n",
+            "doc_size": 32000,
+            "file_path": "_site/gpt-7h.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T10:48:49-07:00",
+            "markdown_path": "_d/gpt-7-habits.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "LEADER: Another Take on the 7 Habits",
+            "url": "/gpt-7h"
+        },
+        "/gpt-system-design": {
+            "description": "\n\n\n",
+            "doc_size": 28000,
+            "file_path": "_site/gpt-system-design.html",
+            "incoming_links": [],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/gpt-system-design-interview.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "System Design Interviews- The SHINE Method",
+            "url": "/gpt-system-design"
+        },
+        "/grammerly": {
+            "description": "\n\n",
+            "doc_size": 12000,
+            "file_path": "_site/grammerly.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-24T09:03:19-07:00",
+            "markdown_path": "_td/grammerly.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Grammarly",
+            "url": "/grammerly"
+        },
+        "/graph": {
+            "description": "Igor's Blog",
+            "doc_size": 13000,
+            "file_path": "_site/graph.html",
+            "incoming_links": [],
+            "last_modified": "2025-07-26T10:43:02-07:00",
+            "markdown_path": "graph.html",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Graph",
+            "url": "/graph"
+        },
+        "/grateful": {
+            "description": "Gratefulness exercises work - here’s somethings to help.\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/grateful.html",
+            "incoming_links": [
+                "/appreciate",
+                "/process-journal"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/grateful2.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Gratefulness",
+            "url": "/grateful"
+        },
+        "/groupchat": {
+            "description": "Imagine a group chat as the bustling kitchen of a high-end restaurant. In place of culinary masterpieces, it’s ideas, gossip, and insights that are cooked up, seasoned, and served. Just as a great dinner party brings together eclectic personalities for a memorable evening, a stellar group chat assembles diverse voices for ongoing, vibrant conversations. Basically Sriram’s awesome post on great group chats.\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/groupchat.html",
+            "incoming_links": [],
+            "last_modified": "2024-06-08T09:10:34-07:00",
+            "markdown_path": "_d/groupchat.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "My favorite group chats - the forever dinner party",
+            "url": "/groupchat"
+        },
+        "/gtd": {
+            "description": "Getting Things Done (GTD) is a model based on David Allen’s book of the same name. It’s a deep dive into Habit 3 - first things first, with some lite weight Habit 2 - begin with the end in mind, mixed in for good measure. By using GTD religiously you can have a drastic reduction in stress and procrastination.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/gtd.html",
+            "incoming_links": [
+                "/4dx",
+                "/books-that-defined-me",
+                "/d/resistance",
+                "/depression",
+                "/first-things-first",
+                "/frog",
+                "/parkinson",
+                "/psychic-weight"
+            ],
+            "last_modified": "2025-07-20T19:13:52-07:00",
+            "markdown_path": "_d/gtd.md",
+            "outgoing_links": [
+                "/anxiety",
+                "/chop",
+                "/dip",
+                "/essentialism",
+                "/frog",
+                "/idle",
+                "/outsourcing",
+                "/psychic-weight"
+            ],
+            "redirect_url": "",
+            "title": "Getting things done",
+            "url": "/gtd"
+        },
+        "/happy": {
+            "description": "Happy is a 5 letter word that many use as the answer to what is the point of life. The follow up question of “How can you be happy” is usually followed by a blank stare, so here’s my study of the subject.\n\n",
+            "doc_size": 27000,
+            "file_path": "_site/happy.html",
+            "incoming_links": [
+                "/chasing-daylight",
+                "/emotions",
+                "/hobby",
+                "/joy",
+                "/mood",
+                "/siy",
+                "/timeoff",
+                "/timeoff-2020-12",
+                "/timeoff-2021-12",
+                "/timeoff-2022-02",
+                "/timeoff-2022-07",
+                "/timeoff-2022-11",
+                "/timeoff-2022-12",
+                "/timeoff-2023-04",
+                "/timeoff-2023-08",
+                "/timeoff-2023-11",
+                "/timeoff-2024-08",
+                "/timeoff-2025-08"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_posts/2017-04-12-happy.md",
+            "outgoing_links": [
+                "/addiction",
+                "/anxiety",
+                "/curious",
+                "/eulogy",
+                "/idle",
+                "/joy",
+                "/mental-pain",
+                "/moments",
+                "/mood",
+                "/negotiate"
+            ],
+            "redirect_url": "",
+            "title": "Happy",
+            "url": "/happy"
+        },
+        "/heath-class-act": {
+            "description": "\n\n\n",
+            "doc_size": 32000,
+            "file_path": "_site/heath-class-act.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/class-act-4.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Being a Class Act - How to Stand Out with Grace and Dignity in Any Situation",
+            "url": "/heath-class-act"
+        },
+        "/hobby": {
+            "description": "Some days thinking about work makes me stressed, thinking of my family makes me resentful, and I don’t want to feel like a sloth feeding my addictions to TikTok, and doom scrolling. Those days, I’m grateful for my hobbies. This post gives you reasons to find a hobby and teaches you the attributes in an ideal hobby: Being accessible, Supporting mastery, Reinforcing your identity, and building relationships.\n\n",
+            "doc_size": 19000,
+            "file_path": "_site/hobby.html",
+            "incoming_links": [
+                "/operating-manual",
+                "/retire"
+            ],
+            "last_modified": "2022-05-09T07:53:36-07:00",
+            "markdown_path": "_d/hobby.md",
+            "outgoing_links": [
+                "/d/habits",
+                "/eulogy",
+                "/happy",
+                "/joy",
+                "/magic"
+            ],
+            "redirect_url": "",
+            "title": "Why a Engineering Manager masquerades as a magician on the weekends",
+            "url": "/hobby"
+        },
+        "/human-meetings": {
+            "description": "Having our emotions heard is a fundamental human need. The modern world denies this need, but that doesn’t make the need go away. More than denying the need, society gives, and encourages, us to suppress our emotions. Feelings meetings stand in opposition. They exist to allow us, no, encourage us, to fulfill our fundamental need of expressing emotion.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/human-meetings.html",
+            "incoming_links": [
+                "/being-a-great-manager",
+                "/eulogy",
+                "/job"
+            ],
+            "last_modified": "2022-03-20T09:40:39-07:00",
+            "markdown_path": "_d/human-meeting.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Feelings/Human Meetings",
+            "url": "/human-meetings"
+        },
+        "/humans-are-underrated": {
+            "description": "As robots become better then humans at most things, what roles will be left for humans? What skills are required for those roles? Empathizing, collaborating, leading,and building relationships.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/humans-are-underrated.html",
+            "incoming_links": [
+                "/books-that-defined-me",
+                "/chop"
+            ],
+            "last_modified": "2025-03-01T18:25:15-08:00",
+            "markdown_path": "_posts/2015-12-12-humans-are-underrated.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Humans are underrated",
+            "url": "/humans-are-underrated"
+        },
+        "/husband": {
+            "description": "\n\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/husband.html",
+            "incoming_links": [],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/good_husband-4.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Being a GOOD Husband",
+            "url": "/husband"
+        },
+        "/hyper-personal": {
+            "description": "Useful writing tells people (including, possibly most importantly you) something true and important that they didn’t already know in a way that leaves no doubt. And Everyone is different. So how to do both?\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/hyper-personal.html",
+            "incoming_links": [
+                "/ai-journal"
+            ],
+            "last_modified": "2025-09-08T09:31:34-07:00",
+            "markdown_path": "_d/hyper-personal.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Hyper Personalization",
+            "url": "/hyper-personal"
+        },
+        "/idle": {
+            "description": "Waiting in line at the grocery store, sitting in an Uber, pooping - in these invisible times, we execute our idle loop. We spend a lot of time in our idle loop, and it can either increase our energy or drain it. By being aware of and then modifying how we spend our idle loop we can improve our lives one poop at a time.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/idle.html",
+            "incoming_links": [
+                "/anxiety",
+                "/depression",
+                "/gtd",
+                "/happy",
+                "/psychic-weight"
+            ],
+            "last_modified": "2025-09-06T12:06:16-07:00",
+            "markdown_path": "_d/idle-loop.md",
+            "outgoing_links": [
+                "/addiction",
+                "/be-proactive",
+                "/d/habits",
+                "/frog",
+                "/magic",
+                "/mental-pain",
+                "/mind-monsters",
+                "/psychic-shadows",
+                "/siy"
+            ],
+            "redirect_url": "",
+            "title": "Your idle loop",
+            "url": "/idle"
+        },
+        "/insecure": {
+            "description": "We all get it. Imposter syndrome, which includes shame\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/insecure.html",
+            "incoming_links": [
+                "/90days",
+                "/affirmations",
+                "/depression",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2024-09-14T14:16:00-07:00",
+            "markdown_path": "_d/imposter.md",
+            "outgoing_links": [
+                "/coaching",
+                "/shame"
+            ],
+            "redirect_url": "",
+            "title": "Insecurity and Imposter Syndrome",
+            "url": "/insecure"
+        },
+        "/insomnia": {
+            "description": "Insomnia controls you, instead of you controlling your sleep. If you want advice on how to deal with insomnia, do NOT ask a person who hasn’t slept in two nights. Instead, ask someone who’s had insomnia several times, and has a checklist on how to respond when insomnia flares up. By the way, I’ve never actually taken this advice, but maybe writing it down will make it more likely that I’ll take it in the future.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/insomnia.html",
+            "incoming_links": [
+                "/activation",
+                "/depression",
+                "/essentialism",
+                "/physical-health",
+                "/sleep"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_d/2016-2-11-Insomnia.md",
+            "outgoing_links": [
+                "/sleep"
+            ],
+            "redirect_url": "",
+            "title": "What I should do when I can't sleep",
+            "url": "/insomnia"
+        },
+        "/interviewsarehard": {
+            "description": "I’ve been hard on myself these last few months as I haven’t made a lot of progress on my habits or goals. Reflecting, that shouldn’t be a surprise as I’ve been putting a tonne of energy into my job hunt. Here is a reminder of the effort required, which will aid setting realistic expectations during the job hunt.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/interviewsarehard.html",
+            "incoming_links": [
+                "/job-hunt-stress"
+            ],
+            "last_modified": "2023-12-17T18:53:39+00:00",
+            "markdown_path": "_posts/2016-11-26-interviewsarehard.markdown",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Be easy on yourself, job hunts are hard",
+            "url": "/interviewsarehard"
+        },
+        "/ios-accessibility": {
+            "description": "iOS has some great accessibility features which allow hands-free and eye-less control of the device. Here they are.\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/ios-accessibility.html",
+            "incoming_links": [],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_td/ios-accessibility.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "iOS Accessibility",
+            "url": "/ios-accessibility"
+        },
+        "/irl": {
+            "description": "I started writing a technical blog to help me remember the many things I explore. One day, I realized I’ve got a real life too. Here’s a place I can remember the many things I explore IRL (In real Life)\n\n",
+            "doc_size": 79000,
+            "file_path": "_site/irl.html",
+            "incoming_links": [
+                "/physical-health",
+                "/td/ios-nomad"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_td/irl.md",
+            "outgoing_links": [
+                "/bike",
+                "/emotional-health",
+                "/eulogy",
+                "/physical-health",
+                "/siy",
+                "/tesla"
+            ],
+            "redirect_url": "",
+            "title": "In Real Life Diary",
+            "url": "/irl"
+        },
+        "/job": {
+            "description": "In my dream job, I learn the customer and business needs and focus the team on delivering them in a sustainable manner. Simultaneously, I help team members grow, develop our culture, and build valuable tech. When talking to others I prefer a couch to a table, and when I need a break, you might see me juggling, practicing magic, or riding my folding bike—often in the office.\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/job.html",
+            "incoming_links": [
+                "/bmy",
+                "/eulogy",
+                "/job-hunt-stress",
+                "/manager-book",
+                "/manager-book-appendix"
+            ],
+            "last_modified": "2025-09-07T05:53:44-07:00",
+            "markdown_path": "_posts/2018-06-7-my-perfect-job.md",
+            "outgoing_links": [
+                "/being-a-great-manager",
+                "/cache",
+                "/coaching",
+                "/human-meetings",
+                "/manager-book",
+                "/moments-at-work",
+                "/software-leadership-roles"
+            ],
+            "redirect_url": "",
+            "title": "My Dream Job",
+            "url": "/job"
+        },
+        "/job-hunt-stress": {
+            "description": "Job hunts are stressful, and my goal for job hunts is getting the job I want while minimizing my stress. The stress comes from: lack of confidence, being rushed, not having options, disappointing others and the pressure from current job responsibilities. By expecting and mitigating each of these stressors I greatly reduce stress during my job hunt.\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/job-hunt-stress.html",
+            "incoming_links": [
+                "/bmy",
+                "/comp",
+                "/manager-book",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2025-08-24T09:03:19-07:00",
+            "markdown_path": "_posts/2017-02-17-job-hunt-stress.md",
+            "outgoing_links": [
+                "/bmy",
+                "/comp",
+                "/decisive",
+                "/interviewsarehard",
+                "/job",
+                "/system-design"
+            ],
+            "redirect_url": "",
+            "title": "Reducing job hunt stress",
+            "url": "/job-hunt-stress"
+        },
+        "/joy": {
+            "description": "If you could have one superpower, what would it be? At 46, you’d think I’d have a quick answer, but the usual ideas—flying, invisibility, stopping time—felt childish. Probably the setting: a circle of 9-17-year-olds, breaking the ice, sharing their wished-for superpowers. As my mind scrambled, a mild panic set in. Nothing surfaced—until a bit of my eulogy came to me: Igor lived to see eyes go wide and mouths gape with wonder. He loved when strangers were drawn in against their objections, when a kid in meltdown, or an adult weighed down by life, forgot their troubles. Relief washed over me, I knew my answer. The super power I wished for:  bringing joy to others.\n\n",
+            "doc_size": 31000,
+            "file_path": "_site/joy.html",
+            "incoming_links": [
+                "/affirmations",
+                "/balloon",
+                "/build-bubble-bike",
+                "/emotions",
+                "/end-in-mind",
+                "/energy",
+                "/happy",
+                "/hobby",
+                "/magic",
+                "/mood",
+                "/sublime"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/joy.md",
+            "outgoing_links": [
+                "/balloon",
+                "/build-bubble-bike",
+                "/eulogy",
+                "/happy",
+                "/ig66/621",
+                "/like-switch",
+                "/magic",
+                "/smilebox",
+                "/touching"
+            ],
+            "redirect_url": "",
+            "title": "Smiles, Joy and Wonder",
+            "url": "/joy"
+        },
+        "/kayak": {
+            "description": "When Meta announced they’d start charging $15 a day for parking, my first thought was: “Are you kidding me? Fifteen dollars a DAY?” I couldn’t believe they were suddenly gouging us employees for something that had been free for years. The math was infuriating - that’s $75 a week, $300 a month, nearly $4,000 a year just to park my damn car at work!\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/kayak.html",
+            "incoming_links": [],
+            "last_modified": "2025-07-29T19:19:42-07:00",
+            "markdown_path": "_d/kayak-commuting.md",
+            "outgoing_links": [
+                "/tesla"
+            ],
+            "redirect_url": "",
+            "title": "Kayak Commuting: From Parking Fees to Paddling Adventures",
+            "url": "/kayak"
+        },
+        "/kettlebell": {
+            "description": "There’s no way I’m swinging that thing between my legs; I’m going to kill my back. When I started working out with a trainer in 2020, they tried to get me to do a kettlebell swing, and I was like, no way. Then they spent 3 weeks teaching me Turkish Get-Ups (TGUs), which I absolutely loved. Then I read Simple and Sinister, and now I’ve achieved Timeless Simple and do heavy clubs instead of halos.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/kettlebell.html",
+            "incoming_links": [
+                "/eulogy",
+                "/gap-year-igor",
+                "/physical-health",
+                "/timeoff",
+                "/untangled",
+                "/y24"
+            ],
+            "last_modified": "2025-07-20T19:13:52-07:00",
+            "markdown_path": "_d/bells.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Kettlebells - A rock with a handle",
+            "url": "/kettlebell"
+        },
+        "/last-year": {
+            "description": "Bad news, you’ve got a last year on earth. Good news, if you’re lucky you’ll accept that “grand father dies, father dies, son dies” is the best blessing you can have (imagine a different ordering). If you’re luckier, you’ll have age appropriate health right up till that last year, or even better that last few months. If you’re even luckier you’ll have the strength to do what you want in your personal “centenarian Olympics”.\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/last-year.html",
+            "incoming_links": [
+                "/42",
+                "/chasing-daylight",
+                "/death",
+                "/retire",
+                "/y24",
+                "/y25"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/last-year.md",
+            "outgoing_links": [
+                "/chasing-daylight",
+                "/death"
+            ],
+            "redirect_url": "",
+            "title": "Kick the Bucket List: Your Guide to an Epic Last Year on Earth",
+            "url": "/last-year"
+        },
+        "/laws-of-power": {
+            "description": "A very cynical book about the laws of power. Probably worth a read in case you want to better understand the dark side.\n\n",
+            "doc_size": 47000,
+            "file_path": "_site/laws-of-power.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/48-laws-of-power.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "The 48 laws of power",
+            "url": "/laws-of-power"
+        },
+        "/learn-code": {
+            "description": "Coding is way easier then people think. Here’s some pointers.\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/learn-code.html",
+            "incoming_links": [],
+            "last_modified": "2025-05-11T06:34:37-07:00",
+            "markdown_path": "_d/learn-to-code.md",
+            "outgoing_links": [
+                "/ig66/602"
+            ],
+            "redirect_url": "",
+            "title": "Learn to Code",
+            "url": "/learn-code"
+        },
+        "/life-as-business": {
+            "description": "Businesses exist to generate profit. But what about life? Can we manage our lives with the same intentionality and clarity businesses use to thrive? Viewing life through this lens helps prioritize what truly matters, sustain energy, and deepen relationships. Just as businesses carefully manage resources, we can intentionally allocate our energy, nurture meaningful assets, and measure success beyond mere productivity. Life operates on two intertwined currencies—Life Value (the true worth of our existence) and energy (the operational fuel). These currencies are generated and sustained by carefully nurturing life assets such as relationships, health, skills, and character.\n\n",
+            "doc_size": 36000,
+            "file_path": "_site/life-as-business.html",
+            "incoming_links": [],
+            "last_modified": "2025-03-06T06:43:27-08:00",
+            "markdown_path": "_d/life-as-business.md",
+            "outgoing_links": [
+                "/balance",
+                "/d/habits",
+                "/energy-abundance",
+                "/operating-manual",
+                "/strategy",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Life as a Business: Managing Energy, Assets, and Satisfaction",
+            "url": "/life-as-business"
+        },
+        "/like-switch": {
+            "description": "The like switch, written by an ex-FBI agent, goes into detail on how to make friends and influence people in a much more modern form.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/like-switch.html",
+            "incoming_links": [
+                "/joy"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/the-like-switch.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "How to build rapport and set people at ease",
+            "url": "/like-switch"
+        },
+        "/lonely": {
+            "description": "Loneliness is not simply being alone. It’s a painful emotional experience that comes from feeling disconnected—from others, from the world, or sometimes from yourself. It is the sense that the connections you need—emotional, social, or even spiritual—are missing or inadequate. And it’s not just a personal feeling— 36% of americans feel lonely “frequently”, “almost all the time” or “all the time” in the prior four weeks. 61% of young people aged 18-25 and 51% of mothers with young children reported these miserable degrees of loneliness. The cost of loneliness is high: it is linked to early mortality and a wide array of serious physical and emotional problems, including depression, anxiety, heart disease, substance abuse, and domestic abuse.\n\n",
+            "doc_size": 43000,
+            "file_path": "_site/lonely.html",
+            "incoming_links": [
+                "/mental-pain"
+            ],
+            "last_modified": "2025-07-13T06:56:50-07:00",
+            "markdown_path": "_d/lonely.md",
+            "outgoing_links": [
+                "/chapters"
+            ],
+            "redirect_url": "",
+            "title": "Loneliness",
+            "url": "/lonely"
+        },
+        "/magic": {
+            "description": "Being a dealer of smiles and wonder is a priority in my life, and magic is my instrument. This post details my history and some highlights\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/magic.html",
+            "incoming_links": [
+                "/d/resistance",
+                "/eulogy",
+                "/hobby",
+                "/idle",
+                "/joy",
+                "/operating-manual",
+                "/timeoff",
+                "/touching"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_posts/2016-04-21-magical-memories.md",
+            "outgoing_links": [
+                "/joy"
+            ],
+            "redirect_url": "",
+            "title": "Magical memories",
+            "url": "/magic"
+        },
+        "/manager-book": {
+            "description": "Being an engineering manager is hard. Supporting people well is harder. Lessons are hard earned and should be cherished. This post is designed to make explicit, and improve behaviors and practices. It reminds me how to behave and encourages my own continuous improvement.\n\n",
+            "doc_size": 169000,
+            "file_path": "_site/manager-book.html",
+            "incoming_links": [
+                "/amazon",
+                "/being-a-great-manager",
+                "/coaching",
+                "/content-audience",
+                "/job",
+                "/manager-book-appendix",
+                "/retire",
+                "/software-leadership-roles",
+                "/tribe",
+                "/work-satisfaction",
+                "/y24",
+                "/y25"
+            ],
+            "last_modified": "2025-08-14T20:41:27-07:00",
+            "markdown_path": "_posts/2016-03-03-the-manager-book-2.md",
+            "outgoing_links": [
+                "/22",
+                "/90days",
+                "/being-a-great-manager",
+                "/books-that-defined-me",
+                "/coaching",
+                "/coe",
+                "/comp",
+                "/d/habits",
+                "/decisive",
+                "/dip",
+                "/end-in-mind",
+                "/job",
+                "/job-hunt-stress",
+                "/manager-book-appendix",
+                "/ml",
+                "/moments-at-work",
+                "/overload",
+                "/pride",
+                "/product",
+                "/prompts",
+                "/remote-work",
+                "/software-leadership-roles",
+                "/static/idvorkin-linked-in-feedback-lastest.pdf",
+                "/strategy",
+                "/td/cloud-first-applications",
+                "/testing",
+                "/what-makes-a-leader",
+                "/work-satisfaction",
+                "/writing"
+            ],
+            "redirect_url": "",
+            "title": "How to EM: Be the manager everyone wants",
+            "url": "/manager-book"
+        },
+        "/manager-book-appendix": {
+            "description": "A hodgepodge of additional resources for the manager book.\n\n",
+            "doc_size": 34000,
+            "file_path": "_site/manager-book-appendix.html",
+            "incoming_links": [
+                "/manager-book",
+                "/operating-manual"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/manager-book-appendix.md",
+            "outgoing_links": [
+                "/amazon",
+                "/books-that-defined-me",
+                "/facebook",
+                "/job",
+                "/manager-book",
+                "/parkinson",
+                "/writing"
+            ],
+            "redirect_url": "",
+            "title": "Manager Book Appendix",
+            "url": "/manager-book-appendix"
+        },
+        "/mania": {
+            "description": "The words that follow, I pray will never be my own – What pains me most is I see how crystal clear my illness was in the beginning and how I was surrounded by so much love. So, so many family and friends were desperately trying to intervene, and I spurned them and then reacted despicably. I am so, so sorry. I failed as a husband, a father, a brother, friend, and as a kind human being. It is a hard pill to swallow that I was the Evil one. Why did I fail? Me. My brain. My manic self. I wanted more than anything to prove them wrong. That I could do this. But I couldn’t. You can learn a lot, but you can’t unlearn bipolar disorder. I desperately wanted to believe that bipolar disorder wasn’t real and that I could stop living in fear of it. That all the doubters were wrong (from a friend with bipolar).\n\n",
+            "doc_size": 22000,
+            "file_path": "_site/mania.html",
+            "incoming_links": [
+                "/energy",
+                "/mood"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/mania.md",
+            "outgoing_links": [
+                "/emotional-health",
+                "/tesla"
+            ],
+            "redirect_url": "",
+            "title": "Mania: It's like a free cocaine drip",
+            "url": "/mania"
+        },
+        "/media-edit": {
+            "description": "Lets play with media editing. So far I’ve liked luma fusion for post:\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/media-edit.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/media-edit.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Media Editing",
+            "url": "/media-edit"
+        },
+        "/mental-pain": {
+            "description": "Pain is in the brain as they say, which is especially true for mental pains. Pain isn’t the enemy though, pain is a signal. The pain system, when working properly draws our attention to a problem so that we can deal with it. However, our pain can evolve into unecassary suffering, be phantom pain, meaning it is being applied when it should not be, or chronic pain, which flares up even though it is no longer providing value.\n\n",
+            "doc_size": 37000,
+            "file_path": "_site/mental-pain.html",
+            "incoming_links": [
+                "/addiction",
+                "/ai-journal",
+                "/anger",
+                "/anxiety-management",
+                "/curious",
+                "/d/resistance",
+                "/happy",
+                "/idle",
+                "/mind-monsters",
+                "/physical-pain",
+                "/psychic-shadows",
+                "/psychic-weight",
+                "/regrets",
+                "/shame",
+                "/timeoff-2020-12",
+                "/work-satisfaction",
+                "/y24"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/mental-pain.md",
+            "outgoing_links": [
+                "/addiction",
+                "/d/resistance",
+                "/depression",
+                "/frog",
+                "/lonely",
+                "/physical-pain",
+                "/pride"
+            ],
+            "redirect_url": "",
+            "title": "The thoughts that pain us",
+            "url": "/mental-pain"
+        },
+        "/mermaid": {
+            "description": "Lets try d2\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/mermaid.html",
+            "incoming_links": [],
+            "last_modified": "2023-12-17T18:49:14+00:00",
+            "markdown_path": "_d/mermaid.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Playing w/Mermaid",
+            "url": "/mermaid"
+        },
+        "/micro-economics": {
+            "description": "Supply, demands and markets, oh my!\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/micro-economics.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/micro-economics.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Micro Economics",
+            "url": "/micro-economics"
+        },
+        "/mind-at-work": {
+            "description": "I have a problem, an addiction, an addiction so detrimental to quality of life, it should be described as a disease. This disease is not being present. There are many symptoms of the disease, but today I’m going to talk about my most frequent symptoms, my body at home, but my mind at work.\n\n",
+            "doc_size": 19000,
+            "file_path": "_site/mind-at-work.html",
+            "incoming_links": [
+                "/addiction",
+                "/timeoff",
+                "/timeoff-2022-11",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/2016-2-10-body-at-home-mind-at-work.md",
+            "outgoing_links": [
+                "/addiction",
+                "/d/habits",
+                "/emotional-health",
+                "/psychic-weight",
+                "/timeoff",
+                "/work-satisfaction"
+            ],
+            "redirect_url": "",
+            "title": "Body at home, mind at work",
+            "url": "/mind-at-work"
+        },
+        "/mind-monsters": {
+            "description": "Last night I was having trouble sleeping so I plopped down on the couch to watch infomercials. The infomercial I picked was religious in nature, and was talking about mind monsters.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/mind-monsters.html",
+            "incoming_links": [
+                "/being-a-great-manager",
+                "/idle",
+                "/psychic-shadows",
+                "/psychic-weight",
+                "/siy"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_d/2015-11-11-mind-monsters.md",
+            "outgoing_links": [
+                "/mental-pain",
+                "/pride",
+                "/siy",
+                "/voices"
+            ],
+            "redirect_url": "",
+            "title": "Mind monsters",
+            "url": "/mind-monsters"
+        },
+        "/ml": {
+            "description": "It used to be that software was eating the world. Now ML is eating software. ML is computers building algorithms by only looking at the data. This is powerful as the computer can find patterns in large data sets that are too complicated for humans to find and express via algorithms. In human terms programming is following a check list which someone else provided (E.g. bake a cake by following the recipe). ML is following your intuition. (E.g making a stir fry from stuff in the fridge). As with ML, you can’t articulate your intuition as it built through countless experiences, but it mostly works (E.g. you never put a banana in your stirfry).\n\n",
+            "doc_size": 52000,
+            "file_path": "_site/ml.html",
+            "incoming_links": [
+                "/ai",
+                "/manager-book",
+                "/td/stats"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/machine-learning.md",
+            "outgoing_links": [
+                "/ai-testing",
+                "/gpt",
+                "/nlp",
+                "/pandas",
+                "/recommend"
+            ],
+            "redirect_url": "",
+            "title": "Machine learning for regular programmers.",
+            "url": "/ml"
+        },
+        "/modal": {
+            "description": "Modal seems like a system custom built for ML, giving it a shot\n\n",
+            "doc_size": 12000,
+            "file_path": "_site/modal.html",
+            "incoming_links": [],
+            "last_modified": "2023-05-21T06:34:43-07:00",
+            "markdown_path": "_td/modal.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Modal - A tool to play with ML",
+            "url": "/modal"
+        },
+        "/moments": {
+            "description": "Take a few seconds to close your eyes and think back on an important memory. In that moment, did you feel a sense of elevation? Did you experience insight? Have a sense of pride? Make a connection? In the power of moments, the attributes of powerful moments are understood so that they can be better engineered.\n\n",
+            "doc_size": 26000,
+            "file_path": "_site/moments.html",
+            "incoming_links": [
+                "/balance",
+                "/chasing-daylight",
+                "/happy",
+                "/moments-at-work",
+                "/random-idea",
+                "/timeoff-2022-12",
+                "/timeoff-2023-04",
+                "/timeoff-2023-08",
+                "/timeoff-2023-11",
+                "/timeoff-2024-08",
+                "/timeoff-2025-08"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/2018-04-03-moments.md",
+            "outgoing_links": [
+                "/moments-at-work"
+            ],
+            "redirect_url": "",
+            "title": "Engineering Moments",
+            "url": "/moments"
+        },
+        "/moments-at-work": {
+            "description": "Of all the places we spend our time, work is the one that dominates. However, when we look back on our lives, work is often the thing we remember least. Why? Because we remember our lives through peak moments, and there are few of those, especially positive peak moments, at work. Luckily, peak moments can be created and managers can be taught how to create them. This post explores opportunities and techniques to create these moments.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/moments-at-work.html",
+            "incoming_links": [
+                "/being-a-great-manager",
+                "/job",
+                "/manager-book",
+                "/moments",
+                "/random-idea"
+            ],
+            "last_modified": "2020-06-17T07:39:28-07:00",
+            "markdown_path": "_posts/2018-04-09-moments-at-work.md",
+            "outgoing_links": [
+                "/coaching",
+                "/moments"
+            ],
+            "redirect_url": "",
+            "title": "Moments at work",
+            "url": "/moments-at-work"
+        },
+        "/monetize": {
+            "description": "Let’s talk money. Whether you’re a content creator dreaming of YouTube riches or a brand trying to understand the advertising landscape, this guide breaks down the reality of monetization - spoiler alert: it’s harder than you think, but not impossible.\n\n",
+            "doc_size": 28000,
+            "file_path": "_site/monetize.html",
+            "incoming_links": [
+                "/advertising",
+                "/content-creation"
+            ],
+            "last_modified": "2025-07-30T10:50:40-07:00",
+            "markdown_path": "_d/monetization.md",
+            "outgoing_links": [
+                "/advertising",
+                "/content-creation",
+                "/gap-year",
+                "/retire"
+            ],
+            "redirect_url": "",
+            "title": "Creator Monetization: From Dreams to Reality",
+            "url": "/monetize"
+        },
+        "/money": {
+            "description": "Most of the tax information on the web is a mess. It’s confusing as it tries to apply to everyone, with varying situations, and is often written by non-engineers for non-engineers. I think my tax situation is common to people who have been in software engineering companies for most of their careers, and here are my notes.\n\n",
+            "doc_size": 67000,
+            "file_path": "_site/money.html",
+            "incoming_links": [
+                "/gap-year",
+                "/gap-year-igor",
+                "/operating-manual",
+                "/parkinson",
+                "/retire",
+                "/stock-concentration",
+                "/timeoff-2020-03"
+            ],
+            "last_modified": "2025-08-25T10:19:14-07:00",
+            "markdown_path": "_d/taxes.md",
+            "outgoing_links": [
+                "/parkinson",
+                "/partner-trouble",
+                "/stock-concentration"
+            ],
+            "redirect_url": "",
+            "title": "Tax and Saving",
+            "url": "/money"
+        },
+        "/mood": {
+            "description": "Let me ask an easy question: “How are you feeling?”. How long did it take you to answer? Less then a second? Impressive. Now a harder question “What makes you say that?”, or even harder “How do you ‘compute’ how are you feeling?” What is going on? Human’s have a super fast heuristic called mood giving them an insant assessment of their sujective reality. Mood is critical to understand as it drives our behaviors, has an outsized influence on our subjective experience, can be in conflict to our pursuit of happiness, and most importantly has several bugs which can be exploited by the resistance and other bad actors.\n\n",
+            "doc_size": 28000,
+            "file_path": "_site/mood.html",
+            "incoming_links": [
+                "/energy",
+                "/happy",
+                "/timeoff-2024-08",
+                "/timeoff-2025-08"
+            ],
+            "last_modified": "2025-08-24T10:29:13-07:00",
+            "markdown_path": "_d/mood.md",
+            "outgoing_links": [
+                "/anger",
+                "/depression",
+                "/energy",
+                "/happy",
+                "/joy",
+                "/mania",
+                "/regrets",
+                "/slow"
+            ],
+            "redirect_url": "",
+            "title": "Mood - Our blazing fast heuristic for subjective experience",
+            "url": "/mood"
+        },
+        "/mortality-software": {
+            "description": "Mortality is a word avoided. But, earlier or later, we all face it. Life is finite, time is limited. Mortality software helps us understand and then ensure we are using our precious time well. It helps us create our future and reflect on our past. Why must we do this? Because A)”first you’ve lost a day and the day becomes a week and a week becomes a month and before you know it you’ve lost a year” and B) “At the point change is obvious it’s too late - it means the need for change is long since past”\n\n",
+            "doc_size": 32000,
+            "file_path": "_site/mortality-software.html",
+            "incoming_links": [
+                "/balance",
+                "/goals"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/2018-04-29-mortality-software.md",
+            "outgoing_links": [
+                "/affirmations",
+                "/checklist",
+                "/death"
+            ],
+            "redirect_url": "",
+            "title": "Time.ltd - Mortality Software",
+            "url": "/mortality-software"
+        },
+        "/negotiate": {
+            "description": "Negotiation is the heart of collaboration. It is what makes conflict potentially meaningful and productive for all parties. Getting To Yes is the seminal book on negotiation. It’s the deep dive into win win or no deal and seek first to understand. The formal, be hard on problems and soft on people, then focus on the desired outcomes not the positions, next get more options on the table, and make sure you measure by objective criteria - lastly know your BATNA.Several years later a new book came out by a hostage negotiator. Instead of being analytic focus, it’s all about influencing the elephant.\n\n",
+            "doc_size": 22000,
+            "file_path": "_site/negotiate.html",
+            "incoming_links": [
+                "/curious",
+                "/getting-to-yes-with-yourself",
+                "/happy",
+                "/productive",
+                "/regrets",
+                "/sell",
+                "/synergize",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/gty.md",
+            "outgoing_links": [
+                "/curious",
+                "/first-understand",
+                "/switch",
+                "/win-win"
+            ],
+            "redirect_url": "",
+            "title": "Getting to yes",
+            "url": "/negotiate"
+        },
+        "/neovim": {
+            "description": "Long ago a fork from vim emerged. Neovim! I avoided it for a long time, but when Bram (the inventor of vim) died, I decided it was time to switch. Now that I’ve sucked up the 20-40 hours in the conversion, I’m thrilled I did. Turns out all the “kids” have been using and developing on neovim. This results in 1, good tools, and nice best practices.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/neovim.html",
+            "incoming_links": [
+                "/vim"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/nvim.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Neovim",
+            "url": "/neovim"
+        },
+        "/new-skills": {
+            "description": "Magic, Kettle Bells, Public Speaking - every skill I’ve acquired follows the same immutable laws. These laws govern how we learn, progress, and master new abilities. It’s possible these laws don’t apply to you, but I doubt it.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/new-skills.html",
+            "incoming_links": [
+                "/about",
+                "/operating-manual",
+                "/physical-health",
+                "/physical-pain",
+                "/recent"
+            ],
+            "last_modified": "2025-02-09T09:50:07-08:00",
+            "markdown_path": "_d/laws-of-new-skills.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "The Immutable Laws of New Skills",
+            "url": "/new-skills"
+        },
+        "/nlp": {
+            "description": "My explorations of NLP, mostly using my corpus of journal entries and other writing. My intent is twofold: 1) learning about NLP and sentiment analysis 2) finding latent meaning in my writing, ideally to help me better understand my own psychological processes. I’ve had much more success with the former than the latter.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/nlp.html",
+            "incoming_links": [
+                "/ml",
+                "/tools"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_td/nlp.md",
+            "outgoing_links": [
+                "/gpt"
+            ],
+            "redirect_url": "",
+            "title": "Sentiment Analysis and NLP",
+            "url": "/nlp"
+        },
+        "/nurture": {
+            "description": "In “Nurturing Love,” the Heath Brothers distill the wisdom of renowned relationship experts Drs. John and Julie Gottman into a concise and actionable guide for couples seeking to strengthen their relationships. Using their signature storytelling approach and evidence-based insights, the Heath Brothers create an engaging and accessible roadmap to the Gottman Method.\n\n",
+            "doc_size": 42000,
+            "file_path": "_site/nurture.html",
+            "incoming_links": [
+                "/gpt"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/nurture.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "NURTURE: The Gottman Method",
+            "url": "/nurture"
+        },
+        "/operating-manual": {
+            "description": "I’ve learned what I like, how I want to spend my energy, and how I want to be thinking about my life. I’ve learned my roles, reasonable expectations, and healthy ways to operate given my personality, behaviors, and frequently occurring situations. This post is a summary of those learnings - an operating manual if you will, reminding me how to think about, respond to and behave, so I can operate at maximum effectiveness and efficiency. Super important: You don’t rise to the level of your goals, you fall to the level of your systems.\n\n",
+            "doc_size": 39000,
+            "file_path": "_site/operating-manual.html",
+            "incoming_links": [
+                "/energy",
+                "/energy-abundance",
+                "/life-as-business"
+            ],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/operating-manual-2.md",
+            "outgoing_links": [
+                "/Immutable-Laws-Of-Hard",
+                "/affirmations",
+                "/anxiety",
+                "/bike",
+                "/blueprint",
+                "/covid",
+                "/curious",
+                "/d/habits",
+                "/diet",
+                "/emotional-health",
+                "/eulogy",
+                "/hobby",
+                "/ig66/587",
+                "/magic",
+                "/manager-book-appendix",
+                "/money",
+                "/new-skills",
+                "/parkinson",
+                "/physical-health",
+                "/process-journal",
+                "/siy",
+                "/sleight-of-mouth",
+                "/strengths",
+                "/tesla",
+                "/timeoff-2022-07",
+                "/todo_enjoy",
+                "/tony",
+                "/voices",
+                "/writing"
+            ],
+            "redirect_url": "",
+            "title": "Igor the operating manual",
+            "url": "/operating-manual"
+        },
+        "/osx": {
+            "description": "\nCheck out my [Mac install script](https://github.com/idvorkin/Settings/blob/master/mac/install.sh) for automated setup of my Mac environment.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/osx.html",
+            "incoming_links": [
+                "/tools"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/osx.md",
+            "outgoing_links": [
+                "/screencast"
+            ],
+            "redirect_url": "",
+            "title": "Igor's OSX Tools",
+            "url": "/osx"
+        },
+        "/outsourcing": {
+            "description": "Time is my precious resource - I have a limited number of hours in my life, and once I’ve used them, I never get them back. However, I can preserve my time by outsourcing activities that don’t have high enough return on investment. This post reminds me to outsource by enumerating my position on outsourcing, and the things I have outsourced.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/outsourcing.html",
+            "incoming_links": [
+                "/gtd"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_d/2015-11-18-Outsourcing.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "On outsourcing",
+            "url": "/outsourcing"
+        },
+        "/overload": {
+            "description": "We all get to a point where our boss (*) gives us more work than we can handle. This spikes our anxiety and we’ll end up in one of three conversations: 1) I’ve got too much on my plate, 2) I can’t get this done; 3) I quit. Which do you think your boss would rather have?\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/overload.html",
+            "incoming_links": [
+                "/manager-book",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_d/handling-overwork.md",
+            "outgoing_links": [
+                "/anxiety",
+                "/essentialism",
+                "/sustainable-work"
+            ],
+            "redirect_url": "",
+            "title": "Dealing with Task Overload",
+            "url": "/overload"
+        },
+        "/pandas": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/pandas.html",
+            "incoming_links": [
+                "/ml",
+                "/timeoff-2020-12"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/pandas-tutorial.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Pandas + IPython + Jupyter Incantations",
+            "url": "/pandas"
+        },
+        "/parkinson": {
+            "description": "Work expands to fill the resources available. The more you make, the more you spend. Stuff accumulates to fill the available storage space. And if you want something done, give it to a busy person.\n\n",
+            "doc_size": 22000,
+            "file_path": "_site/parkinson.html",
+            "incoming_links": [
+                "/balance",
+                "/gap-year-igor",
+                "/manager-book-appendix",
+                "/money",
+                "/operating-manual",
+                "/timeoff"
+            ],
+            "last_modified": "2025-03-11T06:05:27-07:00",
+            "markdown_path": "_d/resource-paradox.md",
+            "outgoing_links": [
+                "/amazon",
+                "/d/resistance",
+                "/dip",
+                "/essentialism",
+                "/frog",
+                "/goals",
+                "/gtd",
+                "/money",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Parkinson's Law: The Paradox of Plenty",
+            "url": "/parkinson"
+        },
+        "/partner-trouble": {
+            "description": "There are two types of couples in the world. Those who fight, and those you don’t know. Your life partnership is the most impactful relationship you have, are you investing sufficiently?\n\n",
+            "doc_size": 30000,
+            "file_path": "_site/partner-trouble.html",
+            "incoming_links": [
+                "/gap-year",
+                "/money",
+                "/tori"
+            ],
+            "last_modified": "2025-08-31T06:37:16-07:00",
+            "markdown_path": "_d/partner-trouble.md",
+            "outgoing_links": [
+                "/essentialism"
+            ],
+            "redirect_url": "",
+            "title": "Double Trouble: From Lust to Love to Lost",
+            "url": "/partner-trouble"
+        },
+        "/physical-health": {
+            "description": "Physical health is not bought, it’s rented and rent is due every day. Physical health is the basis of energy, and thus the source of success, and a key saw to sharpen. Physical health requires weight, fitness, and sleep.\n\n",
+            "doc_size": 28000,
+            "file_path": "_site/physical-health.html",
+            "incoming_links": [
+                "/42",
+                "/depression",
+                "/diet",
+                "/essentialism",
+                "/eulogy",
+                "/gap-year",
+                "/gap-year-igor",
+                "/irl",
+                "/operating-manual",
+                "/retire",
+                "/sharpen-the-saw",
+                "/tech-health-toys"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_posts/2017-10-07-physical-health.md",
+            "outgoing_links": [
+                "/d/habits",
+                "/diet",
+                "/insomnia",
+                "/irl",
+                "/kettlebell",
+                "/new-skills",
+                "/sharpen-the-saw",
+                "/sleep",
+                "/tech-health-toys",
+                "/terzepatide"
+            ],
+            "redirect_url": "",
+            "title": "Physical Health Lets you look good in your jeans, and wrestle bears",
+            "url": "/physical-health"
+        },
+        "/physical-pain": {
+            "description": "Physical pain is a universal experience, yet it remains one of the least understood aspects of human health. Whether it’s a stubbed toe or chronic back pain, understanding the nature of physical pain can empower us to manage it effectively and improve our quality of life.\n\n",
+            "doc_size": 31000,
+            "file_path": "_site/physical-pain.html",
+            "incoming_links": [
+                "/mental-pain"
+            ],
+            "last_modified": "2025-09-01T09:31:18-07:00",
+            "markdown_path": "_d/physical-pain.md",
+            "outgoing_links": [
+                "/coe",
+                "/mental-pain",
+                "/new-skills"
+            ],
+            "redirect_url": "",
+            "title": "Physical Pain: Understanding and Managing It",
+            "url": "/physical-pain"
+        },
+        "/podcast": {
+            "description": "To my amazement, I listen to podcasts. I think they’re pretty interesting, here are my notes on them.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/podcast.html",
+            "incoming_links": [
+                "/enable"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/podcast.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Podcasting",
+            "url": "/podcast"
+        },
+        "/pride": {
+            "description": "“That is Pride Fucking With You” is the only scene I can quote from any movie. It’s a powerful scene, and the advice is timeless. Two thousand years ago when a Roman emperor had a victory parade, he was required to have a slave standing behind him holding his helmet high in the air and whispering continuously: “You are mortal. You are mortal”. Pride and ego are serious foes that must be kept in check.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/pride.html",
+            "incoming_links": [
+                "/being-a-great-manager",
+                "/coaching",
+                "/comp",
+                "/enemy",
+                "/manager-book",
+                "/mental-pain",
+                "/mind-monsters",
+                "/psychic-weight"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_posts/2018-01-01-fuck-pride.md",
+            "outgoing_links": [
+                "/decisive"
+            ],
+            "redirect_url": "",
+            "title": "That is pride fucking with you",
+            "url": "/pride"
+        },
+        "/process-journal": {
+            "description": "I’ve been doing daily stream of consciousness journaling since 2011, writing over a million words. Here’s how I think about processing and analyzing my journal entries. While I don’t always achieve this perfectly, this represents my aspirational process that I strive towards.\n\n",
+            "doc_size": 19000,
+            "file_path": "_site/process-journal.html",
+            "incoming_links": [
+                "/chop",
+                "/eulogy",
+                "/operating-manual",
+                "/y24",
+                "/y25"
+            ],
+            "last_modified": "2025-03-02T19:25:33-08:00",
+            "markdown_path": "_d/process-journal.md",
+            "outgoing_links": [
+                "/affirmations",
+                "/be-proactive",
+                "/chop",
+                "/emotional-health",
+                "/grateful",
+                "/psychic-weight"
+            ],
+            "redirect_url": "",
+            "title": "Daily Journaling: From Psychic Diarrhea to Polished Turds",
+            "url": "/process-journal"
+        },
+        "/produce-consume": {
+            "description": "Remember when you finished binge-watching that entire series and felt… empty? Now remember the last time you made something — anything — even if it sucked. Which memory makes you smile? Yeah, me too. We live in the golden age of consumption, where infinite content is one thumb-swipe away, yet we’re more anxious and less satisfied than ever. Here’s the thing: you’re not meant to be a consumer. You’re meant to be a producer.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/produce-consume.html",
+            "incoming_links": [
+                "/slow"
+            ],
+            "last_modified": "2025-08-24T08:45:07-07:00",
+            "markdown_path": "_d/produce-consume.md",
+            "outgoing_links": [
+                "/activation"
+            ],
+            "redirect_url": "",
+            "title": "The Producer's Paradox: Why Creating Beats Consuming Every Time",
+            "url": "/produce-consume"
+        },
+        "/product": {
+            "description": "From creating a vision that inspires to laying out the strategies to get there, product work requires a range of skills—and a good dose of creativity. Putting the puzzle pieces together is essential to creating a product that appeals to its customers. With the right combination of vision, strategy, product design and execution, anyone can create something truly remarkable. With this in mind, let’s start building the future we want to create!\n\n",
+            "doc_size": 38000,
+            "file_path": "_site/product.html",
+            "incoming_links": [
+                "/manager-book"
+            ],
+            "last_modified": "2024-10-27T17:27:54-07:00",
+            "markdown_path": "_d/product.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Building products",
+            "url": "/product"
+        },
+        "/productive": {
+            "description": "At the core of balance, energy, wlb, habits is being productive.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/productive.html",
+            "incoming_links": [
+                "/balance",
+                "/energy",
+                "/timeoff-2022-02"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/productive2.md",
+            "outgoing_links": [
+                "/addiction",
+                "/anxiety",
+                "/balance",
+                "/d/habits",
+                "/d/resistance",
+                "/end-in-mind",
+                "/energy",
+                "/frog",
+                "/negotiate",
+                "/switch"
+            ],
+            "redirect_url": "",
+            "title": "Productive",
+            "url": "/productive"
+        },
+        "/prompts": {
+            "description": "A prompt will kick start a great conversation, a great insight, and a great relationship. Here are lots of prompts. For fun, pick a prompt at random and ask it to someone else, or answer it yourself. However, it takes a lot of trust and vulnerability to answer these questions, so make sure the person feels very empowered to not answer a question.\n\n",
+            "doc_size": 45000,
+            "file_path": "_site/prompts.html",
+            "incoming_links": [
+                "/coaching",
+                "/first-understand",
+                "/manager-book"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/prompt.md",
+            "outgoing_links": [
+                "/coaching"
+            ],
+            "redirect_url": "",
+            "title": "Prompts, your guide to starting a conversation",
+            "url": "/prompts"
+        },
+        "/psychic-shadows": {
+            "description": "It’s 3am and your brain is replaying that conversation from six months ago, calculating worst-case financial scenarios, or imagining all the ways you’ll fail at that thing you haven’t even started yet. These aren’t just ordinary worries - they’re psychic shadows, specific thought patterns that loop endlessly in your mind like restless spirits. If you’re tired of being held hostage by these ruminating thoughts, this post will teach you how to craft personalized spells that banish each shadow the moment it appears, giving you a mystical toolkit for transforming persistent mental loops into single-word circuit breakers that actually work.\n\n",
+            "doc_size": 31000,
+            "file_path": "_site/psychic-shadows.html",
+            "incoming_links": [
+                "/anxiety-management",
+                "/caring",
+                "/depression",
+                "/idle",
+                "/psychic-weight",
+                "/siy"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/psychic-shadows.md",
+            "outgoing_links": [
+                "/addiction",
+                "/anxiety-management",
+                "/d/resistance",
+                "/mental-pain",
+                "/mind-monsters",
+                "/psychic-weight",
+                "/todo_enjoy"
+            ],
+            "redirect_url": "",
+            "title": "Psychic Shadows: Crafting Spells to Banish Ruminating Thoughts",
+            "url": "/psychic-shadows"
+        },
+        "/psychic-weight": {
+            "description": "Imagine a weight tied around your body, imagine it dragging behind you, slowing down your motions, preventing you from going where you want to go. Imagine never taking it off, and getting no relief regardless of when you sit or sleep. Now imagine that’s not a physical weight, but instead a mental weight, a psychic weight if you will. Psychic weight are the thoughts that prevent your mind and emotions from being fluid and light.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/psychic-weight.html",
+            "incoming_links": [
+                "/depression",
+                "/gtd",
+                "/mind-at-work",
+                "/process-journal",
+                "/psychic-shadows"
+            ],
+            "last_modified": "2025-07-18T07:57:44-07:00",
+            "markdown_path": "_d/psychic-weight.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/addiction",
+                "/curious",
+                "/d/habits",
+                "/d/resistance",
+                "/death",
+                "/frog",
+                "/gtd",
+                "/idle",
+                "/mental-pain",
+                "/mind-monsters",
+                "/pride",
+                "/psychic-shadows",
+                "/shame",
+                "/siy"
+            ],
+            "redirect_url": "",
+            "title": "Psychic Weight",
+            "url": "/psychic-weight"
+        },
+        "/quip": {
+            "description": "My group lives in QUIP. Here are some tips for my quip usage.\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/quip.html",
+            "incoming_links": [],
+            "last_modified": "2020-05-23T10:50:45-07:00",
+            "markdown_path": "_td/quip.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Quip tips and tricks",
+            "url": "/quip"
+        },
+        "/random": {
+            "description": "Igor's Blog",
+            "doc_size": 11000,
+            "file_path": "_site/random.html",
+            "incoming_links": [],
+            "last_modified": "2025-07-27T15:35:40-07:00",
+            "markdown_path": "random.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Random Page",
+            "url": "/random"
+        },
+        "/random-idea": {
+            "description": "There are lots of rough ideas I have that are not yet categorized, or good enough to be a thought. This will be a\nplace to store them.\n\n",
+            "doc_size": 28000,
+            "file_path": "_site/random-idea.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T10:48:49-07:00",
+            "markdown_path": "_d/2010-2-15-2016-Misc-Uncategorized.md",
+            "outgoing_links": [
+                "/decisive",
+                "/moments",
+                "/moments-at-work",
+                "/switch"
+            ],
+            "redirect_url": "",
+            "title": "Random Uncategorized Notes",
+            "url": "/random-idea"
+        },
+        "/rapport": {
+            "description": "In today’s fast-paced and interconnected world, building and maintaining strong relationships is essential for personal and professional success. POWER is a five-step process that will help you establish rapport and create meaningful connections with people from all walks of life. The POWER acronym stands for: Proximity Observation, Warmth, Empathy, Revelation\n\n",
+            "doc_size": 33000,
+            "file_path": "_site/rapport.html",
+            "incoming_links": [
+                "/gpt"
+            ],
+            "last_modified": "2025-08-25T10:46:49-07:00",
+            "markdown_path": "_d/rapport.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "How to build rapport",
+            "url": "/rapport"
+        },
+        "/recent": {
+            "description": "This page shows the most recently modified content across the site, helping you discover what’s been updated lately.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/recent.html",
+            "incoming_links": [
+                "/about"
+            ],
+            "last_modified": "2025-07-27T15:35:40-07:00",
+            "markdown_path": "_d/recent.md",
+            "outgoing_links": [
+                "/new-skills"
+            ],
+            "redirect_url": "",
+            "title": "Recently Modified Content",
+            "url": "/recent"
+        },
+        "/recommend": {
+            "description": "My explorations of recommender and ranking systems, heavly based on the superb book Practical Recommender Systems\n\n",
+            "doc_size": 34000,
+            "file_path": "_site/recommend.html",
+            "incoming_links": [
+                "/ai",
+                "/ml",
+                "/timeoff-2022-07"
+            ],
+            "last_modified": "2025-08-24T09:03:19-07:00",
+            "markdown_path": "_td/recommender.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Recommender Systems",
+            "url": "/recommend"
+        },
+        "/reflect-tool": {
+            "description": "Igor's Blog",
+            "doc_size": 12000,
+            "file_path": "_site/reflect-tool.html",
+            "incoming_links": [],
+            "last_modified": "2023-12-17T18:51:48+00:00",
+            "markdown_path": "self-reflect.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Self Reflection Tool",
+            "url": "/reflect-tool"
+        },
+        "/regrets": {
+            "description": "Regrets, both ours and others, are a powerful tools to shape our present and future. four main types: foundation regrets related to not laying a proper base for life; boldness regrets stemming from missed opportunities and risks; moral regrets from not doing the right thing; and connection regrets from neglecting or damaging relationships. May you fin dinsights into how we can better navigate our choices to minimize regret and enhance our sense of fulfillment.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/regrets.html",
+            "incoming_links": [
+                "/emotions",
+                "/mood"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/regrets.md",
+            "outgoing_links": [
+                "/be-proactive",
+                "/curious",
+                "/mental-pain",
+                "/negotiate",
+                "/sustainable-work"
+            ],
+            "redirect_url": "",
+            "title": "Regrets",
+            "url": "/regrets"
+        },
+        "/remote-work": {
+            "description": "In March 2020, the world shut down from Covid-19. In May 2020, I started a new job as a remote manager at FB. Here are my thoughts.\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/remote-work.html",
+            "incoming_links": [
+                "/manager-book"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/remotework.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Remote Work",
+            "url": "/remote-work"
+        },
+        "/retire": {
+            "description": "When we ponder retirement - we’re masters at planning our exit, but surprisingly vague about what happens after. We’re so focused on what we’re retiring from rather than what we’re retiring to. The real goal isn’t the escape itself - it’s creating a life of genuine freedom, growth, and meaning on the other side. And here’s the plot twist - much of this post isn’t about retirement at all. It’s about what to do while you’re still working.\n\n",
+            "doc_size": 26000,
+            "file_path": "_site/retire.html",
+            "incoming_links": [
+                "/42",
+                "/gap-year",
+                "/gap-year-igor",
+                "/monetize",
+                "/stock-concentration"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/retire.md",
+            "outgoing_links": [
+                "/42",
+                "/chapters",
+                "/diet",
+                "/enemy",
+                "/eulogy",
+                "/gap-year",
+                "/hobby",
+                "/last-year",
+                "/manager-book",
+                "/money",
+                "/physical-health",
+                "/static/idvorkin-linked-in-feedback-lastest.pdf",
+                "/sustainable-work",
+                "/work-satisfaction"
+            ],
+            "redirect_url": "",
+            "title": "Retirement: Stop Planning the Exit, Start Planning the Life",
+            "url": "/retire"
+        },
+        "/roblox-dev": {
+            "description": "Zach and Amelia are roblox fans, so it’s fun to be able to create things in there playgrounds. With Zach (and maybe Amelia in a while) it’s even more fun to get to program. Here’s some stuff I’ve learned about programming robolox.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/roblox-dev.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/roblox2.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Developing on roblox",
+            "url": "/roblox-dev"
+        },
+        "/save-the-soup": {
+            "description": "“Are you insane?” I half shouted at Biff, my college roommate. We had just finished our Operating Systems midterm and were lounging at “The Bomber,” our college pub. Biff suggested we both do our last internship at Microsoft.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/save-the-soup.html",
+            "incoming_links": [],
+            "last_modified": "2020-04-12T19:50:58+00:00",
+            "markdown_path": "_posts/2018-11-04-save-the-soup.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Save the Soup",
+            "url": "/save-the-soup"
+        },
+        "/save-the-souse": {
+            "description": "Internships are best approached as a long-term field trip. You should plan to be exposed to new things, spend some time out of your comfort zone, and, by all means – use the buddy system.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/save-the-souse.html",
+            "incoming_links": [],
+            "last_modified": "2020-04-12T19:50:58+00:00",
+            "markdown_path": "_posts/2018-11-05-save-the-souse.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Save the Souse",
+            "url": "/save-the-souse"
+        },
+        "/screencast": {
+            "description": "Screencasting has become an essential tool for content creators, educators, and professionals alike. In this post, I’ll share my experiences and insights on screencasting on macOS, covering various tools, techniques, and tips I’ve discovered along the way. From recording software to post-production enhancements, this guide aims to help you navigate the world of screencasting on your Mac.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/screencast.html",
+            "incoming_links": [
+                "/content-creation",
+                "/osx"
+            ],
+            "last_modified": "2025-01-04T12:24:44-08:00",
+            "markdown_path": "_td/screencast.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Screencasting on OSX",
+            "url": "/screencast"
+        },
+        "/seattle": {
+            "description": "Seattle is my home, I want to die here, though not soon. If you’re visiting, here’s a list of fun things you can try. But here’s the deal, give me feedback on stuff to add/remove from this list\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/seattle.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/seattle.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Seattle",
+            "url": "/seattle"
+        },
+        "/sell": {
+            "description": "Selling matters - it’s pitching, convincing, negotiating, hiring. Selling has a bad rap, because the seller often puts their needs ahead of the buyer - a win/lose paradigm. You should make selling win/win or no deal by needing to answer yes to these questions. 1/ If the buyer agrees, will their life improve? 2/ When the deal is done, will the world be a better place than when you began?\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/sell.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/2017-2-5-To-Sell-Is-Human.md",
+            "outgoing_links": [
+                "/first-understand",
+                "/negotiate",
+                "/win-win"
+            ],
+            "redirect_url": "",
+            "title": "To Sell Is Human",
+            "url": "/sell"
+        },
+        "/shame": {
+            "description": "Shame and guilt are often confused emotions caused by self judgments that lead to contrasting behaviors. Shame drives people to hide or deny their wrongdoings while guilt, properly applied drives people to the correct behaviors. These are both examples of mental-pain and when the pain is phantom or cronic, are often well served by grandmother mind.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/shame.html",
+            "incoming_links": [
+                "/90days",
+                "/curious",
+                "/depression",
+                "/emotions",
+                "/insecure",
+                "/psychic-weight",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/shame.md",
+            "outgoing_links": [
+                "/curious",
+                "/mental-pain"
+            ],
+            "redirect_url": "",
+            "title": "Shame",
+            "url": "/shame"
+        },
+        "/sharpen-the-saw": {
+            "description": "A young man saw a woodcutter cutting down a tree and asked “What are you doing?” “Are you blind?” the woodcutter replied. “I’m cutting down this tree.” The young man continued. “You look exhausted! Take a break. Sharpen your saw.” The woodcutter explained he’d been sawing for hours and did not have time to take a break. The young man pushed back… “If you sharpen the saw, you would cut down the tree much faster.” The woodcutter said “I don’t have time to sharpen the saw. Don’t you see I’m too busy. These are my insights based on the 7 habits Chapter 7.\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/sharpen-the-saw.html",
+            "incoming_links": [
+                "/7-habits",
+                "/emotional-health",
+                "/physical-health"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/7h-c7.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/d/habits",
+                "/diet",
+                "/emotional-health",
+                "/physical-health",
+                "/siy"
+            ],
+            "redirect_url": "",
+            "title": "Sharpen the saw",
+            "url": "/sharpen-the-saw"
+        },
+        "/sicp": {
+            "description": "LISP, and SICP\n\n",
+            "doc_size": 33000,
+            "file_path": "_site/sicp.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/sicp.md",
+            "outgoing_links": [
+                "/static/roots_of_lisp.pdf"
+            ],
+            "redirect_url": "",
+            "title": "Structure and Design of Computer Programs",
+            "url": "/sicp"
+        },
+        "/siy": {
+            "description": "Training Emotional Intelligence through mindfulness. Search inside yourself is a meditation training manual for engineers. It’s also a pun as the author works at google, and built the program internally at Google. Joy on demand by the same author, is less engineer focused, and uses joy as a path to medatitive bliss.\n\n",
+            "doc_size": 61000,
+            "file_path": "_site/siy.html",
+            "incoming_links": [
+                "/anxiety-management",
+                "/be-proactive",
+                "/books-that-defined-me",
+                "/coaching",
+                "/curious",
+                "/depression",
+                "/emotional-health",
+                "/eulogy",
+                "/first-understand",
+                "/gap-year-igor",
+                "/idle",
+                "/irl",
+                "/mind-monsters",
+                "/operating-manual",
+                "/psychic-weight",
+                "/sharpen-the-saw",
+                "/slow",
+                "/timeoff",
+                "/timeoff-2020-03"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/siy.md",
+            "outgoing_links": [
+                "/be-proactive",
+                "/emotional-health",
+                "/end-in-mind",
+                "/happy",
+                "/ig66/685",
+                "/mind-monsters",
+                "/psychic-shadows",
+                "/sublime",
+                "/what-makes-a-leader"
+            ],
+            "redirect_url": "",
+            "title": "Search inside yourself",
+            "url": "/siy"
+        },
+        "/sleep": {
+            "description": "Bryan Johnson says sleep is like life on easy mode. He has lots to say on this, and it gets technical, and I think I agree:\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/sleep.html",
+            "incoming_links": [
+                "/energy",
+                "/gap-year-igor",
+                "/insomnia",
+                "/physical-health"
+            ],
+            "last_modified": "2025-08-13T07:43:13-07:00",
+            "markdown_path": "_d/sleep.md",
+            "outgoing_links": [
+                "/blueprint",
+                "/insomnia"
+            ],
+            "redirect_url": "",
+            "title": "Keep life on easy mode - Prioritize Sleep",
+            "url": "/sleep"
+        },
+        "/sleeping-bag-sacrifices": {
+            "description": "I started in Windows Azure in 2007. Back then, the name “Azure” wasn’t invented, and Azure was still called “Reddog.” I started on the OS team, drawn in by my dream of changing the world, and getting to be Dave Cutler’s lackey. I didn’t get to work with Cutler, but I still may change the world - now that I’ve learned it’s OK to wake sleeping giants. My giant was named Jay.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/sleeping-bag-sacrifices.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-25T10:46:49-07:00",
+            "markdown_path": "_posts/2018-11-06-sleeping-bag-sacrifices.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Sleeping bag sacrifices",
+            "url": "/sleeping-bag-sacrifices"
+        },
+        "/sleight-of-mouth": {
+            "description": "Language, often unknown to us, creates our mental models, our reality, and defines our meaning. But the model is not the terrain, and by engaging with the language we can change mental models. Sleight of mouth (SoM) is a series of techniques for changing our models, reality and meanings and thus our experiences. Our mental models are a frame, and we need help going from a ‘problem frame’ to a ‘desired outcome frame’ , a ‘failure frame’, to a ‘feedback frame’ and an ‘impossible frame ‘ to an ‘as if’ frame. To experience the power of language, find anything that is invisible to you, and name it. Now as you’ve given it a name, see how you perceive it, and become aware of it.\n\n",
+            "doc_size": 26000,
+            "file_path": "_site/sleight-of-mouth.html",
+            "incoming_links": [
+                "/7h-concepts",
+                "/operating-manual",
+                "/timeoff-2022-02"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/2016-3-12-sleight-of-mouth.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Sleight Of Mouth",
+            "url": "/sleight-of-mouth"
+        },
+        "/slow": {
+            "description": "Fight or flight, the sympathetic nervous system, gets all the attention, but its twin sister “Rest and Digest” or the parasympathetic nervous system is equally important. These are the two divisions of the Autonomic Nervous system — the stuff that operates without conscious control. While everyone’s obsessed with productivity and hustle, your body’s crying out for balance. Here’s the thing: you can’t sprint a marathon, and life’s definitely a marathon.\n\n",
+            "doc_size": 29000,
+            "file_path": "_site/slow.html",
+            "incoming_links": [
+                "/anxiety",
+                "/balance",
+                "/energy",
+                "/mood"
+            ],
+            "last_modified": "2025-08-25T08:36:03-07:00",
+            "markdown_path": "_d/slow.md",
+            "outgoing_links": [
+                "/activation",
+                "/anxiety",
+                "/balance",
+                "/d/habits",
+                "/d/resistance",
+                "/emotions",
+                "/energy",
+                "/produce-consume",
+                "/siy"
+            ],
+            "redirect_url": "",
+            "title": "Rest and Digest - Sometimes you'd rather go slow ",
+            "url": "/slow"
+        },
+        "/smilebox": {
+            "description": "Way back in 2012 I had this idea to make a Smilebox. The tech wasn’t good enough, but in 2023 tech is right ready. Here’s quoting the original blog post … Nothing makes me happier then seeing someone smile. In fact, seeing others smile makes me smile. As a result, I’m creating a box that captures smiles, which I’m calling a smile box. If you look at the smile box, you’ll see the smiles that are already captured . If you smile at the box, it’ll capture your smile and add it to the box.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/smilebox.html",
+            "incoming_links": [
+                "/joy"
+            ],
+            "last_modified": "2023-02-20T13:23:02-08:00",
+            "markdown_path": "_td/smilebox.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Smilebox",
+            "url": "/smilebox"
+        },
+        "/snjb": {
+            "description": "Zach built Steve’s Night Jungle and Bar in twee, here’s our port to python!\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/snjb.html",
+            "incoming_links": [
+                "/timeoff-2021-11"
+            ],
+            "last_modified": "2021-11-25T22:54:03-08:00",
+            "markdown_path": "_d/snjb_.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Welcome to Steve's jungle and bar!",
+            "url": "/snjb"
+        },
+        "/software-leadership-roles": {
+            "description": "The line between a technical lead and architect (and product manager and engineering manager) is fuzzy and subjective. The best articulation of the difference I’ve found is inline from Quora. In this classification I like to run a team small enough that I can be the engineering manager and step in as the software architect as required.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/software-leadership-roles.html",
+            "incoming_links": [
+                "/job",
+                "/manager-book"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_posts/2018-01-14-software-leadership-roles.md",
+            "outgoing_links": [
+                "/manager-book"
+            ],
+            "redirect_url": "",
+            "title": "Tech leads, software architects and engineering managers - oh my!",
+            "url": "/software-leadership-roles"
+        },
+        "/stock-concentration": {
+            "description": "When you work at a tech company and receive RSUs, it’s easy to accidentally become dangerously concentrated in your company’s stock. You didn’t mean to bet your entire future on one company, but here you are - watching every earnings call with your stomach in knots because a 30% drop would devastate your net worth. This guide explains the risks and strategies for managing concentrated stock positions - from tax-efficient selling strategies to protective options that cost you nothing, and exchange funds that diversify without triggering taxes.\n\n",
+            "doc_size": 37000,
+            "file_path": "_site/stock-concentration.html",
+            "incoming_links": [
+                "/gap-year-igor",
+                "/money"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/stock-concentration.md",
+            "outgoing_links": [
+                "/gap-year",
+                "/gap-year-igor",
+                "/money",
+                "/retire"
+            ],
+            "redirect_url": "",
+            "title": "Stock Concentration: How I Learned to Stop Worrying and Love the Capital Gains Tax",
+            "url": "/stock-concentration"
+        },
+        "/strategy": {
+            "description": "As competition in the market intensifies, companies must find ways to differentiate themselves in order to have a successful business - and that means strategic positioning. If they want to get the buyers money they have to choose a strategy that works for them and make sure it has sustainable competitive advantages. From offering a different value, to providing the same value using different activities - the possibilities for positioning are endless. Ultimately, it’s all about creating trade offs and making sure those trade offs give a sustainable competitive advantage!\n\n",
+            "doc_size": 28000,
+            "file_path": "_site/strategy.html",
+            "incoming_links": [
+                "/energy-abundance",
+                "/life-as-business",
+                "/manager-book"
+            ],
+            "last_modified": "2025-02-01T18:47:48-08:00",
+            "markdown_path": "_d/2015-11-18-what-is-strategy.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "On strategy",
+            "url": "/strategy"
+        },
+        "/strengths": {
+            "description": "Developing you strengths is 3 times as effective as improving your weakness, so find your strengths and double down. To bootstrap the discovery of my strengths, I used a tool called StrengthFinder and it discovered my strengths are Activator, Communication, Problem Solving (Resolver in StrengthFinder speak) Adaptability, and Ideation.\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/strengths.html",
+            "incoming_links": [
+                "/operating-manual"
+            ],
+            "last_modified": "2025-08-22T10:48:49-07:00",
+            "markdown_path": "_posts/2018-05-25-strength-finder.md",
+            "outgoing_links": [
+                "/static/StrengthFinderIgor.pdf",
+                "/static/igor-enneagram.pdf"
+            ],
+            "redirect_url": "",
+            "title": "My Strengths from Strength Finder",
+            "url": "/strengths"
+        },
+        "/structure": {
+            "description": "What if structure could be kind? You already know what you want to do. You know exercise is good for you. You know journaling helps. You know you should call your mom more often. The problem isn’t knowing—it’s the gap between intention and action, especially when life gets messy. Most of us recoil from the word “structure” because we’ve only experienced harsh management-style systems that treat humans like machines. But there’s another way: humane structure that works with your nature, not against it. Humane structure starts with a core assumption: You’re not broken, you just need better support. You don’t need more willpower, discipline, or motivation. You need systems that help you remember what you care about and make it easier to act on those values, especially when you’re struggling.\n\n",
+            "doc_size": 30000,
+            "file_path": "_site/structure.html",
+            "incoming_links": [
+                "/gap-year-igor"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/structure.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Humane Structure -  A Gentle Framework for Wild Minds",
+            "url": "/structure"
+        },
+        "/sublime": {
+            "description": "Emotional health is pretty important. Western folks don’t have a lot of words to support this. Luckily, the Buddhists have the sublime states: Loving-kindness, Compassion, Altruistic Joy, and Equanimity. Give ‘em a try. Most of this post is based on “The Joy of Happiness”.\n\n",
+            "doc_size": 19000,
+            "file_path": "_site/sublime.html",
+            "incoming_links": [
+                "/affirmations",
+                "/emotional-health",
+                "/emotions",
+                "/siy",
+                "/timeoff-2024-02"
+            ],
+            "last_modified": "2024-05-22T16:40:30-07:00",
+            "markdown_path": "_d/sublime.md",
+            "outgoing_links": [
+                "/emotional-health",
+                "/joy",
+                "/touching"
+            ],
+            "redirect_url": "",
+            "title": "Training the sublime states",
+            "url": "/sublime"
+        },
+        "/suicide": {
+            "description": "“Igor, what advice would you give a 20-year-old that just found out their dad killed themselves?” Sadly, when I was 20, I got a call from a family friend saying “Igor, you want to sit down, this isn’t going to be fun to hear.” My dad had taken his own life.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/suicide.html",
+            "incoming_links": [],
+            "last_modified": "2024-11-09T06:51:11-08:00",
+            "markdown_path": "_d/suicide.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Brain Attacks: A Better Model for Suicide",
+            "url": "/suicide"
+        },
+        "/sustainable-work": {
+            "description": "I don’t want to die knowing I spent too much time at work and I bet you don’t either. As a result I want to work with people who value a culture encouraging them to balance their family, health, hobbies, and work - aka work-life balance. To make a culture real leaders needs to walk the talk, and I’ll describe how I model a work-life balance, and the mechanisms I use to help team members achieve their own balance.\n\n",
+            "doc_size": 29000,
+            "file_path": "_site/sustainable-work.html",
+            "incoming_links": [
+                "/42",
+                "/balance",
+                "/being-a-great-manager",
+                "/depression",
+                "/gap-year-igor",
+                "/overload",
+                "/regrets",
+                "/retire",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2025-02-15T10:13:03-08:00",
+            "markdown_path": "_posts/2020-01-04-sustainable-work.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "I don't want to die knowing I spent too much time at work, and I bet you don't either",
+            "url": "/sustainable-work"
+        },
+        "/switch": {
+            "description": "Human action can be modeled by an elephant, a rider, and the path. Our emotional side is the Elephant and our rational side is the Rider. Perched atop the Elephant, the Rider holds the reins and seems to be the leader. But the Rider’s control is precarious because the Rider is so small relative to the Elephant. Anytime the six-ton Elephant and the Rider disagree about which direction to go, the Rider is going to lose. He’s completely overmatched. Lastly, the path is the structural elements that nudge your elephant and your rider in a direction, without effort.\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/switch.html",
+            "incoming_links": [
+                "/enable",
+                "/first-things-first",
+                "/negotiate",
+                "/productive",
+                "/random-idea",
+                "/timeoff-2022-02"
+            ],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_d/switch.md",
+            "outgoing_links": [
+                "/coe",
+                "/d/habits"
+            ],
+            "redirect_url": "",
+            "title": "Switch",
+            "url": "/switch"
+        },
+        "/synergize": {
+            "description": "We’ve all got stuff we’re good at, and stuff we’re bad at. We can combine these in ways that make the system greater then the sum of its parts.\n\n",
+            "doc_size": 27000,
+            "file_path": "_site/synergize.html",
+            "incoming_links": [
+                "/7-habits"
+            ],
+            "last_modified": "2025-03-07T11:21:07-08:00",
+            "markdown_path": "_d/7h-c6.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/negotiate",
+                "/win-win"
+            ],
+            "redirect_url": "",
+            "title": "Creating Synergy: Making 1+1 = 3!",
+            "url": "/synergize"
+        },
+        "/system-design": {
+            "description": "As a technologist I love system designs. I like to tell interview candidates you don’t need to practice them, it’s what you do every day. In fact, it’s one of the favorite parts of my technical role. I never liked crossword puzzles, but I could totally do system design problems instead. Here’s a great list ..\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/system-design.html",
+            "incoming_links": [
+                "/job-hunt-stress"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/system-design.md",
+            "outgoing_links": [
+                "/design",
+                "/td/better-security-design",
+                "/td/cloud-first-applications",
+                "/td/data-systems"
+            ],
+            "redirect_url": "",
+            "title": "System Design Questions",
+            "url": "/system-design"
+        },
+        "/taas": {
+            "description": "Transportation as a service is the third transportation revolution. The first revolution was the addition of 20,000 miles of track which led to the emergence of cities. The second revolution was the assembly line which mass produced cars. The third revolution is ride sharing which is a different transport option. The Fourth transportation revolution will be the human to autonomous transition. The fifth revolution will be the redefining of our cities.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/taas.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/2016-09-18-transportation-as-a-service.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Transportation as a Service",
+            "url": "/taas"
+        },
+        "/td/alexa-skill": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/td/alexa-skill.html",
+            "incoming_links": [],
+            "last_modified": "2020-04-11T16:32:11+00:00",
+            "markdown_path": "_td/alexa-skill.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Make an Alexa Skill",
+            "url": "/td/alexa-skill"
+        },
+        "/td/back_ref": {
+            "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/td/back_ref.html",
+            "incoming_links": [],
+            "last_modified": "2022-04-16T15:22:43-07:00",
+            "markdown_path": "_td/back_ref.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Adding back references to my blog",
+            "url": "/td/back_ref"
+        },
+        "/td/better-security-design": {
+            "description": "I used to do security in a former life, and here are some musings on the topic, which will eventually be dissected into various essays. For now it’ll be confusing as I’m brain dumping to various audiences with various knowledge (end users, architects, CEOs, designers)\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/td/better-security-design.html",
+            "incoming_links": [
+                "/system-design"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/better-security-design.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Security Notes",
+            "url": "/td/better-security-design"
+        },
+        "/td/cloud-first-applications": {
+            "description": "The world is now on the cloud, here are my random notes on the topic.\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/td/cloud-first-applications.html",
+            "incoming_links": [
+                "/amazon",
+                "/design",
+                "/manager-book",
+                "/system-design"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/cloud-first-applications.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Cloud First Applications",
+            "url": "/td/cloud-first-applications"
+        },
+        "/td/data-systems": {
+            "description": "This page contains my knowledge of data systems. Mostly just a summary of Designing Data-Intensive Applications: The Big Ideas Behind Reliable, Scalable, and Maintainable Systems\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/td/data-systems.html",
+            "incoming_links": [
+                "/amazon",
+                "/chow",
+                "/system-design"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_td/data-systems.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Data Systems",
+            "url": "/td/data-systems"
+        },
+        "/td/dump_imessage_history": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/td/dump_imessage_history.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/dump_imessage_history.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Accessing iMessage history",
+            "url": "/td/dump_imessage_history"
+        },
+        "/td/fix_ssh": {
+            "description": "For some reason, SSH is just hanging out of no where. To debug on the server, be sure to open your firewall\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/td/fix_ssh.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T10:48:49-07:00",
+            "markdown_path": "_td/fix_ssh.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "SSH Client Commands Timing Out from Some Clients Sometimes",
+            "url": "/td/fix_ssh"
+        },
+        "/td/hack-web": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 29000,
+            "file_path": "_site/td/hack-web.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/hack-web.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Hacking the web for fun and profit",
+            "url": "/td/hack-web"
+        },
+        "/td/ios": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/td/ios.html",
+            "incoming_links": [
+                "/tools",
+                "/writing"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/ios.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "iOS and iPadOS tips",
+            "url": "/td/ios"
+        },
+        "/td/ios-nomad": {
+            "description": "So you want to be an iPad Developer Nomad. A person who can do all their development on the iPad. I’m not sure why you’d want to be such a character, in fact, I’m not sure why I want to be such a character, but I do, and here’s how I do it. To be a developer nomad, you better already be a command line wiz. If you’re not at an expert at the terminal, vim or Emacs and TMUX - don’t even try.\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/td/ios-nomad.html",
+            "incoming_links": [
+                "/tools",
+                "/writing"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/ios-nomad.md",
+            "outgoing_links": [
+                "/irl"
+            ],
+            "redirect_url": "",
+            "title": "iOS Software Engineer Nomad How-To",
+            "url": "/td/ios-nomad"
+        },
+        "/td/linqpad_from_redshift": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/td/linqpad_from_redshift.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T10:48:49-07:00",
+            "markdown_path": "_td/linqpad_from_redshift.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Make LINQPad Work with Redshift",
+            "url": "/td/linqpad_from_redshift"
+        },
+        "/td/minecraft": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/td/minecraft.html",
+            "incoming_links": [],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_td/minecraft.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Minecraft Notes",
+            "url": "/td/minecraft"
+        },
+        "/td/mosh": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/td/mosh.html",
+            "incoming_links": [],
+            "last_modified": "2020-04-11T16:32:11+00:00",
+            "markdown_path": "_td/mosh.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Mosh",
+            "url": "/td/mosh"
+        },
+        "/td/private_web_site": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/td/private_web_site.html",
+            "incoming_links": [],
+            "last_modified": "2020-04-11T16:32:11+00:00",
+            "markdown_path": "_td/private_web_site.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Private Web Site",
+            "url": "/td/private_web_site"
+        },
+        "/td/ring-video-download": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/td/ring-video-download.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/ring-video-download.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Ring Video Doorbell",
+            "url": "/td/ring-video-download"
+        },
+        "/td/slow_zsh": {
+            "description": "All of the sudden, hititng enter in zsh took seconds - took me a while, but I realized if I kiled tmux (not just a window), then it would be fast again (well, that’s better then a reboot I guess. Sigh, this drove me nuts and I just switched to Atuin instead\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/td/slow_zsh.html",
+            "incoming_links": [
+                "/timeoff-2024-08"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/slow_zsh.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Slow ZSH prompts",
+            "url": "/td/slow_zsh"
+        },
+        "/td/sqlalchemy-redshift": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/td/sqlalchemy-redshift.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/sqlalchemy-redshift.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "SQLAlchemy with Redshift",
+            "url": "/td/sqlalchemy-redshift"
+        },
+        "/td/stats": {
+            "description": "Statistics is a tool which lets us summarize data, and make inferences from it.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/td/stats.html",
+            "incoming_links": [],
+            "last_modified": "2024-10-05T21:35:59-07:00",
+            "markdown_path": "_td/stats.md",
+            "outgoing_links": [
+                "/ml"
+            ],
+            "redirect_url": "",
+            "title": "Statistics",
+            "url": "/td/stats"
+        },
+        "/td/streaks": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/td/streaks.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/streaks.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Habit tracking app",
+            "url": "/td/streaks"
+        },
+        "/td/usbtech": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/td/usbtech.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T10:48:49-07:00",
+            "markdown_path": "_td/usbtech.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "USB Tech",
+            "url": "/td/usbtech"
+        },
+        "/td/virtual-desktops": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/td/virtual-desktops.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/virtual-desktops.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Virtual desktops in Wox",
+            "url": "/td/virtual-desktops"
+        },
+        "/td/visual-vocabulary": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/td/visual-vocabulary.html",
+            "incoming_links": [
+                "/viz"
+            ],
+            "last_modified": "2020-04-11T16:32:11+00:00",
+            "markdown_path": "_td/visual-vocabulary.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Visual Thinking Notes",
+            "url": "/td/visual-vocabulary"
+        },
+        "/td/windbg": {
+            "description": "Copied from my GitHub techdiary\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/td/windbg.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T10:48:49-07:00",
+            "markdown_path": "_td/windbg.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "WinDbg Notes",
+            "url": "/td/windbg"
+        },
+        "/tech-health-toys": {
+            "description": "Physical health is the basis of my energy, so it’s a place I’m happy spending money and energy. I’ve been buying lots of technology to help me understand and measure my health and fitness and this post will track my favorite toys.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/tech-health-toys.html",
+            "incoming_links": [
+                "/d/2016-02-03-positive-computing-survey",
+                "/physical-health"
+            ],
+            "last_modified": "2020-02-15T17:30:47+00:00",
+            "markdown_path": "_posts/2017-10-06-tech-health-toys.md",
+            "outgoing_links": [
+                "/physical-health"
+            ],
+            "redirect_url": "",
+            "title": "Tech for health",
+            "url": "/tech-health-toys"
+        },
+        "/tech-rituals": {
+            "description": "There is so much change in tech it’s important to check in on what has changed to make sure you’re still using the latest. You can do this at an ad-hoc basis, but you’re probably better off having it on a calendar.\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/tech-rituals.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/tech-ritual.md",
+            "outgoing_links": [
+                "/chop"
+            ],
+            "redirect_url": "",
+            "title": "Tech Rituals",
+            "url": "/tech-rituals"
+        },
+        "/terzepatide": {
+            "description": "“You know Igor, weight loss is a solved problem” - my bestie, texted me when I complained about my pants no longer fitting. Remember - Diet dominates weight, as weight is simple arithmetic -“calories in” minus “calories out”. For me, will power dominates diet, and terzepatide dominates will power when stuffing things in my mouth. I started Terzepatide in February 2024, and so far it’s been great.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/terzepatide.html",
+            "incoming_links": [
+                "/42",
+                "/diet",
+                "/eulogy",
+                "/physical-health",
+                "/timeoff",
+                "/timeoff-2024-04",
+                "/voices"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/terzepatide.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Terzepatide: The magic weight loss shot",
+            "url": "/terzepatide"
+        },
+        "/tesla": {
+            "description": "I don’t like to drive. I don’t like to drive so much that I have it in my eulogy. Luckily, Elon Musk made a car that’s optimized for driving you. In August 2023, I treated myself to a Tesla Model Y. It has lots of trade-offs, but the key for me is its Autopilot (e.g., it driving me).\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/tesla.html",
+            "incoming_links": [
+                "/eulogy",
+                "/irl",
+                "/kayak",
+                "/mania",
+                "/operating-manual",
+                "/timeoff-2024-02"
+            ],
+            "last_modified": "2024-11-28T13:20:09-08:00",
+            "markdown_path": "_d/tesla.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Tony (Tessie) the Tesla",
+            "url": "/tesla"
+        },
+        "/test-auto-sunburst": {
+            "description": "This page demonstrates the auto-generated sunburst functionality that extracts the tree structure from H2 and H3 elements.\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/test-auto-sunburst.html",
+            "incoming_links": [],
+            "last_modified": "2025-07-25T07:05:52-07:00",
+            "markdown_path": "_d/test-auto-sunburst.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Test Auto-Generated Sunburst",
+            "url": "/test-auto-sunburst"
+        },
+        "/testing": {
+            "description": "If it’s not tested, it doesn’t work. When your tests passing lets you deploy without any concerns, your tests are good enough. Otherwise, you’ve got more work to do.\n\n",
+            "doc_size": 29000,
+            "file_path": "_site/testing.html",
+            "incoming_links": [
+                "/chop",
+                "/design",
+                "/manager-book"
+            ],
+            "last_modified": "2024-12-31T07:15:11-08:00",
+            "markdown_path": "_td/testing.md",
+            "outgoing_links": [
+                "/ai-testing",
+                "/design"
+            ],
+            "redirect_url": "",
+            "title": "Testing and Quality",
+            "url": "/testing"
+        },
+        "/the-recruiter-does-not-think-you-are-hot": {
+            "description": "I’ve only had one truly unbearable job. It was awful - The code base sucked, the boss had pointed hair, and to top it off I got a terrible review.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/the-recruiter-does-not-think-you-are-hot.html",
+            "incoming_links": [],
+            "last_modified": "2020-04-12T19:50:58+00:00",
+            "markdown_path": "_posts/2020-01-01-the-recruiter-does-not-think-you-are-hot.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "The recruiter does not think you're hot",
+            "url": "/the-recruiter-does-not-think-you-are-hot"
+        },
+        "/time-traveler": {
+            "description": "What would Past Igor say if he met Future Igor? Would he be impressed by the wisdom, disappointed by the waistline, or wonder how we developed such an intense relationship with pastries? While we can’t physically time travel, we can use mental time travel as a powerful tool - imagining conversations across our past, present, and future selves. Think of it as a group chat between Past Igor (that idealistic youngster), Present Igor (hello!), and Future Igor (who’s probably shaking his head at both of us). Let’s explore how these three versions of ourselves are constantly chatting, arguing, and occasionally giving each other virtual fist bumps across the space-time continuum.\n\n\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/time-traveler.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-24T09:03:19-07:00",
+            "markdown_path": "_d/time-traveler.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "When Past Igor Meets Future Igor",
+            "url": "/time-traveler"
+        },
+        "/timeoff": {
+            "description": "Time off is critical, it’s how we renew our energy, find our creativity, etc. Many people think of time off as synonymous with turning your 1 week off into an action-packed tour of Disneyland. But, there are other kinds of time off that we’ll discuss too. Like most things, time off is a skill that can be improved by studying and applying your learnings. This post includes mine - note to self - read them!!\n\n",
+            "doc_size": 37000,
+            "file_path": "_site/timeoff.html",
+            "incoming_links": [
+                "/balance",
+                "/energy",
+                "/energy-abundance",
+                "/gap-year",
+                "/gap-year-igor",
+                "/life-as-business",
+                "/mind-at-work",
+                "/parkinson",
+                "/timeoff-2020-03",
+                "/timeoff-2020-12",
+                "/timeoff-2021-11",
+                "/timeoff-2021-12",
+                "/timeoff-2022-02",
+                "/timeoff-2022-07",
+                "/timeoff-2022-11",
+                "/timeoff-2022-12",
+                "/timeoff-2023-04",
+                "/timeoff-2023-08",
+                "/timeoff-2023-11",
+                "/timeoff-2024-08",
+                "/timeoff-2025-08"
+            ],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time_off.md",
+            "outgoing_links": [
+                "/addiction",
+                "/balloon",
+                "/d/resistance",
+                "/diet",
+                "/energy",
+                "/essentialism",
+                "/eulogy",
+                "/frog",
+                "/happy",
+                "/kettlebell",
+                "/magic",
+                "/mind-at-work",
+                "/parkinson",
+                "/siy",
+                "/terzepatide",
+                "/timeoff-2020-03",
+                "/timeoff-2024-02"
+            ],
+            "redirect_url": "",
+            "title": "Getting the most out of time off",
+            "url": "/timeoff"
+        },
+        "/timeoff-2020-03": {
+            "description": "In March 2020, I took a 2 month sabatical between leaving Amazon and joining Facebook. Given it was a substantial amount of time, I came up with some big plans, and wrote them down. It was a great plan, BUT my time off correlated perfectly to the Corona Virus and as a result I wasted lots of my mental energy thinking about the Corona Virus, and adjusting to being in pseudo-quarantine. Took me a while, but I finally realized I should ignore corona virus, or at least minimize my time thinking about it.\n\n",
+            "doc_size": 30000,
+            "file_path": "_site/timeoff-2020-03.html",
+            "incoming_links": [
+                "/timeoff"
+            ],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2020-03.md",
+            "outgoing_links": [
+                "/frog",
+                "/money",
+                "/siy",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Adventures March and April 2020",
+            "url": "/timeoff-2020-03"
+        },
+        "/timeoff-2020-12": {
+            "description": "It’s Corona virus X-mas, and I’ve got 2 weeks off. In an attempt to maximize my personal development and satisfaction during my timeoff, by staying balanced, and minimizing my vegetation I’m going to pre-write what I want to get done, and adjust it as I go.\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/timeoff-2020-12.html",
+            "incoming_links": [
+                "/timeoff-2021-12"
+            ],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2020-12.md",
+            "outgoing_links": [
+                "/7-habits",
+                "/happy",
+                "/mental-pain",
+                "/pandas",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Time off X-mas 2020",
+            "url": "/timeoff-2020-12"
+        },
+        "/timeoff-2021-11": {
+            "description": "I should have written up a plan before this time off so I’d have been more deliberate. As it stands, I did what I wanted, got a tonne done, but missed some things that bring me a lot of energy.\n\n",
+            "doc_size": 19000,
+            "file_path": "_site/timeoff-2021-11.html",
+            "incoming_links": [
+                "/timeoff-2021-12"
+            ],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2021-11.md",
+            "outgoing_links": [
+                "/adblocker-trojan",
+                "/brython",
+                "/ig66/591",
+                "/snjb",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Time off Turkey Day 2021",
+            "url": "/timeoff-2021-11"
+        },
+        "/timeoff-2021-12": {
+            "description": "It’s Corona virus X-mas 2021, the not so bad edition, and I’ve got 2 weeks off. In an attempt to maximize my personal development and satisfaction during my time off, by staying balanced, and minimizing my vegetation I’m going to pre-write what I want to get done, and adjust it as I go.\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/timeoff-2021-12.html",
+            "incoming_links": [
+                "/timeoff-2022-12"
+            ],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2021-12.md",
+            "outgoing_links": [
+                "/activation",
+                "/balance",
+                "/happy",
+                "/timeoff",
+                "/timeoff-2020-12",
+                "/timeoff-2021-11"
+            ],
+            "redirect_url": "",
+            "title": "Time off X-mas 2021",
+            "url": "/timeoff-2021-12"
+        },
+        "/timeoff-2022-02": {
+            "description": "It’mid winter break and I’ve got a week off. In an attempt to maximize my personal development and satisfaction during my time off, by staying balanced, and minimizing my vegetation I’m going to pre-write what I want to get done, and adjust it as I go.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/timeoff-2022-02.html",
+            "incoming_links": [],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2022-02.md",
+            "outgoing_links": [
+                "/happy",
+                "/productive",
+                "/sleight-of-mouth",
+                "/switch",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Time off Mid winter break 2022",
+            "url": "/timeoff-2022-02"
+        },
+        "/timeoff-2022-07": {
+            "description": "It’s FISM (olympics of magic), and I’m going to Quebec city to reenergize my love of magic, since I’m already in Canada I’ll also spend time with My Mom, Sister, and college room mate.\n\n",
+            "doc_size": 27000,
+            "file_path": "_site/timeoff-2022-07.html",
+            "incoming_links": [
+                "/operating-manual"
+            ],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2022-07.md",
+            "outgoing_links": [
+                "/essentialism",
+                "/happy",
+                "/recommend",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Time off July 2022 - FISM and Canada.",
+            "url": "/timeoff-2022-07"
+        },
+        "/timeoff-2022-11": {
+            "description": "It’s just about thanksgiving 2022, and after 2 years of not being able to go to Oregon, we’re on our away! Through unexpected timing, before going to Oregon, I’m going to New York City with Ammon, and through even more unexpected timing, we just had lay offs at work, and have a major re-organization. Instead of being able to fully take the time off, I’ll be working several days, so having clarity on my priorities is critical.\n\n",
+            "doc_size": 26000,
+            "file_path": "_site/timeoff-2022-11.html",
+            "incoming_links": [],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2022-11.md",
+            "outgoing_links": [
+                "/happy",
+                "/mind-at-work",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Time off November 2022 - New York with Ammon, and Then Maureen and Brian for Thanksgiving",
+            "url": "/timeoff-2022-11"
+        },
+        "/timeoff-2022-12": {
+            "description": "It’s X-mas 2022, quite the fall excitement edition! and I’ve got 1 and change weeks off in an attempt to maximize my personal development and satisfaction during my time off, by staying balanced, and minimizing my vegetation. I’m going to pre-write what I want to get done, and adjust it as I go.\n\n",
+            "doc_size": 24000,
+            "file_path": "_site/timeoff-2022-12.html",
+            "incoming_links": [],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2022-12.md",
+            "outgoing_links": [
+                "/happy",
+                "/moments",
+                "/timeoff",
+                "/timeoff-2021-12"
+            ],
+            "redirect_url": "",
+            "title": "Time off X-mas 2022",
+            "url": "/timeoff-2022-12"
+        },
+        "/timeoff-2023-04": {
+            "description": "It’s spring break 2023! The kids and I are going to Canada to see Baba, Yelena, Justin, Sam and Baltasar and Rada’s Family. Unfortunately Tori can’t come as she’s critical to her play opening and it’ll be opening that week.\n\n",
+            "doc_size": 19000,
+            "file_path": "_site/timeoff-2023-04.html",
+            "incoming_links": [],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2023-04.md",
+            "outgoing_links": [
+                "/happy",
+                "/moments",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Time off April Break 2023",
+            "url": "/timeoff-2023-04"
+        },
+        "/timeoff-2023-08": {
+            "description": "It’s summer break 2023! It’s late August and our last chance to get a vacation before the kids go back to school. We were going to go to Chilliwack to try a deli run by a small jewish cult, but alas it’s like 100 degrees so we’re going to to coast instead!\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/timeoff-2023-08.html",
+            "incoming_links": [],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2023-08.md",
+            "outgoing_links": [
+                "/happy",
+                "/moments",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Time off August 2023",
+            "url": "/timeoff-2023-08"
+        },
+        "/timeoff-2023-11": {
+            "description": "It’s time for our annual thanksgiving 2023 trip to Oregon!\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/timeoff-2023-11.html",
+            "incoming_links": [],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2023-11.md",
+            "outgoing_links": [
+                "/happy",
+                "/moments",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Ashland T-Day 2023",
+            "url": "/timeoff-2023-11"
+        },
+        "/timeoff-2024-02": {
+            "description": "It’s midwinter break and I’ve got a week off. Most of these I try to do as a big family adventure. Finding something everyone wants to do is super challenging, so this time we tried something new, divide and conquer: I had a 1-2 day mini-vacations with Amelia, Zach, and even Tori. It worked out very well, the time-off was packed, Stanley Park with Amelia, Yellow Deli with Zach, and a crazy hotel on the Peninsula with Tori. On top of that restarting magic, balloons, and kettlebells and meditation in between.\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/timeoff-2024-02.html",
+            "incoming_links": [
+                "/bc",
+                "/timeoff"
+            ],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2024-02.md",
+            "outgoing_links": [
+                "/blueprint",
+                "/ig66/717",
+                "/sublime",
+                "/tesla"
+            ],
+            "redirect_url": "",
+            "title": "Time off Midwinter break 2024 - Divide and conquer",
+            "url": "/timeoff-2024-02"
+        },
+        "/timeoff-2024-04": {
+            "description": "It’s spring break 2024 and I’ve got a week off. The last few weeks have been a bit crazy at work trying to get some big features launched and into public testing, so very excited for the time off. I usually try to avoid too much tech, but I’m looking forward to making some tech investments as it’s been a while.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/timeoff-2024-04.html",
+            "incoming_links": [],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2024-04.md",
+            "outgoing_links": [
+                "/ai-testing",
+                "/terzepatide"
+            ],
+            "redirect_url": "",
+            "title": "Time off Spring break 2024 - Chillin",
+            "url": "/timeoff-2024-04"
+        },
+        "/timeoff-2024-08": {
+            "description": "I’m incredibly fortunate to be able to take 6 weeks off this summer! From when performance reviews finish to when the kids go back to school, it’ll be summer vacation.\n\n",
+            "doc_size": 28000,
+            "file_path": "_site/timeoff-2024-08.html",
+            "incoming_links": [
+                "/y24"
+            ],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2024-08.md",
+            "outgoing_links": [
+                "/happy",
+                "/moments",
+                "/mood",
+                "/td/slow_zsh",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Time off August 2024",
+            "url": "/timeoff-2024-08"
+        },
+        "/timeoff-2025-08": {
+            "description": "I’m incredibly fortunate to be able to take 6 weeks off this summer! After 5 years of service at Meta, you get 30 days (about 5 week) off!\n\n",
+            "doc_size": 34000,
+            "file_path": "_site/timeoff-2025-08.html",
+            "incoming_links": [],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/time-off-2025-08.md",
+            "outgoing_links": [
+                "/gap-year-igor",
+                "/happy",
+                "/moments",
+                "/mood",
+                "/terzepatie",
+                "/timeoff"
+            ],
+            "redirect_url": "",
+            "title": "Time off August 2025 - Meta Recharge",
+            "url": "/timeoff-2025-08"
+        },
+        "/todo_enjoy": {
+            "description": "It’s easy to forget the many, often tiny things that makes me happy. For when that happens, here’s some reminders:\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/todo_enjoy.html",
+            "incoming_links": [
+                "/operating-manual",
+                "/psychic-shadows"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/enjoy2.md",
+            "outgoing_links": [
+                "/eulogy"
+            ],
+            "redirect_url": "",
+            "title": "Things I enjoy",
+            "url": "/todo_enjoy"
+        },
+        "/tools": {
+            "description": "A collection of tips, tricks and pointers of the various tools i use\n\n",
+            "doc_size": 51000,
+            "file_path": "_site/tools.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_td/tool.md",
+            "outgoing_links": [
+                "/nlp",
+                "/osx",
+                "/td/ios",
+                "/td/ios-nomad"
+            ],
+            "redirect_url": "",
+            "title": "Igor's Tech, Tricks, and Tools",
+            "url": "/tools"
+        },
+        "/tori": {
+            "description": "\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/tori.html",
+            "incoming_links": [
+                "/eulogy",
+                "/gap-year-igor"
+            ],
+            "last_modified": "2025-08-19T10:23:51-07:00",
+            "markdown_path": "_d/tori.md",
+            "outgoing_links": [
+                "/partner-trouble"
+            ],
+            "redirect_url": "",
+            "title": "Tori",
+            "url": "/tori"
+        },
+        "/touching": {
+            "description": "It’s pretty easy to be overwhelmed by humanity sucking, but there is so much good in the world. Here are some great examples\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/touching.html",
+            "incoming_links": [
+                "/class-act",
+                "/end-in-mind",
+                "/joy",
+                "/sublime"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/touching2.md",
+            "outgoing_links": [
+                "/anxiety",
+                "/magic"
+            ],
+            "redirect_url": "",
+            "title": "Things that make me cry",
+            "url": "/touching"
+        },
+        "/toysfortots": {
+            "description": "One of the most satisfying (and fun) projects I worked on in my career was giving Alexa customers the ability to donate to charity and then have Amazon match their donations. What is most amazing about this project is we were able to go from zero to announcing our MVP live on Good Morning America in under 4 months which included all sorts of complexities, negotiations, and good luck.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/toysfortots.html",
+            "incoming_links": [
+                "/amazon",
+                "/eulogy"
+            ],
+            "last_modified": "2025-07-20T19:13:52-07:00",
+            "markdown_path": "_d/alexa-charity.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Donating to charity",
+            "url": "/toysfortots"
+        },
+        "/tribe": {
+            "description": "Finding your tribe is important - calling it a tribe makes it sound like I’m a contributing member of the community, perhaps this is more like things I’m a fanboy of.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/tribe.html",
+            "incoming_links": [],
+            "last_modified": "2024-11-10T16:13:17-08:00",
+            "markdown_path": "_d/tribe.md",
+            "outgoing_links": [
+                "/manager-book"
+            ],
+            "redirect_url": "",
+            "title": "My Tribe",
+            "url": "/tribe"
+        },
+        "/untangled": {
+            "description": "Parenting a teenage girl is like mastering the Turkish Get-Up – one of the most technically challenging kettlebell movements that requires patience, balance, and careful progression through distinct phases. Just when you think you’ve got one position figured out, it’s time to transition to the next, all while maintaining your stability and form (and not dropping a heavy weight on your head!). Lisa Damour’s “Untangled” is like having a master coach by your side, breaking down these intricate transitions into seven fundamental movements that take your daughter from childhood to adulthood.\n\n",
+            "doc_size": 67000,
+            "file_path": "_site/untangled.html",
+            "incoming_links": [],
+            "last_modified": "2025-02-02T09:46:23-08:00",
+            "markdown_path": "_d/untangled.md",
+            "outgoing_links": [
+                "/kettlebell"
+            ],
+            "redirect_url": "",
+            "title": "Untangled: Guiding Teenage Girls Through the Seven Transitions into Adulthood",
+            "url": "/untangled"
+        },
+        "/upstream": {
+            "description": "Imagine sitting enjoying a picnic with a friend at the side of a river. Suddenly you see a kid drowning, you and your friend dive in and save him. A few minutes later the same thing happens. When the third kid comes down river, your friend runs away. You scream at him - why the hell aren’t you helping. He replies, I’m running upstream to stop the bastard who’s throwing kids into the river. Upstream is the idea of solving problems before they start. It’s the basis of habit 3, First Things First, where we tackle the important not urgent.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/upstream.html",
+            "incoming_links": [
+                "/first-things-first"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/upstream.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Upstream - How to solve problems before they happen",
+            "url": "/upstream"
+        },
+        "/vibe": {
+            "description": "Vibe coding is the name for letting the ai write your code. The magic lies in AI’s ability to infer intent from vague input—say almost nothing, and it often gives you something surprisingly right. This works because you’re granting it wide degrees of freedom; as long as you’re flexible on the outcome, the model can generate plausible results from minimal cues. But that magic is fragile: on follow-up turns, or when you have a much tighter definition of correct, the inferred intent often changes, and the model applies a different set of constraints then you wanted or what it did previously, causing a cliff, or misery. Turns out this is the same as junior developers.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/vibe.html",
+            "incoming_links": [
+                "/ai",
+                "/chop"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/vibe.md",
+            "outgoing_links": [
+                "/chop"
+            ],
+            "redirect_url": "",
+            "title": "Vibe Coding: Best Practices for Flow, Fun, and Results",
+            "url": "/vibe"
+        },
+        "/vim": {
+            "description": "I used Vim for years, but have now transitioned to Neovim. While most of these tips work in both editors, some are Neovim-specific. Here’s my collection of tips I want to practice and remember.\n\n",
+            "doc_size": 13000,
+            "file_path": "_site/vim.html",
+            "incoming_links": [
+                "/enable"
+            ],
+            "last_modified": "2025-02-08T12:16:42-08:00",
+            "markdown_path": "_d/vim_tips.md",
+            "outgoing_links": [
+                "/neovim"
+            ],
+            "redirect_url": "",
+            "title": "Igors Vim Tips",
+            "url": "/vim"
+        },
+        "/vim-for-writing": {
+            "description": "VIM is great at lots of things, but free form writing has a few gaps in ‘line wrapping’ and ‘distraction free visual beauty’. These gaps can be closed with the plugins Pencil, Goyo and LimeLight.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/vim-for-writing.html",
+            "incoming_links": [
+                "/enable",
+                "/writing"
+            ],
+            "last_modified": "2025-02-08T12:16:42-08:00",
+            "markdown_path": "_posts/2016-5-1-vim-for-writing.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Vim For Writing",
+            "url": "/vim-for-writing"
+        },
+        "/viz": {
+            "description": "Good visualizations transform data into insights and stories into understanding. They serve as a universal language that can communicate complex ideas quickly and clearly. Whether you’re creating diagrams for technical documentation or charts for business presentations, the key is matching your visual vocabulary to your message.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/viz.html",
+            "incoming_links": [
+                "/writing"
+            ],
+            "last_modified": "2025-07-20T19:13:52-07:00",
+            "markdown_path": "_d/viz.md",
+            "outgoing_links": [
+                "/td/visual-vocabulary"
+            ],
+            "redirect_url": "",
+            "title": "Data Visualizations and Visual Storytelling",
+            "url": "/viz"
+        },
+        "/vlc": {
+            "description": "IINA Player Keyboard Shortcuts\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/vlc.html",
+            "incoming_links": [],
+            "last_modified": "2025-06-07T09:22:10-07:00",
+            "markdown_path": "_d/vlc_player.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "IINA Player Keyboard Shortcuts",
+            "url": "/vlc"
+        },
+        "/voices": {
+            "description": "The person that most frequently blocks your success is, wait for it, you! Often it’s your subconscious, and often your subconscious is a bunch of independent voices. It’s hard to deal with this hidden opposition because it’s so opaque. To help understand your feelings, you can name the voices in your head, and imagine asking each of them their positions and desired outcomes.\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/voices.html",
+            "incoming_links": [
+                "/anxiety",
+                "/blueprint",
+                "/depression",
+                "/emotional-health",
+                "/mind-monsters",
+                "/operating-manual"
+            ],
+            "last_modified": "2024-04-14T19:24:46-07:00",
+            "markdown_path": "_posts/2017-01-01-voices-in-my-head.md",
+            "outgoing_links": [
+                "/anxiety",
+                "/curious",
+                "/terzepatide",
+                "/win-win"
+            ],
+            "redirect_url": "",
+            "title": "Voices in my head - A survey of my personalities",
+            "url": "/voices"
+        },
+        "/warm": {
+            "description": "Staying warm is important, here’s the gear I use on and off the bike\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/warm.html",
+            "incoming_links": [
+                "/bike"
+            ],
+            "last_modified": "2023-02-17T15:52:23+00:00",
+            "markdown_path": "_posts/2017-9-29-staying-warm-and-biking.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Staying warm",
+            "url": "/warm"
+        },
+        "/weeks": {
+            "description": "\n\n",
+            "doc_size": 4314000,
+            "file_path": "_site/weeks.html",
+            "incoming_links": [
+                "/balance"
+            ],
+            "last_modified": "2024-04-09T09:09:21-07:00",
+            "markdown_path": "_d/weeks.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Life in Weeks",
+            "url": "/weeks"
+        },
+        "/welcome-to-holland": {
+            "description": "“Welcome to Holland” articulates expectation, blame, and acceptance in a heart warming easy to read story.\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/welcome-to-holland.html",
+            "incoming_links": [
+                "/getting-to-yes-with-yourself"
+            ],
+            "last_modified": "2018-12-25T15:32:00-08:00",
+            "markdown_path": "_posts/2015-12-26-welcome-to-holland.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Welcome to Holland",
+            "url": "/welcome-to-holland"
+        },
+        "/what-makes-a-leader": {
+            "description": "Emotional intelligence (EI) is the crux of leadership. EI is comprised of Self-Awareness, Self-Regulation, Motivation, Empathy and Social Skills. This is a summary of Dan Goleman’s What makes a leader. Before we begin, here’s a consulting 2x2 grid:\n\n",
+            "doc_size": 15000,
+            "file_path": "_site/what-makes-a-leader.html",
+            "incoming_links": [
+                "/manager-book",
+                "/siy"
+            ],
+            "last_modified": "2025-07-12T16:50:19-07:00",
+            "markdown_path": "_posts/2018-11-25-what-makes-a-leader-great.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "What makes a leader",
+            "url": "/what-makes-a-leader"
+        },
+        "/why-is-no-one-referring": {
+            "description": "Your customers don’t provide referrals because it’s a risk to their credibility. Remove the credibility risk, and your referrals will follow.\n\n",
+            "doc_size": 14000,
+            "file_path": "_site/why-is-no-one-referring.html",
+            "incoming_links": [],
+            "last_modified": "2025-08-22T10:48:49-07:00",
+            "markdown_path": "_posts/2015-3-13-why-is-no-one-referring.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Why Is No One Referring My Project",
+            "url": "/why-is-no-one-referring"
+        },
+        "/win-win": {
+            "description": "Win/Win is a constantly seeking mutual benefit in all interactions. Win/Win means that agreements or solutions are mutually beneficial, mutually satisfying. With a Win/Win solution, all parties feel good about the decision and feel committed to the action plan. Win/Win sees life as a cooperative, not a competitive arena. Most people tend to think in terms of dichotomies: strong or weak, hardball or softball, win or lose. But that kind of thinking is fundamentally flawed. It’s based on power and position rather than on principle. Win/Win is based on the paradigm that there is plenty for everybody, that one person’s success is not achieved at the expense or exclusion of the success of others.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/win-win.html",
+            "incoming_links": [
+                "/7-habits",
+                "/curious",
+                "/negotiate",
+                "/sell",
+                "/synergize",
+                "/voices",
+                "/work-satisfaction"
+            ],
+            "last_modified": "2024-10-05T21:24:07-07:00",
+            "markdown_path": "_d/7h-c4.md",
+            "outgoing_links": [
+                "/7-habits"
+            ],
+            "redirect_url": "",
+            "title": "Win/win or no deal",
+            "url": "/win-win"
+        },
+        "/work-satisfaction": {
+            "description": "Love your work, and you’ll never work a day in your life. Sounds great, but work ain’t no Caribbean cruise - one you pay for, and the other pays you. Work should be satisfying (SAT). You should be enjoying solving hard problems, getting opportunities to talk with like-minded people, and even being forced to stretch and grow. Work should also cause you dissatisfaction (DSAT). Some days your boss will piss you off, your co-workers will misunderstand you, and you will be forced to do something you don’t want to. Satisfaction is not a lack of dissatisfaction; they are orthogonal experiences. DSAT is what makes you sleep poorly, and SAT is what makes you set your alarm early Monday morning so you can get back to your favorite project, and to hang out with your awesome team.  By understanding our SAT and DSAT, we can change them, and transform hours slogging into time at the fantasy cruise bar.\n\n",
+            "doc_size": 27000,
+            "file_path": "_site/work-satisfaction.html",
+            "incoming_links": [
+                "/manager-book",
+                "/mind-at-work",
+                "/retire"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/sat_dsat.md",
+            "outgoing_links": [
+                "/comp",
+                "/decisive",
+                "/dip",
+                "/eulogy",
+                "/first-understand",
+                "/insecure",
+                "/job-hunt-stress",
+                "/manager-book",
+                "/mental-pain",
+                "/mind-at-work",
+                "/negotiate",
+                "/overload",
+                "/shame",
+                "/sustainable-work",
+                "/win-win"
+            ],
+            "redirect_url": "",
+            "title": "Satisfaction is not the lack of dissatisfaction",
+            "url": "/work-satisfaction"
+        },
+        "/write-book": {
+            "description": "My notes on writing books, mostly from Write Useful Books\n\n",
+            "doc_size": 18000,
+            "file_path": "_site/write-book.html",
+            "incoming_links": [
+                "/y24"
+            ],
+            "last_modified": "2025-07-20T19:26:41-07:00",
+            "markdown_path": "_d/book-writing.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "How to write a book",
+            "url": "/write-book"
+        },
+        "/writing": {
+            "description": "Useful writing tells people (including, possibly most importantly you) something true and important that they didn’t already know in a way that leaves no doubt. Most writing is bad. Not due to spelling, punctuation or grammar, but due to lack of critical thinking. Critical thinking like analysis, synthesis, simplification, and presentation. To quote someone smart “If you’re thinking without writing, you’re only thinking about thinking”.\n\n",
+            "doc_size": 40000,
+            "file_path": "_site/writing.html",
+            "incoming_links": [
+                "/90days",
+                "/affirmations",
+                "/amazon",
+                "/chow",
+                "/enable",
+                "/manager-book",
+                "/manager-book-appendix",
+                "/operating-manual"
+            ],
+            "last_modified": "2025-08-22T11:54:12-07:00",
+            "markdown_path": "_d/writing.md",
+            "outgoing_links": [
+                "/7h-concepts",
+                "/90days",
+                "/amazon",
+                "/coaching",
+                "/coe",
+                "/enable",
+                "/td/ios",
+                "/td/ios-nomad",
+                "/vim-for-writing",
+                "/viz"
+            ],
+            "redirect_url": "",
+            "title": "Writing is Thinking",
+            "url": "/writing"
+        },
+        "/y24": {
+            "description": "I like to begin in mind, so let’s write a report for 2024. This hasn’t happened, but if I don’t write it out and focus on it, it certainly won’t.\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/y24.html",
+            "incoming_links": [
+                "/gap-year",
+                "/gap-year-igor"
+            ],
+            "last_modified": "2025-09-13T12:56:01-07:00",
+            "markdown_path": "_d/y2024.md",
+            "outgoing_links": [
+                "/42",
+                "/ai-bestie",
+                "/chop",
+                "/kettlebell",
+                "/last-year",
+                "/manager-book",
+                "/mental-pain",
+                "/process-journal",
+                "/timeoff-2024-08",
+                "/write-book"
+            ],
+            "redirect_url": "",
+            "title": "Igor's plan for 2024",
+            "url": "/y24"
+        },
+        "/y25": {
+            "description": "I like to begin in mind, so let’s write a report for 2025. This hasn’t happened, but if I don’t write it out and focus on it, it certainly won’t.\n\n",
+            "doc_size": 19000,
+            "file_path": "_site/y25.html",
+            "incoming_links": [
+                "/gap-year",
+                "/gap-year-igor"
+            ],
+            "last_modified": "2025-06-19T08:16:44-07:00",
+            "markdown_path": "_d/y2025.md",
+            "outgoing_links": [
+                "/42",
+                "/chapters",
+                "/chop",
+                "/content-creation",
+                "/last-year",
+                "/manager-book",
+                "/process-journal"
+            ],
+            "redirect_url": "",
+            "title": "Igor's plan for 2025",
+            "url": "/y25"
+        }
     }
-  }
 }


### PR DESCRIPTION
## Summary
- Resolves fragment validation failures in pre-commit link checking
- Fixes base URL resolution so fragments resolve to current page instead of root
- Excludes GitHub line number fragments from validation to prevent false positives
- Converts broken external links to plain text annotations

## Key Changes
- **Fixed base URL resolution**: Uses page-specific URLs (e.g., `/ai-journal`) as base for fragment validation
- **GitHub fragment exclusion**: Skip validation of `#L123` style GitHub source links
- **Eliminate duplicate checking**: Only check URL once, not both file and URL
- **Broken link cleanup**: Convert known broken links to plain text with "(broken link)" annotations

## Test Plan
- [x] Pre-commit passes on ai-journal.md changes
- [x] Fragment validation works correctly for internal page links
- [x] GitHub line fragments properly excluded
- [x] No false positive fragment errors

## Before/After
**Before**: 18+ fragment validation errors (mostly false positives)  
**After**: 0 errors, 147 successful links, 12 properly excluded

🤖 Generated with [Claude Code](https://claude.ai/code)