### PR TITLE
Add Plan-Do-Review triad to planning post

### DIFF
--- a/_d/planning.md
+++ b/_d/planning.md
@@ -147,6 +147,8 @@ Since you'll avoid it, you need to trick yourself into doing it:
 
 The goal isn't perfect review. It's _some_ review. Consistency beats depth.
 
+When things go really wrong, you need structured review. In engineering we call this a [Correction of Errors](/coe)—a blameless post-mortem that asks "what happened?" and "how do we prevent it next time?" The key word is _blameless_. COEs work because they separate the person from the failure. You can be honest about what went wrong because you're not on trial. The same principle applies to personal review: you're not judging yourself as a person, you're examining what happened so you can do better.
+
 **The ratio matters.** Most people over-plan, under-do, and skip review entirely. If you're going to skimp on something, skimp on planning. But never skip review.
 
 ## Finding the Balance

--- a/back-links.json
+++ b/back-links.json
@@ -1536,6 +1536,7 @@
                 "/fail",
                 "/manager-book",
                 "/physical-pain",
+                "/planning",
                 "/switch",
                 "/writing"
             ],
@@ -4130,11 +4131,12 @@
                 "/end-in-mind",
                 "/manager-book"
             ],
-            "last_modified": "2025-12-31T17:28:57.474824+00:00",
+            "last_modified": "2025-12-31T17:42:48.748372+00:00",
             "markdown_path": "_d/planning.md",
             "outgoing_links": [
                 "/activation",
                 "/coaching",
+                "/coe",
                 "/end-in-mind",
                 "/energy",
                 "/manager-book"


### PR DESCRIPTION
## Summary
- Add the critical third component: Review (Plan → Do → Review)
- Without review, you don't learn from what you did - mistakes repeat
- Link to coaching post since coaching is structured review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive section on Review as part of the Plan-Do-Review learning framework, with detailed guidance on what review adds to continuous learning
  * Expanded review discussion with subsections on outcomes, what worked/didn't work, and lessons learned with practical examples
  * New section explaining why review is commonly skipped and suggested mitigation strategies
  * Enhanced cross-references between planning and coaching documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->