### PR TITLE
Add mandatory pre-commit check instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,13 @@ When adding new features or fixing bugs, **always add both unit tests and e2e te
 
 ### Commit Guidelines
 
+- **ALWAYS run pre-commit checks before committing** - This is mandatory:
+  ```bash
+  pre-commit run --files <files-you-modified>
+  ```
+  - Pre-commit checks validate links, formatting, and other quality checks
+  - Never skip this step - it catches issues before they reach the repo
+  - If pre-commit modifies files, review changes and commit them too
 - **Generated JS files ARE committed** (assets/js/index.js, assets/js/index.js.map)
 - Commit both TypeScript source files (src/\*.ts) and the generated JS bundle
 - JS files are built from TypeScript and should be tracked in git for Jekyll deployment


### PR DESCRIPTION
Fixes #186

Added prominent instructions in CLAUDE.md to ensure Claude always runs pre-commit checks before committing.

## Changes
- Added mandatory pre-commit check section at the top of "Commit Guidelines"
- Included command example and explanation of validation
- Clarified that checks are mandatory and never to be skipped
- Added guidance on handling files modified by hooks

🤖 Generated with [Claude Code](https://claude.ai/code)