### PR TITLE
Add comprehensive content guidelines by post type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,17 +39,6 @@ This file will direct you to all other convention files you need to follow.
 
 **Never skip consulting content_guidelines.md when creating or editing blog content.**
 
-### Quick Reference (See content_guidelines.md for full details)
-- Use "I" for personal perspective, not "we"
-- Direct and concise - avoid flowery language
-- Prefer bullet points over long paragraphs
-- Personal but pragmatic tone
-- Use questions to engage readers
-- Avoid unnecessary adjectives (wonderful, beautiful, etc.)
-- Get to the point quickly
-- Use concrete examples over abstract concepts
-- Match existing post tone when editing
-
 ### Voice Consistency
 - Conversational but not casual
 - Problem-focused rather than solution-preaching

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,15 @@ This file will direct you to all other convention files you need to follow.
 
 ## Blog Writing Style
 
+**VERY IMPORTANT:** Always reference and follow the comprehensive content guidelines in `content_guidelines.md` when working on any blog posts. This file contains:
+- 8 distinct content types with specific guidelines
+- Universal writing style rules
+- Technical implementation details for alert boxes, redirects, book links, and images
+- Content development workflow
+
+**Never skip consulting content_guidelines.md when creating or editing blog content.**
+
+### Quick Reference (See content_guidelines.md for full details)
 - Use "I" for personal perspective, not "we"
 - Direct and concise - avoid flowery language
 - Prefer bullet points over long paragraphs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,36 +39,6 @@ This file will direct you to all other convention files you need to follow.
 
 **Never skip consulting content_guidelines.md when creating or editing blog content.**
 
-### Voice Consistency
-- Conversational but not casual
-- Problem-focused rather than solution-preaching
-- Use "you" when addressing reader directly
-- Self-deprecating humor is okay, but sparingly
-
-### Structure
-- Start with the problem or question
-- Use subheadings liberally for scanning
-- One main idea per paragraph
-- Link to related posts using relative paths (/post-name)
-
-### Technical Writing
-- Code examples should be practical and runnable
-- Explain the "why" before the "how"
-- Include potential pitfalls or gotchas
-- Test all code snippets before including
-
-### Engagement Patterns
-- Ask rhetorical questions to introduce topics
-- Use "Here's what I learned" rather than "You should do this"
-- Include personal anecdotes when relevant
-- End sections with actionable takeaways
-
-### Avoid
-- Marketing speak or buzzwords
-- Overly philosophical tangents
-- Excessive self-promotion
-- Long introductions - get to the meat quickly
-
 ## Code Style Guidelines
 
 - Use TypeScript for all new code with strict typing

