### PR TITLE
Add Claude 4.5 Opus Soul Document gist link to ai-security

### DIFF
--- a/_d/ai-security.md
+++ b/_d/ai-security.md
@@ -52,7 +52,7 @@ Security is super interesting, AI is super interesting, the combination, is supe
 
 A bunch of [leaked prompts](https://github.com/wunderwuzzi23/scratch/tree/master/system_prompts). You can see of the attack mitigations in them.
 
-See also [CL4R1T4S repo](https://github.com/idvorkin/CL4R1T4S) with Claude Sonnet 4.5 and other system prompts.
+See also [CL4R1T4S repo](https://github.com/idvorkin/CL4R1T4S) with Claude Sonnet 4.5 and other system prompts, and the [Claude 4.5 Opus Soul Document](https://gist.github.com/idvorkin/8c04a280fcc54b4fc4eee51df6fdab92) - a cleaned-up version of Anthropic's internal guidelines covering Claude's mission, values, identity, and safety principles.
 
 Another comprehensive collection: [system-prompts-and-models-of-ai-tools](https://github.com/idvorkin-ai-tools/system-prompts-and-models-of-ai-tools) covering Anthropic, OpenAI, Cursor, and more.
 


### PR DESCRIPTION
## Summary
- Added link to [Claude 4.5 Opus Soul Document gist](https://gist.github.com/idvorkin/8c04a280fcc54b4fc4eee51df6fdab92) in the "Leaked System Prompts" section of `/ai-security`
- This gist contains a cleaned-up version of Anthropic's internal guidelines covering Claude's mission, values, identity, and safety principles

## Test plan
- [ ] Verify link renders correctly on `/ai-security` page
- [ ] Confirm gist URL is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded AI security documentation to include an additional resource reference for system prompts, featuring a cleaned-up version of internal guidelines covering AI mission, values, identity, and safety principles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->