### PR TITLE
Fix pet-projects description: move comment after intro

### DIFF
--- a/_d/pet-projects.md
+++ b/_d/pet-projects.md
@@ -6,6 +6,8 @@ redirect_from:
   - /tinkering
 ---
 
+As an engineer, I love to build bespoke tools that solve my unique problems exactly the way I want them solved. The bonus? This is lets me learn new technologies (did you know my blog has multiplayer support?). Sometimes I even make a tool so I have something to learn from. And with AI, this list of projects and explorations has exploded! Note to self, when I want to veg out and just feed my social media addiction I should do some vibe coding on all of these.
+
 <!-- MAINTENANCE INSTRUCTIONS FOR CLAUDE
 
 This page has TWO parts that need to stay in sync:
@@ -36,8 +38,6 @@ GitHub orgs to check:
 - github.com/idvorkin (main)
 - github.com/idvorkin-ai-tools (AI tools org)
 -->
-
-As an engineer, I love to build bespoke tools that solve my unique problems exactly the way I want them solved. The bonus? This is lets me learn new technologies (did you know my blog has multiplayer support?). Sometimes I even make a tool so I have something to learn from. And with AI, this list of projects and explorations has exploded! Note to self, when I want to veg out and just feed my social media addiction I should do some vibe coding on all of these.
 
 {% include alert.html content='[Here is a beautiful landing page for my pet projects](/static/pet-projects.html)' style="info" %}
 

--- a/back-links.json
+++ b/back-links.json
@@ -4027,13 +4027,13 @@
             "url": "/partner-trouble"
         },
         "/pet-projects": {
-            "description": "<!– MAINTENANCE INSTRUCTIONS FOR CLAUDE\n\n",
+            "description": "As an engineer, I love to build bespoke tools that solve my unique problems exactly the way I want them solved. The bonus? This is lets me learn new technologies (did you know my blog has multiplayer support?). Sometimes I even make a tool so I have something to learn from. And with AI, this list of projects and explorations has exploded! Note to self, when I want to veg out and just feed my social media addiction I should do some vibe coding on all of these.\n\n",
             "doc_size": 24000,
             "file_path": "_site/pet-projects.html",
             "incoming_links": [
                 "/eulogy"
             ],
-            "last_modified": "2025-12-14T18:54:21+00:00",
+            "last_modified": "2025-12-14T19:26:54.436664",
             "markdown_path": "_d/pet-projects.md",
             "outgoing_links": [
                 "/bike-tesla-identity",


### PR DESCRIPTION
## Summary

The HTML comment for Claude maintenance instructions was being extracted as the page description in back-links.json.

**Before:** `"description": "<!– MAINTENANCE INSTRUCTIONS FOR CLAUDE\n\n"`

**After:** `"description": "As an engineer, I love to build bespoke tools..."`

Fix: Moved the comment after the intro paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)