### PR TITLE
fix: Correct typos in 2 blog files (batch 5)

### DIFF
--- a/_d/lonely.md
+++ b/_d/lonely.md
@@ -404,7 +404,7 @@ These statistics highlight the profound impact relationships and personal action
 
 Beyond the core frameworks, there are emerging initiatives and fascinating research that further illuminate the loneliness epidemic and potential solutions.
 
-- [Britain has a minster of loneliness](https://time.com/5248016/tracey-crouch-uk-loneliness-minister/)
+- [Britain has a minister of loneliness](https://time.com/5248016/tracey-crouch-uk-loneliness-minister/)
 - [Britain government work on loneliness](https://www.gov.uk/government/collections/governments-work-on-tackling-loneliness)
 
 ### Super cool viz on loneliness and it's impact:

--- a/_d/mental-pain.md
+++ b/_d/mental-pain.md
@@ -8,7 +8,7 @@ redirect_from:
   - pain
 ---
 
-Pain is in the brain as they say, which is especially true for mental pains. Pain isn't the enemy though, pain is a signal. The pain system, when working properly draws our attention to a problem so that we can deal with it. However, our pain can evolve into unecassary suffering, be phantom pain, meaning it is being applied when it should not be, or chronic pain, which flares up even though it is no longer providing value.
+Pain is in the brain as they say, which is especially true for mental pains. Pain isn't the enemy though, pain is a signal. The pain system, when working properly draws our attention to a problem so that we can deal with it. However, our pain can evolve into unnecessary suffering, be phantom pain, meaning it is being applied when it should not be, or chronic pain, which flares up even though it is no longer providing value.
 
 {% include blob_image_float_right.html src="blog/raccoon-mental-pain.webp" %}
 
@@ -156,7 +156,7 @@ But here's a short version:
 
 - **Don't take a step forward and a step backward** - Like dieting for half a day then binging the other half. Either commit to the day or don't. If you study, write down your notes. "Just thinking about it" without completion is pure waste.
 
-Amazingly, and regardless of how often you experience the, resistance prevents you from remembering it --
+Amazingly, and regardless of how often you experience the resistance, it prevents you from remembering it --
 
 **Once you take action, you transform pointless suffering into purposeful pain that actually leads somewhere.**
 
@@ -394,9 +394,9 @@ The correct responses to boredom:
 - “What could I care about here?”
 - Is there a way I can serve, create, or connect?”
 
-Use boredom as a trigger for redirection—not suppression. It invites deliberate design: re-engaging attention, crafting purpose, or revisiting your aspirationsglossary.
+Use boredom as a trigger for redirection—not suppression. It invites deliberate design: re-engaging attention, crafting purpose, or revisiting your aspirations.
 
-Be careful boredom is a breading ground for addiction
+Be careful boredom is a breeding ground for addiction
 
 {%include summarize-page.html src="/addiction"%}
 


### PR DESCRIPTION
## Summary
- Fix typos across 2 blog files
- Part of comprehensive blog spell-check effort

## Files Fixed
1. **lonely.md**: minster→minister
2. **mental-pain.md**: unecassary→unnecessary, "the, resistance"→"the resistance, it", aspirationsglossary→aspirations, breading→breeding

## Test plan
- [x] Files compile correctly
- [x] No broken markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal task and issue tracking with new records covering project-related tasks and maintenance items.

* **Documentation**
  * Fixed spelling, grammar, and punctuation errors across documentation files for improved readability and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->