### PR TITLE
Add system-prompts-and-models-of-ai-tools repo reference

### DIFF
--- a/_d/ai-developer.md
+++ b/_d/ai-developer.md
@@ -358,6 +358,8 @@ def scratch():
 
 A bunch of [leaked prompts](https://github.com/wunderwuzzi23/scratch/tree/master/system_prompts). You can see a bunch of the current alchemy in creating these.
 
+Another comprehensive collection: [system-prompts-and-models-of-ai-tools](https://github.com/idvorkin-ai-tools/system-prompts-and-models-of-ai-tools) covering Anthropic, OpenAI, Cursor, and more.
+
 ### Use LLMs for reasoning not for data retrieval
 
 Great line from Altman, we're currently using them for data retrieval, but their super power is reasoning. If we just focus on reasoning, let other tools do the retrieval that can be better

--- a/_d/ai-security.md
+++ b/_d/ai-security.md
@@ -54,6 +54,8 @@ A bunch of [leaked prompts](https://github.com/wunderwuzzi23/scratch/tree/master
 
 See also [CL4R1T4S repo](https://github.com/idvorkin/CL4R1T4S) with Claude Sonnet 4.5 and other system prompts.
 
+Another comprehensive collection: [system-prompts-and-models-of-ai-tools](https://github.com/idvorkin-ai-tools/system-prompts-and-models-of-ai-tools) covering Anthropic, OpenAI, Cursor, and more.
+
 ### Prompt Obfuscation for all attacks
 
 You can obfusicate the prompts to get past system prompts, and trick users into pasting something safe. By using different languages etc.


### PR DESCRIPTION
## Summary
- Fork system prompts collection repo to idvorkin-ai-tools
- Add reference in both `/ai-security` and `/ai-developer` pages
- Covers Anthropic, OpenAI, Cursor, and more AI tool system prompts

## Test plan
- [ ] Verify links work on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reference links to a comprehensive collection of system prompts and AI tool models covering Anthropic, OpenAI, Cursor, and more in security-related reference materials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->