### PR TITLE
Move kettlebell analogy to appendix, add more relatable introduction

### DIFF
--- a/_d/untangled.md
+++ b/_d/untangled.md
@@ -11,15 +11,13 @@ redirect_from:
   - /untangled-book
 ---
 
-Parenting a teenage girl is like mastering the [Turkish Get-Up](/kettlebell#tgus) – one of the most technically challenging kettlebell movements that requires patience, balance, and careful progression through distinct phases. Just when you think you've got one position figured out, it's time to transition to the next, all while maintaining your stability and form (and not dropping a heavy weight on your head!). Lisa Damour's "Untangled" is like having a master coach by your side, breaking down these intricate transitions into seven fundamental movements that take your daughter from childhood to adulthood.
+Remember when your daughter was little and you could fix almost anything with a hug and a Band-Aid? Those days feel like a different lifetime now. Parenting a teenage girl means navigating a completely new terrain – one where the problems are more complex, the emotions run deeper, and your old playbook doesn't quite work anymore.
 
 {% include amazon.html asin="0553393073" %}
 
-As a father navigating this journey myself, I've found this book to be the perfect spotter – helping me understand when to provide support and when to step back, ensuring both safety and growth. While the book speaks to all parents, I'm writing these notes specifically from a father's perspective, focusing on our unique challenges and opportunities in raising teenage daughters. Whether you're just starting this parenting progression or you're midway through the movement, this guide illuminates what's normal (spoiler: almost everything), what's concerning (less than you might think), and how to maintain your form through each phase of development.
+If you've ever felt lost watching your daughter navigate friendship drama, mood swings, or her first heartbreak – you're not alone. Lisa Damour's "Untangled" breaks down the teenage years into seven key developmental strands, helping fathers (and all parents) understand what's happening beneath the surface. This isn't just about surviving the teenage years – it's about staying connected with your daughter as she grows into the person she's becoming.
 
-_(NOTE: ChatGPT came up with this [kettlebell](/kettlebell) analogy as it knew it was relevant to me, sorry for the normal humans reading this! the Turkish Get-Up analogy works for the complexity and care needed, unlike a Turkish Get-Up where you progress through movements in sequence, these developmental strands are more like juggling – all seven balls are in the air at once, each at its own height and speed. Your daughter might be soaring in emotional development while still finding her footing in social transitions, or vice versa.)_
-
-_(NOTE FOR DADS: I find the book especially helpful as a father, while I don't empathize with the mother/daughter dynamic, many of the female specific concerns are very foreign to me! As fathers, we might feel less equipped to navigate some of these transitions with our daughters. That's normal. This book has helped me understand that being present, supportive, and willing to learn is more important than having all the answers. Sometimes the best thing we can do is acknowledge our discomfort while staying engaged.)_
+As a father myself, I've found this book invaluable. While much of the parenting advice out there focuses on the mother-daughter relationship, these notes highlight insights particularly relevant for dads. Whether you're wondering if her behavior is normal (it usually is), concerned about when to step in (less often than you think), or just trying to figure out how to talk to her anymore (you're not alone), this guide offers practical, research-based answers.
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
@@ -41,6 +39,7 @@ _(NOTE FOR DADS: I find the book especially helpful as a father, while I don't e
   - [Setting Boundaries](#setting-boundaries)
   - [Building Trust](#building-trust)
 - [Resources](#resources)
+- [Appendix: About These Notes](#appendix-about-these-notes)
 
 <!-- vim-markdown-toc-end -->
   <!-- prettier-ignore-end -->
@@ -1156,3 +1155,19 @@ Want more? Check out Lisa Damour's excellent podcast ["Ask Lisa: The Psychology 
 **A Note for Fellow Dads:** While this book wasn't written specifically for fathers, I've found its practical, research-based approach particularly helpful as a dad. It's helped me understand both what my daughter is going through and how to support her effectively. The concrete examples and clear explanations of "what's normal vs. what's concerning" have been especially valuable in building my confidence as a father of a teenage daughter.
 
 {% include amazon.html asin="0553393073" %}
+
+## Appendix: About These Notes
+
+### The Kettlebell Analogy
+
+_When I first created these notes, I used an analogy that was very specific to my own interests – comparing parenting a teenage girl to mastering the Turkish Get-Up kettlebell movement. While this might not resonate with everyone, I'm keeping it here for those who find it helpful:_
+
+Parenting a teenage girl is like mastering the [Turkish Get-Up](/kettlebell#tgus) – one of the most technically challenging kettlebell movements that requires patience, balance, and careful progression through distinct phases. Just when you think you've got one position figured out, it's time to transition to the next, all while maintaining your stability and form (and not dropping a heavy weight on your head!). Lisa Damour's "Untangled" is like having a master coach by your side, breaking down these intricate transitions into seven fundamental movements that take your daughter from childhood to adulthood.
+
+As a father navigating this journey myself, I've found this book to be the perfect spotter – helping me understand when to provide support and when to step back, ensuring both safety and growth. Whether you're just starting this parenting progression or you're midway through the movement, this guide illuminates what's normal, what's concerning, and how to maintain your form through each phase of development.
+
+_(NOTE: The Turkish Get-Up analogy works for the complexity and care needed, but unlike a Turkish Get-Up where you progress through movements in sequence, these developmental strands are more like juggling – all seven balls are in the air at once, each at its own height and speed. Your daughter might be soaring in emotional development while still finding her footing in social transitions, or vice versa.)_
+
+### A Note on the Father's Perspective
+
+As fathers, we might feel less equipped to navigate some of these transitions with our daughters. The mother-daughter dynamic is different from our own experience, and many of the female-specific concerns can feel foreign. That's completely normal. This book has helped me understand that being present, supportive, and willing to learn is more important than having all the answers. Sometimes the best thing we can do is acknowledge our discomfort while staying engaged.


### PR DESCRIPTION
## Summary

Addresses #235 by improving the accessibility of the untangled.md post.

### Changes
- Replaced kettlebell-specific introduction with universal father experience
- Created new "Appendix: About These Notes" section
- Preserved original kettlebell analogy for those who find it helpful
- Updated table of contents to include appendix

### Why
The original Turkish Get-Up analogy was very specific to Igor's kettlebell interests. By moving it to an appendix and replacing with a more relatable introduction, the post is now more accessible to general readers while still preserving the original content.

Fixes #235

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized guide structure with new Appendix: "About These Notes"
  * Updated Table of Contents to reflect new sections
  * Refined narrative framing and content focus throughout
  * Expanded practical guidance framework with developmental themes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->