--- a/content_guidelines.md
+++ b/content_guidelines.md
@@ -1,0 +1,264 @@
+# Content Guidelines by Post Type
+
+## Core Consistency Rules
+
+### Style Consistency Principle
+**If you choose to deviate from the recommended style guidelines below, maintain that deviation consistently throughout the entire piece.** Mixing styles within a single post creates jarring reader experiences.
+
+**Examples of acceptable consistent deviations:**
+- Using "we" throughout an entire post (but never mixing "we" and "I")
+- Writing in third person for a specific piece (but maintaining it throughout)
+- Using formal academic tone for technical content (but not switching to conversational mid-post)
+- Adopting a specific narrative voice for storytelling posts
+
+### Inconsistency Warnings
+**AI assistants and editors should flag these inconsistencies:**
+- ❌ Switching between "I" and "we" within the same post
+- ❌ Mixing formal and conversational tones randomly
+- ❌ Starting personal then becoming impersonal
+- ❌ Inconsistent use of headers, bullet styles, or formatting
+- ❌ Switching between metaphorical frameworks mid-post
+- ❌ Changing target audience assumptions (expert → beginner → expert)
+
+**The goal:** Readers should feel like they're having one coherent conversation, not multiple conversations stitched together.
+
+---
+
+## Universal Writing Style (All Content)
+
+### Voice and Perspective
+- **Always use "I"** for personal perspective, never "we"
+- **Direct and concise** - avoid flowery language where it obscures meaning
+- **Personal but pragmatic** tone
+- **Conversational** - write like you're having coffee with a thoughtful friend
+- **Vulnerable but authoritative** - show uncertainty alongside expertise
+
+### Language Patterns
+- **Questions to engage readers** and introduce new sections
+- **Concrete examples** over abstract concepts
+- **"Here's what I learned"** rather than "You should do this"
+- **Strategic use of rich metaphors** when they enhance understanding
+- **Self-deprecating humor** used sparingly but effectively
+
+### Structure Elements
+- **Extensive use of headers** for easy scanning
+- **Bullet points** to chunk information
+- **Table of contents** for longer pieces (auto-generated via vim-markdown-toc)
+- **Cross-linking** between related content
+- **Progressive revelation** - build complexity throughout posts
+
+### Engagement Techniques
+- **Rhetorical questions** as section breaks
+- **Direct reader address** ("I bet you don't either")
+- **Dialog format** for internal conflicts and decision-making
+- **Real-time authenticity** - admit uncertainty and show work in progress
+- **Meta-commentary** on your own writing and thinking process
+
+---
+
+## Content Type Guidelines
+
+### 1. Book Summaries/Reviews
+**Purpose:** Process learning and share insights from books that shaped your thinking
+
+**Structure:**
+- Always include book cover image and Amazon affiliate link
+- Use chapter-by-chapter breakdown for systematic books
+- Include "Why this book matters" section
+- End with "How this applies to you" practical takeaways
+
+**Voice:** Analytical teacher - "Here's what I learned and how you can apply it"
+
+**Key Elements:**
+- Heavy use of structured outlines and bullet points
+- Personal application examples throughout
+- Quote key passages that resonated
+- Connect to your existing frameworks and other books
+
+**Length:** 300-600 lines typically
+
+**Tags:** `book-notes`, plus relevant topic tags
+
+### 2. Personal Philosophy/Identity Posts
+**Purpose:** Work through fundamental life questions while creating frameworks others can use
+
+**Structure:**
+- Start with personal stakes - why this matters to you
+- Use creative metaphors consistently throughout (dragons, circles, etc.)
+- Include both emotional and logical analysis
+- Create memorable frameworks with clear components
+
+**Voice:** Vulnerable philosopher - "Here's how I think about life"
+
+**Key Elements:**
+- **Dialog format** for internal conflicts ("Dragon:" conversations)
+- **Extensive personal anecdotes** as proof points
+- **Alert boxes** for important caveats
+- **Visual elements** (images, diagrams) to break up text
+- **Cross-references** to related life frameworks
+
+**Length:** 400-1000+ lines for major pieces
+
+**Tags:** `how igor ticks`, plus relevant topics
+
+### 3. Professional/Management Content
+**Purpose:** Share hard-won workplace wisdom and practical frameworks
+
+**Structure:**
+- Start with the problem/challenge
+- Provide systematic framework or approach
+- Include specific workplace examples
+- Link to deeper reference materials
+- Include "what doesn't work" sections
+
+**Voice:** Experienced practitioner - "Here's what works in practice"
+
+**Key Elements:**
+- **Tactical advice** with concrete steps
+- **War stories** from actual management experience
+- **References to "Igor's book of..."** deeper materials
+- **Quantified examples** where possible
+- **Team scenarios** and people stories
+
+**Length:** 150-300 lines typically
+
+**Tags:** `manager`, `software engineering`, `emotional intelligence`
+
+### 4. Reference/Framework Content
+**Purpose:** Create comprehensive, living documents for personal and public use
+
+**Structure:**
+- Comprehensive table of contents
+- Clear section headers for easy navigation
+- "Quick reference" sections for immediate use
+- Update logs showing evolution over time
+
+**Voice:** Systematic organizer - "Here's a complete framework"
+
+**Key Elements:**
+- **Heavy cross-linking** between related concepts
+- **Actionable sections** with specific steps
+- **Examples and scenarios** for each major point
+- **Regular updates** with new insights
+- **Multiple entry points** for different use cases
+
+**Length:** 500-1000+ lines for comprehensive guides
+
+**Tags:** `framework`, `reference`, plus topic-specific tags
+
+### 5. Major Life Decision Documentation
+**Purpose:** Work through significant choices while creating reusable decision-making frameworks
+
+**Structure:**
+- Establish stakes and timeline
+- Map out all considerations systematically
+- Use creative metaphors to explore emotional aspects
+- Document decision-making process in real-time
+- Include uncertainty and evolution of thinking
+
+**Voice:** Thoughtful decision-maker - "Here's how I'm working through this"
+
+**Key Elements:**
+- **Real-time processing** with timestamps
+- **Both rational and emotional analysis**
+- **Creative frameworks** (dragons, councils, etc.)
+- **Progress tracking** and milestone documentation
+- **Honest uncertainty** and course corrections
+
+**Length:** 700+ lines for major decisions
+
+**Tags:** `decision-making`, plus relevant life area tags
+
+### 6. Practical Hobby/Lifestyle Posts
+**Purpose:** Share what works in daily life - products, approaches, systems
+
+**Structure:**
+- Problem or need statement
+- Solution overview
+- Specific recommendations with reasoning
+- Personal experience and results
+- Alternative options and trade-offs
+
+**Voice:** Helpful enthusiast - "Here's what works for me"
+
+**Key Elements:**
+- **Product links** and specific model numbers
+- **Personal experience** with timeline
+- **Comparison with alternatives**
+- **Practical setup tips**
+- **Cost/benefit analysis**
+
+**Length:** 50-200 lines typically
+
+**Tags:** `toys`, `biking`, `health`, plus specific categories
+
+### 7. Journal/Exploration Content
+**Purpose:** Think through emerging topics and capture evolving insights
+
+**Structure:**
+- Date-based entries showing progression
+- Stream-of-consciousness exploration
+- Questions and uncertainties
+- Links to related reading/research
+- Periodic synthesis and pattern identification
+
+**Voice:** Curious explorer - "Here's what I'm figuring out"
+
+**Key Elements:**
+- **Experimental thinking** without predetermined conclusions
+- **Question collections** and research notes
+- **Pattern recognition** across different inputs
+- **Regular synthesis** attempts
+- **Links to external sources** and influences
+
+**Length:** Variable, grows over time
+
+**Tags:** `exploration`, `journal`, plus topic tags
+
+---
+
+## Content Development Workflow
+
+### 1. Start with Purpose
+- **Personal processing** - What am I trying to figure out?
+- **Public value** - How can this help others?
+- **Framework building** - What systematic approach am I developing?
+
+### 2. Choose Content Type
+- Match your purpose to the appropriate content type above
+- Consider hybrid approaches for complex topics
+- Plan for potential evolution (exploration → framework → published advice)
+
+### 3. Apply Type-Specific Guidelines
+- Use the voice and structure patterns for your chosen type
+- Include all key elements relevant to that content type
+- Follow the suggested length guidelines
+
+### 4. Cross-Link and Connect
+- Reference related content throughout
+- Build connections between different frameworks
+- Update existing content with new insights
+
+### 5. Tag and Organize
+- Use consistent tagging system
+- Include type-specific tags plus topic tags
+- Consider searchability and future discovery
+
+---
+
+## Special Considerations
+
+### Dual-Purpose Content
+Most substantial content should serve both personal processing AND public teaching. This is your superpower - turning personal work into valuable public content.
+
+### Living Documents
+Many pieces should be treated as living documents that get updated over time with new insights, examples, and refinements.
+
+### Authentic Vulnerability
+Your willingness to show uncertainty, mistakes, and work-in-progress thinking is what makes the content uniquely valuable. Maintain this across all content types.
+
+### Framework Thinking
+You naturally build systematic approaches to complex topics. Lean into this strength by making frameworks explicit and reusable.
+
+### Meta-Awareness
+Your ability to comment on your own thinking process adds depth and authenticity. Include this meta-commentary where it serves the content.

