### PR TITLE
Fix manager-book front matter

### DIFF
--- a/_posts/2016-03-03-the-manager-book-2.md
+++ b/_posts/2016-03-03-the-manager-book-2.md
@@ -1,5 +1,15 @@
 ---
-{}
+layout: post
+title: "How to EM: Be the manager everyone wants"
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/racoon-manager.webp
+tags:
+  - manager
+  - search-featured
+  - manager-book
+permalink: /manager-book
+redirect_from:
+  - /the-manager-book
+sort_order: 100
 ---
 
 Being an engineering manager is hard. Supporting people well is harder. Lessons are hard earned and should be cherished. This post is designed to make explicit, and improve behaviors and practices. It reminds me how to behave and encourages my own continuous improvement.

--- a/back-links.json
+++ b/back-links.json
@@ -3381,7 +3381,7 @@
                 "/y24",
                 "/y25"
             ],
-            "last_modified": "2025-12-28T19:10:35.548669+00:00",
+            "last_modified": "2025-12-29T17:08:17.191543+00:00",
             "markdown_path": "_posts/2016-03-03-the-manager-book-2.md",
             "outgoing_links": [
                 "/90-days",


### PR DESCRIPTION
## Summary
- Restore front matter that was accidentally wiped by commit 20855e0 ("Add manifesto to TOC")
- The commit replaced all front matter with `{}`, breaking the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)