### PR TITLE
Add notice that CHOP content is moving to CHOW

### DIFF
--- a/_d/ai-coder.md
+++ b/_d/ai-coder.md
@@ -9,7 +9,11 @@ redirect_from:
 
 Welcome to The CHOP Shop! CHOP - or Chat-Oriented Programming - is revolutionizing how we write code. Think of those old-school auto shops: AI started as the shop hand, fetching tools and cleaning parts. Then it became an apprentice mechanic, helping diagnose problems and suggesting fixes. Now? It's a master mechanic, capable of rebuilding entire engines from your high-level specs. Our AIs are getting smarter by the day, and we'll explore how to make the most of this evolution.
 
-**Want to see this in practice?** Check out [How Igor CHOPs](/how-igor-chops) for my personal setup, tooling choices, and daily workflows.
+{% include alert.html content="This post is evolving! Much of the content is moving to [CHOW (Chat-Oriented Writing)](/chow) which covers AI-assisted content creation more broadly - including interactive visualizations and apps, not just code." style="warning" %}
+
+**Want to see this in practice?**
+
+{% include summarize-page.html src="/how-igor-chops" %}
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->

--- a/_d/ai-journal.md
+++ b/_d/ai-journal.md
@@ -18,6 +18,8 @@ A journal of random explorations in AI. Keeping track of them so I don't get sup
 - [What I wrote summary](#what-i-wrote-summary)
 - [Upcoming](#upcoming)
 - [Diary](#diary)
+  - [2026-01-01](#2026-01-01)
+    - [CHOW for Blog Posts: "How Igor CHOPs" Written with AI](#chow-for-blog-posts-how-igor-chops-written-with-ai)
   - [2025-12-21](#2025-12-21)
     - [obs-cli: Rust TUI for Camera Control](#obs-cli-rust-tui-for-camera-control)
     - [Rust tmux_helper: 10x Speedup from Python](#rust-tmux_helper-10x-speedup-from-python)
@@ -211,6 +213,15 @@ lets see if we can simulate him, step #1, lets bring the site down into markdown
 - AI Music: My eulogy as a rap
 
 ## Diary
+
+### 2026-01-01
+
+#### CHOW for Blog Posts: "How Igor CHOPs" Written with AI
+
+- **TOP Takeaway**: Applied [CHOW](/chow) to write the [How Igor CHOPs](/how-igor-chops) post - it's pretty frickin' good
+- CHOW isn't just for code anymore - it's becoming my go-to for writing entire blog posts
+- The post covers my personal CHOP setup, tooling choices, and daily workflows
+- Also added interactive visualization examples to the CHOW post: [Religion Evolution Explorer](https://religion-evolution-explorer.surge.sh/) and [How Long Since](https://idvorkin-how-long-since-ai.surge.sh/?show=tool)
 
 ### 2025-12-21
 


### PR DESCRIPTION
## Summary
- Add warning alert to CHOP post noting content is evolving toward CHOW
- Replace plain link to "How Igor CHOPs" with summarize-page include
- Add 2026-01-01 AI journal entry about using CHOW to write blog posts

## Test plan
- [ ] Preview `/chop` and verify the alert box displays correctly
- [ ] Verify summarize-page for `/how-igor-chops` renders
- [ ] Preview `/ai-journal` and verify new entry appears at top of Diary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a warning alert after the introduction to note the content is actively evolving toward CHOW.
  * Replaced the single direct link with a "Want to see this in practice?" section that embeds a summarized view of "How Igor CHOPs."
  * Added a new diary entry (2026-01-01) titled "CHOW for Blog Posts: 'How Igor CHOPs' Written with AI" and updated the page TOC to include the new entry and nested CHOW link.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->