### PR TITLE
Add 'Failure is Data not Disaster' section to fail.md

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -88,6 +88,9 @@ emacs = "emacs"
 # Greek words for love (linguistic relativity post)
 Storge = "Storge"  # Greek word for familial love
 storge = "storge"  # Greek word for familial love
+# Psychology/mental health terms
+catastrophize = "catastrophize"  # To view or present a situation as catastrophic
+catastrophizing = "catastrophizing"  # Present participle of catastrophize
 
 [files]
 # Files to ignore

--- a/_d/fail2.md
+++ b/_d/fail2.md
@@ -41,9 +41,29 @@ Failures are a great opportunity to learn. Use [COEs](/coe)
 - Success is falling down 7 times and getting up 8
 - Failure isn't an option; it's a requirement
 - The default, doing nothing, is usually a failure
+- [Failure is Data not Disaster](#failure-is-data-not-disaster)
 - Fear is the mind killer
 - Fear of failure is brought to you by the [resistance](/resistance)
 - Fear is not the enemy. Paralysis is the enemy.
+
+### Failure is Data not Disaster
+
+When something doesn't work out, it's easy to catastrophize - to see it as proof of incompetence or a sign of impending doom. But failure is actually feedback. It's information about what works and what doesn't.
+
+Treating failure as data means:
+
+- Analyzing what happened without self-judgment
+- Extracting lessons and insights
+- Using those lessons to improve your next attempt
+- Moving forward rather than getting stuck in shame
+
+Treating failure as disaster means:
+
+- Taking it personally and catastrophizing
+- Letting fear paralyze future action
+- Missing the opportunity to learn
+
+The difference isn't just semantic - it's about whether failure stops you or helps you grow. Data can be analyzed, understood, and used. Disasters just hurt.
 
 ## Smart people talking about fear of failure
 

--- a/back-links.json
+++ b/back-links.json
@@ -1820,7 +1820,6 @@
                 "/enemy",
                 "/energy",
                 "/energy-abundance",
-                "/fail",
                 "/frog",
                 "/gap-year",
                 "/gap-year-igor",
@@ -2396,16 +2395,16 @@
         },
         "/fail": {
             "description": "Failure is not an option; it’s a necessity. Failure is not a person but an event. You can’t grow without failing, and you can’t beat yourself up over it. The key is to analyze without judgment, understand why it failed, and learn to move on.\n\n",
-            "doc_size": 20000,
+            "doc_size": 21000,
             "file_path": "_site/fail.html",
             "incoming_links": [],
-            "last_modified": "2025-03-11T05:04:46-07:00",
+            "last_modified": "2025-11-16T15:50:49.022763",
             "markdown_path": "_d/fail2.md",
             "outgoing_links": [
                 "/anxiety",
                 "/anxiety-management",
                 "/coe",
-                "/d/resistance"
+                "/resistance"
             ],
             "redirect_url": "",
             "title": "Failure is not an option, it is a necessity",


### PR DESCRIPTION
## Summary
- Added new section "Failure is Data not Disaster" to explain the importance of treating failure as feedback rather than catastrophizing
- Added `catastrophize` and `catastrophizing` to `.typos.toml` as legitimate psychological terms

## Changes
- **_d/fail2.md**: New section with two lists distinguishing constructive vs destructive approaches to failure
- **.typos.toml**: Added psychology/mental health terms to prevent false positives

## Test plan
- ✅ Pre-commit checks pass (typo checker, link checker)
- ✅ Content renders correctly on local Jekyll server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new content section contrasting approaches to treating failure as data versus disaster, with practical practices for each mindset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->