--- a/content_guidelines.md
+++ b/content_guidelines.md
@@ -294,3 +294,124 @@ You naturally build systematic approaches to complex topics. Lean into this stre
 
 ### Meta-Awareness
 Your ability to comment on your own thinking process adds depth and authenticity. Include this meta-commentary where it serves the content.
+
+---
+
+## Technical Implementation Guide
+
+### Alert Boxes
+Use alert boxes to highlight important information, warnings, or construction notices:
+
+**Syntax:**
+```liquid
+{% include alert.html content="Your message here" style="info" %}
+{% include alert.html content="Warning or caution message" style="warning" %}
+{% include alert.html content="Work in progress notice" style="danger" %}
+```
+
+**Common use cases:**
+- Construction/work-in-progress notices
+- Important caveats or disclaimers
+- Cross-references to related content
+- Privilege acknowledgments
+
+**Example:**
+```liquid
+{% include alert.html content="🚧 Construction Zone 🚧 This post is in heavy progress! 🔨 Check back later for updates ⏳" style="warning" %}
+```
+
+### URL Redirects
+Set up redirects for shorter, memorable URLs using both `redirect_from` and `alias`:
+
+**Syntax:**
+```yaml
+redirect_from:
+  - /shortname
+  - /abbreviation
+alias:
+  - /shortname
+  - /abbreviation
+```
+
+**Example:**
+```yaml
+redirect_from:
+  - /7habits
+  - /7h
+alias:
+  - /7habits
+  - /7h
+```
+
+### Book Links and Amazon Affiliate Integration
+For book references, use Amazon affiliate links with specific formatting:
+
+**Format:**
+```markdown
+[Book Title](https://www.amazon.com/[PRODUCT-PATH])
+```
+
+**Best practices:**
+- Include book cover images when available
+- Use consistent affiliate link format
+- Place links naturally within context
+- Consider using book title as the link text
+
+### Images
+Use the custom image includes for consistent formatting:
+
+**Right-floating images:**
+```liquid
+{% include blob_image_float_right.html src="blog/image-name.webp" %}
+```
+
+**Standard images:**
+```liquid
+{% include blob_image.html src="blog/image-name.webp" %}
+```
+
+**Small right-floating images (25% width):**
+```liquid
+{% include blob_image_float_right_w25.html src="blog/image-name.webp" %}
+```
+
+**Image best practices:**
+- Use WebP format for efficiency
+- Store images in the GitHub blob: `https://github.com/idvorkin/blob/raw/master/blog/filename.webp`
+- Reference using relative paths in includes: `blog/filename.webp`
+- Place floating images near relevant text sections
+
+### Cross-References and Internal Linking
+Use the summarize-page include for rich internal linking:
+
+**Syntax:**
+```liquid
+{% include summarize-page.html src="/page-name" %}
+```
+
+**When to use:**
+- Referencing related comprehensive posts
+- Building connections between related frameworks
+- Providing deeper dive options
+- Creating content clusters around themes
+
+### Jekyll Front Matter Essentials
+Include these key elements in post front matter:
+
+```yaml
+---
+title: "Your Post Title"
+layout: post
+permalink: /url-slug
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/image.webp
+tags:
+  - relevant-tag
+  - category-tag
+redirect_from:
+  - /short-url
+alias:
+  - /short-url
+---
+```
+
+**IMPORTANT IMPLEMENTATION RULE:** Always use these technical elements consistently. Alert boxes for important notices, redirects for memorable URLs, affiliate links for books, proper image includes for formatting, and summarize-page includes for internal references.

