### PR TITLE
Add goals link to planning post

### DIFF
--- a/_d/planning.md
+++ b/_d/planning.md
@@ -165,5 +165,6 @@ The plan is a means, not an end. The moment it stops propelling you forward—th
 
 ## See also
 
+- [Goals](/goals) - Planning without clear goals is just motion
 - [Coaching](/coaching) - Structured review with a partner
 - [Manager Book: Planning, Roadmaps and Resource Allocation](/manager-book#planning-roadmaps-and-resource-allocation)

--- a/back-links.json
+++ b/back-links.json
@@ -2715,7 +2715,8 @@
             "file_path": "_site/goals.html",
             "incoming_links": [
                 "/4dx",
-                "/parkinson"
+                "/parkinson",
+                "/planning"
             ],
             "last_modified": "2025-12-07T03:06:25+00:00",
             "markdown_path": "_d/goals.md",
@@ -4125,13 +4126,13 @@
         },
         "/planning": {
             "description": "The plan trains the planner. Planning isn’t about predicting the future—it’s about preparing your mind to meet it. It clarifies goals, surfaces unknowns, and builds the pattern recognition you’ll need when reality punches your plan in the face. But the goal of planning is action, not the plan. The moment you’re polishing instead of testing, you’ve crossed from preparation into procrastination.\n\n",
-            "doc_size": 21000,
+            "doc_size": 25000,
             "file_path": "_site/planning.html",
             "incoming_links": [
                 "/end-in-mind",
                 "/manager-book"
             ],
-            "last_modified": "2025-12-31T17:42:48.748372+00:00",
+            "last_modified": "2026-01-01T14:13:44.166092+00:00",
             "markdown_path": "_d/planning.md",
             "outgoing_links": [
                 "/activation",
@@ -4139,6 +4140,7 @@
                 "/coe",
                 "/end-in-mind",
                 "/energy",
+                "/goals",
                 "/manager-book"
             ],
             "redirect_url": "",


### PR DESCRIPTION
## Summary
- Add Goals to See also section
- "Planning without clear goals is just motion"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new reference link in the planning documentation to the goals section, improving navigation between related topics and helping users understand how goal-setting integrates with planning workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->