### PR TITLE
Add claude-code-transcripts tool to CHOP post

### DIFF
--- a/_d/ai-coder.md
+++ b/_d/ai-coder.md
@@ -254,6 +254,17 @@ claude-code-log --tui
 
 Example: [AI journal](/ai-journal) with [published logs](/published-chop-logs/2025-10-09-religion-exploration.html).
 
+#### claude-code-transcripts
+
+[claude-code-transcripts on GitHub](https://github.com/simonw/claude-code-transcripts) - Simon Willison's tool for converting Claude Code sessions to mobile-friendly HTML with pagination and batch processing.
+
+```bash
+uv tool install claude-code-transcripts
+claude-code-transcripts --help
+```
+
+Features: GitHub Gist upload, batch index generation, repository commit linking.
+
 ## Use Cases and Examples
 
 Not sure if this should be a separate post, but I'm going to start looking at this from the perspective of use cases.


### PR DESCRIPTION
## Summary

Adds Simon Willison's [claude-code-transcripts](https://github.com/simonw/claude-code-transcripts) tool alongside the existing claude-code-log reference.

Features:
- Mobile-friendly HTML with pagination
- GitHub Gist upload
- Batch index generation
- Repository commit linking

## Test plan

- [ ] Verify CHOP post renders correctly at `/chop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the "claude-code-transcripts" tool, including installation instructions, usage examples, and feature highlights.
  * New documentation covers GitHub integration, batch index generation, and repository commit linking capabilities.
  * Note: Content appears duplicated in two locations within the document.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->