### PR TITLE
fix: update swing analyzer URL to surge.sh deployment

### DIFF
--- a/_d/bells.md
+++ b/_d/bells.md
@@ -71,6 +71,6 @@ And here's my latest form check video (you can jump to [Hand To Hand](https://ww
 
 I've created a web app to analyze kettlebell swing form. You can upload a video of your swing and get feedback on your technique:
 
-[Kettlebell Swing Analyzer](https://swing-analyzer.vercel.app)
+[Kettlebell Swing Analyzer](https://swing-analyzer.surge.sh/)
 
 Using computer vision, the app tracks your body position throughout the swing and provides insights on hip hinge, arm position, and overall form. Give it a try with your swing videos!

--- a/_d/pet-projects.md
+++ b/_d/pet-projects.md
@@ -10,59 +10,59 @@ As an engineer, I love to build bespoke tools that solve my unique problems exac
 
 ## Self Reflection
 
-| Project | Description |
-| ------- | ----------- |
-| [This Blog](https://idvork.in) | Where I think through writing. Jekyll-based enabling environment. [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io) |
-| [Tony the Tesla](/bike-tesla-identity) | AI life coach for working through problems. [<i class="fa fa-github"></i>](https://github.com/idvorkin/tony_tesla) |
-| [`ij`](https://github.com/idvorkin/nlp/blob/master/igor_journal.py) | Journal management and analysis CLI tool |
-| [`gmail`](https://github.com/idvorkin/Settings/blob/master/py/gmail_reader.py) | Email journal analysis. [Blog post](/process-journal) |
+| Project                                                                        | Description                                                                                                                                      |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [This Blog](https://idvork.in)                                                 | Where I think through writing. Jekyll-based enabling environment. [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io) |
+| [Tony the Tesla](/bike-tesla-identity)                                         | AI life coach for working through problems. [<i class="fa fa-github"></i>](https://github.com/idvorkin/tony_tesla)                               |
+| [`ij`](https://github.com/idvorkin/nlp/blob/master/igor_journal.py)            | Journal management and analysis CLI tool                                                                                                         |
+| [`gmail`](https://github.com/idvorkin/Settings/blob/master/py/gmail_reader.py) | Email journal analysis. [Blog post](/process-journal)                                                                                            |
 
 ## Personal Productivity Tools
 
-| Project | Description |
-| ------- | ----------- |
-| [Humane Tracker](https://humane-tracker.surge.sh/) | Habit tracking across 5 wellness categories. Firebase-based with weekly views. [<i class="fa fa-github"></i>](https://github.com/idvorkin/humane-tracker-1) |
-| [Tax Calculator](https://idvorkin.github.io/tax-calculator/) | Interactive tax bracket visualizer. [<i class="fa fa-github"></i>](https://github.com/idvorkin/tax-calculator) |
+| Project                                                                                                    | Description                                                                                                                                                                  |
+| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Humane Tracker](https://humane-tracker.surge.sh/)                                                         | Habit tracking across 5 wellness categories. Firebase-based with weekly views. [<i class="fa fa-github"></i>](https://github.com/idvorkin/humane-tracker-1)                  |
+| [Tax Calculator](https://idvorkin.github.io/tax-calculator/)                                               | Interactive tax bracket visualizer. [<i class="fa fa-github"></i>](https://github.com/idvorkin/tax-calculator)                                                               |
 | [Weight Analysis](http://nbviewer.jupyter.org/github/idvorkin/jupyter/blob/master/Weight%20Analysis.ipynb) | Jupyter notebook analyzing Apple Health weight data. Box plots, time series, interactive visualizations. [<i class="fa fa-github"></i>](https://github.com/idvorkin/jupyter) |
-| [OmniFocus CLI](https://github.com/idvorkin/omnifocus_cli) | Command-line interface for OmniFocus task management |
-| [MathFlash](https://idvorkin.github.io/mathflash/) | Math flashcard trainer for kids. [<i class="fa fa-github"></i>](https://github.com/idvorkin/mathflash) |
-| [World Happiness Report](https://idvorkin.github.io/world-happiness-report/) | Interactive data visualization of global happiness data. [<i class="fa fa-github"></i>](https://github.com/idvorkin/world-happiness-report) |
-| [Donut Profit Calculator](https://idvorkin.github.io/donut-profit-calculator/) | Calculate donut shop profitability. [<i class="fa fa-github"></i>](https://github.com/idvorkin/donut-profit-calculator) |
+| [OmniFocus CLI](https://github.com/idvorkin/omnifocus_cli)                                                 | Command-line interface for OmniFocus task management                                                                                                                         |
+| [MathFlash](https://idvorkin.github.io/mathflash/)                                                         | Math flashcard trainer for kids. [<i class="fa fa-github"></i>](https://github.com/idvorkin/mathflash)                                                                       |
+| [World Happiness Report](https://idvorkin.github.io/world-happiness-report/)                               | Interactive data visualization of global happiness data. [<i class="fa fa-github"></i>](https://github.com/idvorkin/world-happiness-report)                                  |
+| [Donut Profit Calculator](https://idvorkin.github.io/donut-profit-calculator/)                             | Calculate donut shop profitability. [<i class="fa fa-github"></i>](https://github.com/idvorkin/donut-profit-calculator)                                                      |
 
 ## CLI Tools
 
-| Project | Description |
-| ------- | ----------- |
-| [CLI Tools](https://github.com/idvorkin/Settings/tree/master/py) | [`a`](https://github.com/idvorkin/Settings/blob/master/py/a.py) (Aerospace), [`y`](https://github.com/idvorkin/Settings/blob/master/py/y.py) (yabai), [`chop`](https://github.com/idvorkin/Settings/blob/master/py/chop.py) (logs), [`ai-clip`](https://github.com/idvorkin/Settings/blob/master/py/ai_clip.py), [`tmux_helper`](https://github.com/idvorkin/Settings/blob/master/py/tmux_helper.py) |
-| [`gpt`](https://github.com/idvorkin/nlp/blob/master/gpt3.py) | GPT integration utilities |
-| [`captions.py`](https://github.com/idvorkin/nlp/blob/master/captions.py) | Converts YouTube VTT transcripts to clean text |
+| Project                                                                  | Description                                                                                                                                                                                                                                                                                                                                                                                          |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [CLI Tools](https://github.com/idvorkin/Settings/tree/master/py)         | [`a`](https://github.com/idvorkin/Settings/blob/master/py/a.py) (Aerospace), [`y`](https://github.com/idvorkin/Settings/blob/master/py/y.py) (yabai), [`chop`](https://github.com/idvorkin/Settings/blob/master/py/chop.py) (logs), [`ai-clip`](https://github.com/idvorkin/Settings/blob/master/py/ai_clip.py), [`tmux_helper`](https://github.com/idvorkin/Settings/blob/master/py/tmux_helper.py) |
+| [`gpt`](https://github.com/idvorkin/nlp/blob/master/gpt3.py)             | GPT integration utilities                                                                                                                                                                                                                                                                                                                                                                            |
+| [`captions.py`](https://github.com/idvorkin/nlp/blob/master/captions.py) | Converts YouTube VTT transcripts to clean text                                                                                                                                                                                                                                                                                                                                                       |
 
 ## Computer Vision & Motion
 
-| Project | Description |
-| ------- | ----------- |
-| [Swing Analyzer](https://swing-analyzer.vercel.app) | Browser-based kettlebell swing analyzer. [<i class="fa fa-github"></i>](https://github.com/idvorkin/swing-analyzer) |
-| [Magic Monitor](https://magic-monitor.surge.sh) | Smart mirror app with instant replay and AI-powered smart zoom. [<i class="fa fa-github"></i>](https://github.com/idvorkin/magic-monitor) |
-| [Video Edit](https://github.com/idvorkin/video-edit) | Computer vision explorations: YOLO object detection, OpenCV motion detection |
+| Project                                              | Description                                                                                                                               |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [Swing Analyzer](https://swing-analyzer.surge.sh/)   | Browser-based kettlebell swing analyzer. [<i class="fa fa-github"></i>](https://github.com/idvorkin/swing-analyzer)                       |
+| [Magic Monitor](https://magic-monitor.surge.sh)      | Smart mirror app with instant replay and AI-powered smart zoom. [<i class="fa fa-github"></i>](https://github.com/idvorkin/magic-monitor) |
+| [Video Edit](https://github.com/idvorkin/video-edit) | Computer vision explorations: YOLO object detection, OpenCV motion detection                                                              |
 
 ## Dev Tools & Infrastructure
 
-| Project | Description |
-| ------- | ----------- |
-| [Chop Conventions](https://github.com/idvorkin/chop-conventions) | Development conventions for AI-assisted coding. [Blog post](/vibe) |
-| [mdserve](https://github.com/idvorkin/mdserve) | Fast markdown preview server with live reload and theme support |
-| [VAPI Call Viewer](https://www.youtube.com/watch?v=hE-qimUbKdg) | TUI for viewing Vapi.ai call transcripts. [<i class="fa fa-github"></i>](https://github.com/idvorkin/vapi-call-viewer) |
+| Project                                                                    | Description                                                                                                                                   |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Chop Conventions](https://github.com/idvorkin/chop-conventions)           | Development conventions for AI-assisted coding. [Blog post](/vibe)                                                                            |
+| [mdserve](https://github.com/idvorkin/mdserve)                             | Fast markdown preview server with live reload and theme support                                                                               |
+| [VAPI Call Viewer](https://www.youtube.com/watch?v=hE-qimUbKdg)            | TUI for viewing Vapi.ai call transcripts. [<i class="fa fa-github"></i>](https://github.com/idvorkin/vapi-call-viewer)                        |
 | [Manager Book Redirect](https://idvorkin--igor-blog-fastapi-app.modal.run) | Creates shareable blog links with proper Open Graph titles. [<i class="fa fa-github"></i>](https://github.com/idvorkin/manager-book-redirect) |
-| [Jupyter Notebooks](http://nbviewer.jupyter.org/github/idvorkin/jupyter) | Data exploration notebooks. [<i class="fa fa-github"></i>](https://github.com/idvorkin/jupyter) |
-| [Blog MCP Server](https://github.com/idvorkin/idvorkin-blog-mcp) | MCP server for AI assistants to query blog content |
-| [Cursor Chat Browser](https://github.com/idvorkin/cursor-chat-browser) | Browse and export Cursor AI chat histories |
+| [Jupyter Notebooks](http://nbviewer.jupyter.org/github/idvorkin/jupyter)   | Data exploration notebooks. [<i class="fa fa-github"></i>](https://github.com/idvorkin/jupyter)                                               |
+| [Blog MCP Server](https://github.com/idvorkin/idvorkin-blog-mcp)           | MCP server for AI assistants to query blog content                                                                                            |
+| [Cursor Chat Browser](https://github.com/idvorkin/cursor-chat-browser)     | Browse and export Cursor AI chat histories                                                                                                    |
 
 ## VIM & Editor Tools
 
-| Project | Description |
-| ------- | ----------- |
-| [VIM Keybindings for OneNote](https://github.com/idvorkin/Vim-Keybindings-For-Onenote) | Brings VIM navigation to OneNote |
-| [markdown-toc.nvim](https://github.com/idvorkin/markdown-toc.nvim) | Auto-generate and update table of contents for markdown |
-| [nvim-messages](https://github.com/idvorkin/nvim-messages) | Neovim plugin to read iMessage and other chat apps |
-| [Dotfiles](https://github.com/idvorkin/settings) | VIM, TMUX, and shell configuration |
-| [Tech Diary](https://github.com/idvorkin/techdiary) | Technical notes and learnings |
+| Project                                                                                | Description                                             |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| [VIM Keybindings for OneNote](https://github.com/idvorkin/Vim-Keybindings-For-Onenote) | Brings VIM navigation to OneNote                        |
+| [markdown-toc.nvim](https://github.com/idvorkin/markdown-toc.nvim)                     | Auto-generate and update table of contents for markdown |
+| [nvim-messages](https://github.com/idvorkin/nvim-messages)                             | Neovim plugin to read iMessage and other chat apps      |
+| [Dotfiles](https://github.com/idvorkin/settings)                                       | VIM, TMUX, and shell configuration                      |
+| [Tech Diary](https://github.com/idvorkin/techdiary)                                    | Technical notes and learnings                           |

--- a/back-links.json
+++ b/back-links.json
@@ -3189,7 +3189,7 @@
                 "/untangled",
                 "/y24"
             ],
-            "last_modified": "2025-07-20T19:13:52-07:00",
+            "last_modified": "2025-11-30T21:23:05.753047",
             "markdown_path": "_d/bells.md",
             "outgoing_links": [],
             "redirect_url": "",


### PR DESCRIPTION
## Summary
Updated swing analyzer links from `vercel.app` to the correct `surge.sh` deployment URL.

## Changes
- Updated link in `_d/bells.md` (Swing Analyzer App section)
- Updated link in `_d/pet-projects.md` (Computer Vision & Motion table)
- Changed URL from `https://swing-analyzer.vercel.app` to `https://swing-analyzer.surge.sh/`

## Test plan
- [x] Verified new URL is accessible (returns HTTP 200)
- [x] Tested that surge.sh deployment works correctly
- [x] Pre-commit hooks passed

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted project documentation tables for improved readability and consistency.
  * Updated external resource links in documentation.

* **Chores**
  * Updated content metadata timestamps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->