### PR TITLE
Edit devotional text on authentic self

### DIFF
--- a/_d/walking-with-god.md
+++ b/_d/walking-with-god.md
@@ -326,6 +326,8 @@ _Here's how I translate this:_
 
 This is about the work of finding who you really are and then having the courage to be that person - even when the world pushes back against it. For me, finding my authentic self meant working on [my eulogy](/eulogy) - literally writing out who I want to be and how I want to be remembered. It's not a one-time decision. It's constant assessment: Am I being who I want to be? Am I living aligned with my true self? And then doing the hard work of course-correcting when the answer is no.
 
+{%include summarize-page.html src="/eulogy" %}
+
 The world wants you to fit in. To be comfortable. To not make waves. But when you're being your essentialist self - when you're living authentically as who you actually are - you won't fit comfortably into the world's boxes. You'll be ill-adapted to the standardized paths everyone else is walking.
 
 And that's the point.
@@ -338,9 +340,7 @@ The work is worth it. Being a satisfied misfit beats being a miserable conformis
 
 **Important distinction:** This isn't about being contrarian for its own sake or rejecting everything conventional just to be different. It's about knowing yourself well enough to recognize when fitting in would require betraying who you are. Some people's true selves happen to align well with conventional paths - that's fine. But if your true self doesn't fit the mold, forcing yourself into it creates a different kind of suffering. The goal is authenticity, not rebellion. The misfit status is a side effect, not the objective.
 
-{%include summarize-page.html src="/eulogy" %}
 {%include summarize-page.html src="/essentialism" %}
-{%include summarize-page.html src="/e1" %}
 
 ### December
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new November 1st devotional entry (“Jesus in This World”) and updates the TOC accordingly.
> 
> - **Content update** (`_d/walking-with-god.md`):
>   - **New entry**: `#### November 1st - Jesus in This World` with reflections on authenticity/essentialism and an “Important distinction” section.
>   - **Cross-links**: Adds `{%include summarize-page.html %}` links to `/eulogy`, `/essentialism`, and `/e1`.
>   - **TOC**: Adds `November 1st - Jesus in This World` link under November.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73f411babf360ca5294ad90e59d66177786056dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a November 1st devotional titled "Jesus in This World" with translation notes, interpretation, and rationale.
  * Included a reflective section on authentic self vs. misfit authenticity with links to related essays.
  * Updated the November table of contents to include the new entry and mirrored the piece in the public content flow, plus summarized links to related resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->