### PR TITLE
Add 'Momentum is emotional gravity' concept

### DIFF
--- a/_d/energy.md
+++ b/_d/energy.md
@@ -19,6 +19,14 @@ You can get a blast of energy when someone smiles at you. [Joy](/joy) is like th
 
 It's amazing to me that a good workout does this. So does a productive day at work.
 
+### Momentum is emotional gravity
+
+Momentum is more than progress—it's emotional gravity. When you're moving fast, people want to join you, invest in you, and stay committed. When you're stuck, everything feels heavier than it is.
+
+Most teams don't fail from competition. They fail from losing the energy that made everyone believe in the first place.
+
+Forward motion creates its own fuel. The [productive](/productive) feeling of shipping, completing, moving—it compounds. Stagnation compounds too, but in the wrong direction.
+
 ### Energy drains, regardless of if it's being applied to do work
 
 In fact, sometimes it even drains worse, so care deeply about

--- a/_d/productive2.md
+++ b/_d/productive2.md
@@ -53,6 +53,8 @@ No point spending "my high energy/willpower time" on a low energy activity. It's
 
 ### Motivation
 
+[Momentum is emotional gravity](/energy#momentum-is-emotional-gravity). The feeling of shipping, completing, moving forward—it compounds. When you're making progress, everything feels lighter. When you're stuck, everything feels heavier than it is. Forward motion creates its own fuel.
+
 ### Realistic Expectations
 
 ### Flow

--- a/_posts/2016-03-03-the-manager-book-2.md
+++ b/_posts/2016-03-03-the-manager-book-2.md
@@ -434,13 +434,11 @@ Good self assessments are concise, focus on impact, and then how you delivered t
 Here are some fictitious examples modeled on my own career:
 
 - Improved Azure virtual machine boot time from 12 minutes to 2 minutes at P90 by investigating end to end system behavior, understanding end 2 end system operation, creating and driving agreement to all up goal, and then working with teams to establish budgets, and holding them accountable to delivering them.
-
   - > At first my team was skeptical that the performance improvements could be achieved and were hesitant to invest, but once we saw the organizational support and monthly meetings of progress we found it inspiring and made sure we contributed to the goal.
 
 - Drove XXX\$ to charities, and increased Alexa Shopping DAU XXX % (XXX to YYY) to by proposing a charity giving feature and implementing it in 5 months. Complexity, 20 eng/months, supporting work from 5 teams, across multiple divisions
 
 - Delivered XYZ, required to deliver TLS support on windows phone at very high quality. Complexity 1 engineer, 4 months - however required ramping up on complex error prone C++ code base, and no bugs found
-
   - > Igor's delivery was on time and of high quality. The feature had no bugs in production, due to high test coverage, which was impressive given the high complexity of the C++ code.
 
 - Increased team morale and cross group collaboration by proposing weekly team lunches, and monthly lunches with the broader organization.
@@ -1201,20 +1199,17 @@ When looking at code reviews as a teaching tool:
 When planning execution, follow this order:
 
 1. **Why** - Start with the purpose and impact
-
    - What problem are we solving?
    - What's the business value?
    - Why is this important now?
 
 2. **What** - Define Success
-
    - What does success look like?
    - What are we building?
    - What are the key requirements?
    - What are the constraints?
 
 3. **When** - Establish timeline and milestones
-
    - When do we need this by?
    - What are the key dependencies?
    - What's the critical path?
@@ -1465,14 +1460,12 @@ Recruiting is ultimately product sales, where you're selling the team you suppor
 ### What about structured vs free form interview loops
 
 - External Structured
-
   - Leadership skills - most important
   - Self aware - a [critical part of being a leader](/what-makes-a-leader)
   - Design
   - Coding
 
 - Internal, Structured but Different
-
   - Review internal code/design/documentation artifacts. Ask candidate for artifacts they're proud of.
   - Go on a whiteboard to have them explain one of their systems, or help you on yours. No need for the candidate to practice, this is just them doing their day job.
   - Talk about hard situations they've had. Listen for the criteria smart/gets things done/emotionally intelligent
@@ -1553,7 +1546,6 @@ Also good to refresh yourself on total compensation vs salary. It's important to
 ### Best Practices For Performance Reviews
 
 - Before Calibrations:
-
   - Continue seeking feedback for team members, and anonymizing and providing feedback
   - Continue explaining how tracking is occurring
   - Do mid-point checkins and peer manager review for hard situations (e.g. bottom performers and pending promotions)
@@ -1561,7 +1553,6 @@ Also good to refresh yourself on total compensation vs salary. It's important to
   - Remind engineers you might find new data late, and what you do that could change their assessment
 
 - At the start of every calibration session. Reminder that:
-
   - Confidentiality is critical - Amazon says breaking confidentiality is a firing offense, which is great.
   - Reminder of the importance of catching unconscious bias.
   - Point is to calibrate the assessment process so it's fair.
@@ -1596,7 +1587,6 @@ The pains of the PSC - _Pain is a good thing, it tells you to pay attention, and
 The things I suffer about during PSCs - _Suffering is unhelpful, try to avoid it_
 
 - Someone gets a bad outcome because I :
-
   - didn't give them the right opportunity or sufficient feedback
   - missed something critical during the year that I should have caught
   - wrote the packet poorly, or presented the packet poorly (or both)
@@ -1716,7 +1706,6 @@ This applies to work, and to life. You could buy a lemon of a car, get brain can
 Three "Players" in this situation:
 
 - The struggling employee
-
   - Remember being in the wrong role SUCKS. Employee is going home after long day, and feeling like shit (rinse and repeat)
   - Once in right role - will feel great. Seen lots of times this happens.
 
@@ -2128,7 +2117,7 @@ Few things make me prouder then this [public feedback on LinkedIn](/static/idvor
 
 On my deathbed, the product I will be most proud of is the people who I watched blossom and grow. It's cliche, but when you love your people they know it, they thrive, and do their best work. It's not just about the work, I want to make sure people think of their lives as well, because, well, that's even more important.
 
-I'm also energized by getting shit done. The thought of shipping, clearing roadblocks, and never being blocked puts a smile on my face.
+I'm also energized by getting shit done. The thought of shipping, clearing roadblocks, and never being blocked puts a smile on my face. [Momentum is emotional gravity](/energy#momentum-is-emotional-gravity)—forward motion creates its own fuel, and teams thrive when they feel that energy.
 
 Speaking of smiling, nothing brings me back up like reading this kind of feedback that I got when I left a team.
 

--- a/back-links.json
+++ b/back-links.json
@@ -307,8 +307,7 @@
             "doc_size": 17000,
             "file_path": "_site/22.html",
             "incoming_links": [
-                "/chapters",
-                "/manager-book"
+                "/chapters"
             ],
             "last_modified": "2025-12-06T18:12:26-08:00",
             "markdown_path": "_d/22.md",
@@ -1223,7 +1222,6 @@
             "file_path": "_site/books-that-defined-me.html",
             "incoming_links": [
                 "/being-a-great-manager",
-                "/manager-book",
                 "/manager-book-appendix"
             ],
             "last_modified": "2025-07-20T19:26:41-07:00",
@@ -1819,11 +1817,9 @@
                 "/hobby",
                 "/idle",
                 "/life-as-business",
-                "/manager-book",
                 "/mind-at-work",
                 "/operating-manual",
                 "/physical-health",
-                "/productive",
                 "/psychic-weight",
                 "/sharpen-the-saw",
                 "/slow",
@@ -1859,7 +1855,6 @@
                 "/activation",
                 "/books-that-defined-me",
                 "/enemy",
-                "/energy",
                 "/energy-abundance",
                 "/fail",
                 "/frog",
@@ -1867,7 +1862,6 @@
                 "/gap-year-igor",
                 "/mental-pain",
                 "/parkinson",
-                "/productive",
                 "/psychic-shadows",
                 "/psychic-weight",
                 "/slow",
@@ -1970,7 +1964,6 @@
                 "/coaching",
                 "/gap-year",
                 "/job-hunt-stress",
-                "/manager-book",
                 "/pride",
                 "/random-idea",
                 "/work-satisfaction"
@@ -2241,8 +2234,6 @@
                 "/d/resistance",
                 "/elder",
                 "/gap-year-igor",
-                "/manager-book",
-                "/productive",
                 "/siy",
                 "/walking-with-god"
             ],
@@ -2290,19 +2281,19 @@
                 "/slow",
                 "/timeoff"
             ],
