### PR TITLE
Add 'Tables Are Turned' post draft and AI slop include docs

### DIFF
--- a/_d/tables-turned.md
+++ b/_d/tables-turned.md
@@ -1,0 +1,101 @@
+---
+layout: post
+title: "The Tables Are Turned"
+permalink: /tables-turned
+tags:
+  - family
+  - how-igor-ticks
+  - parenting
+redirect_from:
+  - /kids-teach
+  - /role-reversal
+alias:
+  - /kids-teach
+  - /role-reversal
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-learning-from-kids.webp
+---
+
+When did my kids stop being students and start being teachers? I'm not sure exactly when it happened, but somewhere along the way, the tables turned. Now my kids are my role models.
+
+{% include ai-slop.html percent="90" %}
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [The Arc: Caretaker → Collaborator → Student](#the-arc-caretaker--collaborator--student)
+  - [Phase 1: Caretaker - "Let me show you"](#phase-1-caretaker---let-me-show-you)
+  - [Phase 2: Collaborator - "Let's figure this out together"](#phase-2-collaborator---lets-figure-this-out-together)
+  - [Phase 3: Student - "Teach me"](#phase-3-student---teach-me)
+- [What Zach teaches me](#what-zach-teaches-me)
+- [What Amelia teaches me](#what-amelia-teaches-me)
+- [The emotional shift](#the-emotional-shift)
+- [Why this matters](#why-this-matters)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+## The Arc: Caretaker → Collaborator → Student
+
+The parent-child relationship isn't static. It evolves through distinct phases, and if you're paying attention, you realize you've been promoted - or maybe demoted - to student.
+
+### Phase 1: Caretaker - "Let me show you"
+
+This is where it starts. You know things. They don't. You tie their shoes, teach them to read, explain why the sky is blue. The information flows one direction: down.
+
+<!-- TODO: Add specific early memories -->
+
+### Phase 2: Collaborator - "Let's figure this out together"
+
+Somewhere in the middle, things shift. You're no longer the sole source of knowledge. You start having actual conversations. They have opinions - good ones. You solve problems together.
+
+<!-- TODO: Add examples of collaboration moments -->
+
+### Phase 3: Student - "Teach me"
+
+And then one day you realize: they have something you don't. Something you want. Something you need to learn.
+
+This isn't about them knowing more facts or being better at technology. It's about character traits, ways of being in the world, that you aspire to.
+
+<!-- TODO: Add the moment of realization -->
+
+## What Zach teaches me
+
+<!-- TODO: Specific traits and examples -->
+
+**Curiosity without hesitation.** Zach just... tries things. Yellow Deli? Let's go. Random creamery? Why not. He doesn't overthink. He doesn't need to research it first. He just engages.
+
+**Healthy pride without arrogance.** Reading hard books. Not wearing headphones so he can be present. Reading on the bus instead of scrolling. He's figured out how to feel good about being different without making it about being better than others.
+
+**Presence.** He's actually there when he's there.
+
+## What Amelia teaches me
+
+<!-- TODO: Specific traits and examples -->
+
+**Radical authenticity.** She wears a tail. Sometimes a mask. She doesn't ask permission to be herself. She just is.
+
+**Physical confidence.** Quadrobics on the trampoline. Carrying kettlebells. Bear hugs. She inhabits her body fully.
+
+**Emotional wisdom beyond her years.** She wants to be a couples counselor. At 10. And honestly? She'd probably be good at it.
+
+## The emotional shift
+
+What does it feel like when you realize your kid has something you want?
+
+<!-- TODO: Explore the emotions here -->
+
+There's pride, obviously. But also something else. A kind of... humility? Gratitude?
+
+Maybe a little grief for the version of yourself that took so long to learn what they seem to know instinctively.
+
+## Why this matters
+
+This isn't just a cute observation about parenting. It's about staying alive, intellectually and emotionally.
+
+The moment you stop learning from the people around you - including (especially?) the ones you raised - you start calcifying.
+
+My kids keep me growing.
+
+---
+
+_See also: [My Eulogy](/eulogy) - where I first wrote about looking forward to Zach teaching me_

--- a/content_guidelines.md
+++ b/content_guidelines.md
@@ -409,6 +409,7 @@ Jekyll automatically generates excerpts (post summaries/previews) for blog index
 **What excerpts are:**
 
 Excerpts are automatically extracted text snippets that represent your post in:
+
 - Blog homepage listing pages
 - Category/tag archive pages
 - RSS/Atom feed readers
@@ -444,6 +445,7 @@ Your opening paragraph...
 ```
 
 **Best practices:**
+
 - Make the opening paragraph 2-4 sentences
 - Hook the reader with a personal stake or compelling question
 - Give enough context that the excerpt works as a standalone preview
@@ -474,6 +476,30 @@ Use alert boxes to highlight important information, warnings, or construction no
 ```liquid
 {% include alert.html content="🚧 Construction Zone 🚧 This post is in heavy progress! 🔨 Check back later for updates ⏳" style="warning" %}
 ```
+
+### AI Slop Notice
+
+Use the AI slop include to mark posts that are heavily AI-generated and need human refinement:
+
+**Syntax:**
+
+```liquid
+{% include ai-slop.html percent="90" %}
+```
+
+**Parameters:**
+
+- `percent`: Estimated percentage of AI-generated content (0-100)
+
+**When to use:**
+
+- Posts drafted primarily by AI that need Igor's real voice and stories
+- Book processing experiments
+- AI-augmented learning content in draft state
+
+**Example output:** "AI Slop Notice: This post is approximately 90% AI slop. I'm using this as an experiment in AI-augmented learning and book processing. Working on refining it!"
+
+As the post gets refined with real voice, stories, and human editing, reduce the percentage or remove the notice entirely.
 
 ### URL Redirects
 


### PR DESCRIPTION
## Summary

- New blog post `/tables-turned` - explores the arc of parent-child relationships: **caretaker → collaborator → student**
- Documents the `ai-slop.html` include in content_guidelines.md for marking AI-generated drafts

## The Post

The "Tables Are Turned" post explores how Igor's kids (Zach and Amelia) have become his role models. Currently marked as 90% AI slop - needs Igor's real voice, stories, and specific moments.

### Structure
- The Arc: Caretaker → Collaborator → Student
- What Zach teaches me (curiosity, healthy pride, presence)
- What Amelia teaches me (radical authenticity, physical confidence, emotional wisdom)
- The emotional shift
- Why this matters

## Test plan
- [ ] Verify post renders at `/tables-turned`
- [ ] Verify AI slop notice displays correctly
- [ ] Verify content_guidelines.md AI slop section is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated content guidelines with new guidance on AI-generated content notices, including syntax, parameters, and best practices for reducing notices as content is refined
  * Enhanced existing guidelines with additional best practices and excerpt documentation

* **Blog**
  * Published new blog post exploring parenting dynamics, collaboration, and lessons learned from children

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->