--- a/content_guidelines.md
+++ b/content_guidelines.md
@@ -344,18 +344,32 @@ alias:
 ```
 
 ### Book Links and Amazon Affiliate Integration
-For book references, use Amazon affiliate links with specific formatting:
+Use the Amazon include for book references with ASIN numbers:
 
-**Format:**
-```markdown
-[Book Title](https://www.amazon.com/[PRODUCT-PATH])
+**Syntax:**
+```liquid
+{% include amazon.html asin="ASIN_NUMBER" %}
+{% include amazon.html asin="ASIN1;ASIN2;ASIN3" %}
 ```
 
+**Examples:**
+```liquid
+{% include amazon.html asin="0071499938" %}
+{% include amazon.html asin="B07LDSPRYM;B00506CSDQ;B07C66Z4M4" %}
+```
+
+**How it works:**
+- ASINs are looked up in `_data/asins.json` for title, image, and description
+- Automatically includes affiliate tag (`ighe-20`)
+- Falls back to generic Amazon image if product data not available
+- Supports multiple books separated by semicolons
+- Images are styled consistently with fallback text if images fail to load
+
 **Best practices:**
-- Include book cover images when available
-- Use consistent affiliate link format
-- Place links naturally within context
-- Consider using book title as the link text
+- Use ASIN numbers (found in Amazon URLs) rather than direct links
+- Group related books together in single include
+- Place near relevant text sections
+- ASIN data is managed automatically via scripts in `/scripts/` directory
 
 ### Images
 Use the custom image includes for consistent formatting:
@@ -389,11 +403,25 @@ Use the summarize-page include for rich internal linking:
 {% include summarize-page.html src="/page-name" %}
 ```
 
+**How it works:**
+- Automatically pulls title and description from the linked page
+- Creates a styled summary box with proper attribution
+- Uses data from `back-links.json` for consistent metadata
+- Provides rich preview of the linked content
+
 **When to use:**
 - Referencing related comprehensive posts
 - Building connections between related frameworks
 - Providing deeper dive options
 - Creating content clusters around themes
+- Cross-linking between book summaries and related life posts
+
+**Examples:**
+```liquid
+{% include summarize-page.html src="/7habits" %}
+{% include summarize-page.html src="/death" %}
+{% include summarize-page.html src="/gap-year" %}
+```
 
 ### Jekyll Front Matter Essentials
 Include these key elements in post front matter:

--- a/content_guidelines.md
+++ b/content_guidelines.md
@@ -30,29 +30,37 @@
 - **Always use "I"** for personal perspective, never "we"
 - **Direct and concise** - avoid flowery language where it obscures meaning
 - **Personal but pragmatic** tone
-- **Conversational** - write like you're having coffee with a thoughtful friend
+- **Conversational vulnerability** - write like you're having coffee with a thoughtful friend who shares real struggles
 - **Vulnerable but authoritative** - show uncertainty alongside expertise
+- **Systems thinking approach** - naturally build frameworks and structured approaches
+- **Metaphorical thinking** - use consistent metaphors (dragons, mountains, rivers) to explain complex concepts
 
 ### Language Patterns
 - **Questions to engage readers** and introduce new sections
 - **Concrete examples** over abstract concepts
 - **"Here's what I learned"** rather than "You should do this"
 - **Strategic use of rich metaphors** when they enhance understanding
-- **Self-deprecating humor** used sparingly but effectively
+- **Self-deprecating humor** with phrases like "completely aspirational" and acknowledgment of personal flaws
+- **Vulnerability as strength** - openly discussing fears, failures, and contradictions
+- **Research integration** - heavy citing of books, studies, and external sources
 
 ### Structure Elements
 - **Extensive use of headers** for easy scanning
 - **Bullet points** to chunk information
 - **Table of contents** for longer pieces (auto-generated via vim-markdown-toc)
-- **Cross-linking** between related content
-- **Progressive revelation** - build complexity throughout posts
+- **Heavy cross-referencing** using `{% include summarize-page.html %}` for internal linking
+- **Progressive disclosure** - start with simple concepts, then drill deeper
+- **Iterative development** - posts evolve over time with update notes
+- **Framework building** - most posts end with practical application methods
 
 ### Engagement Techniques
 - **Rhetorical questions** as section breaks
 - **Direct reader address** ("I bet you don't either")
-- **Dialog format** for internal conflicts and decision-making
+- **Dialog format** for internal conflicts and decision-making (real and imagined conversations)
 - **Real-time authenticity** - admit uncertainty and show work in progress
 - **Meta-commentary** on your own writing and thinking process
+- **Personal anecdotes as teaching tools** - stories that illustrate broader principles
+- **Pre-mortem/scenario planning** - regular use of "what if" thinking
 
 ---
 
@@ -214,6 +222,30 @@
 **Length:** Variable, grows over time
 
 **Tags:** `exploration`, `journal`, plus topic tags
+
+### 8. Personal Narrative/Story Posts
+**Purpose:** Use personal stories and experiences as teaching tools to illustrate broader principles
+
+**Structure:**
+- Set scene with personal context
+- Develop story with specific details and dialogue
+- Extract universal principles or lessons
+- Connect to broader frameworks or life philosophy
+- Invite reader reflection or application
+
+**Voice:** Reflective storyteller - "Here's what this experience taught me"
+
+**Key Elements:**
+- **AI conversations** with Tony (life coach) showing real-time processing
+- **Family adventures and moments** that illustrate larger principles
+- **Life transition narratives** about major changes and decisions
+- **Identity conflict stories** (bike vs car, work vs family, etc.)
+- **Dialogue format** showing internal or external conversations
+- **Specific sensory details** that make stories vivid and memorable
+
+**Length:** 200-800 lines typically
+
+**Tags:** `story`, `narrative`, plus relevant life area tags
 
 ---
 


### PR DESCRIPTION
## Summary
- Creates systematic content guidelines organized by 7 distinct post types
- Establishes consistency rules to prevent style mixing within posts
- Provides type-specific voice, structure, and length guidelines
- Supports Igor's dual-purpose content approach (personal processing + public value)

## Key Features
- **Universal style guidelines** that apply to all content
- **7 content types**: Book summaries, personal philosophy, professional advice, reference frameworks, life decisions, practical lifestyle, and journal exploration
- **Consistency rules** with specific warnings for AI assistants to flag
- **Content development workflow** from purpose to publication
- **Type-specific guidelines** including voice, structure, key elements, and tags

## Test plan
- [x] Guidelines cover all existing content patterns identified in blog analysis
- [x] Consistency rules address common style mixing issues
- [x] Type-specific sections provide actionable guidance
- [x] Document supports both personal and AI-assisted content creation

🤖 Generated with [Claude Code](https://claude.ai/code)