-            "last_modified": "2025-09-30T07:24:35-07:00",
+            "last_modified": "2025-12-21T15:23:15.432495+00:00",
             "markdown_path": "_d/energy.md",
             "outgoing_links": [
                 "/activation",
-                "/d/resistance",
                 "/joy",
                 "/mania",
                 "/mood",
                 "/operating-manual",
                 "/productive",
+                "/resistance",
                 "/sleep",
                 "/slow",
-                "/timeoff"
+                "/time-off"
             ],
             "redirect_url": "",
             "title": "Control your Energy",
@@ -3363,24 +3354,25 @@
                 "/y24",
                 "/y25"
             ],
-            "last_modified": "2025-10-31T17:18:27-07:00",
+            "last_modified": "2025-12-21T15:35:58.643459+00:00",
             "markdown_path": "_posts/2016-03-03-the-manager-book-2.md",
             "outgoing_links": [
-                "/22",
+                "/7h-c2",
+                "/90-days",
                 "/90days",
                 "/being-a-great-manager",
-                "/books-that-defined-me",
+                "/books",
+                "/coach",
                 "/coaching",
                 "/coe",
                 "/comp",
-                "/d/habits",
-                "/decisive",
+                "/decide",
                 "/dip",
-                "/end-in-mind",
+                "/dsat",
+                "/habits",
                 "/job",
                 "/job-hunt-stress",
                 "/manager-book-appendix",
-                "/ml",
                 "/moments-at-work",
                 "/overload",
                 "/pride",
@@ -3391,10 +3383,11 @@
                 "/static/idvorkin-linked-in-feedback-lastest.pdf",
                 "/strategy",
                 "/td/cloud-first-applications",
+                "/td/machine-learning",
                 "/testing",
+                "/twentytwo",
                 "/what-makes-a-leader",
-                "/work-satisfaction",
-                "/writing"
+                "/write"
             ],
             "redirect_url": "",
             "title": "How to EM: Be the manager everyone wants",
@@ -3588,7 +3581,6 @@
             "file_path": "_site/ml.html",
             "incoming_links": [
                 "/ai",
-                "/manager-book",
                 "/td/stats"
             ],
             "last_modified": "2025-08-22T11:54:12-07:00",
@@ -3782,7 +3774,6 @@
                 "/curious",
                 "/get-to-yes-with-yourself",
                 "/happy",
-                "/productive",
                 "/sell",
                 "/synergize",
                 "/work-satisfaction"
@@ -4223,18 +4214,18 @@
                 "/energy",
                 "/timeoff-2022-02"
             ],
-            "last_modified": "2024-10-05T21:35:59-07:00",
+            "last_modified": "2025-12-21T15:35:58.643459+00:00",
             "markdown_path": "_d/productive2.md",
             "outgoing_links": [
+                "/7h-c2",
                 "/addiction",
                 "/anxiety",
                 "/balance",
-                "/d/habits",
-                "/d/resistance",
-                "/end-in-mind",
                 "/energy",
                 "/frog",
-                "/negotiate",
+                "/gty",
+                "/habits",
+                "/resistance",
                 "/switch"
             ],
             "redirect_url": "",
@@ -5508,7 +5499,6 @@
             "incoming_links": [
                 "/activation",
                 "/balance",
-                "/energy",
                 "/energy-abundance",
                 "/gap-year",
                 "/gap-year-igor",
@@ -6211,7 +6201,6 @@
             "doc_size": 32000,
             "file_path": "_site/work-satisfaction.html",
             "incoming_links": [
-                "/manager-book",
                 "/mind-at-work",
                 "/retire"
             ],
@@ -6263,7 +6252,6 @@
                 "/chow",
                 "/enable",
                 "/four-healths",
-                "/manager-book",
                 "/manager-book-appendix",
                 "/operating-manual"
             ],


### PR DESCRIPTION
## Summary

- Adds new concept to `/energy`: momentum as emotional gravity
- Forward motion creates its own fuel; stagnation compounds in the wrong direction
- Cross-links from `/productive` and `/manager-book`

## Changes

**`/energy`** - New section "Momentum is emotional gravity":
> When you're moving fast, people want to join you, invest in you, and stay committed. When you're stuck, everything feels heavier than it is. Most teams don't fail from competition. They fail from losing the energy that made everyone believe in the first place.

**`/productive`** - Added to Motivation section with link back to energy

**`/manager-book`** - Added to "Why management is attractive" section

## Test plan

- [ ] Verify anchor link works: `/energy#momentum-is-emotional-gravity`
- [ ] Check cross-links render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive new content exploring the concept of "Momentum is emotional gravity," explaining how forward progress compounds energy and sustains team commitment.
  * Expanded existing documentation with cross-references to the new momentum content, improving navigation across related topics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->