### PR TITLE
Reframe CHOW as Chat-Oriented Thinking, add PR checklist

### DIFF
--- a/_d/chow.md
+++ b/_d/chow.md
@@ -1,36 +1,33 @@
 ---
 layout: post
-title: "The CHOW Kitchen: Where AI Meets Writing"
+title: "CHOW: Chat-Oriented Writing"
 permalink: /chow
 tags:
   - writing
   - tools
   - ai
   - how
+redirect_from:
+  - /chot
 ---
 
-Welcome to The CHOW Kitchen! CHOW - or Chat-Oriented Writing - is transforming how we create content. Think of those bustling restaurant kitchens: AI started as the prep cook, chopping vegetables and measuring ingredients. Then it became a line cook, helping with recipes and plating. Now? It's becoming a sous chef, capable of crafting entire dishes from your creative vision. Our AIs are getting more sophisticated daily, and we'll explore how to make the most of this culinary revolution in writing.
+I used to stare at blank pages. Now I have a different problem: AI will happily fill those pages for me, but my brain stays empty. CHOW - Chat-Oriented Writing - is my answer: using AI to think better, not just write faster. The written artifact is a side effect. The real product is clarity in your head. This post covers why writing equals thinking, the risk of outsourcing that thinking to AI, and the four thinking modes - Madman, Architect, Carpenter, Judge - that help you partner with AI instead of just delegating to it.
 
-The concept emerged from the realization that traditional writing processes are being transformed by Large Language Models (LLMs). As these models become more sophisticated at tasks like research, outlining, and even drafting, the role of the writer shifts towards higher-level creative direction and refinement. This isn't just about AI replacing basic writing tasks - it's about a new way of working where writers who embrace CHOW can achieve significant productivity boosts while maintaining their unique voice and vision.
+{% include alert.html content="I use the word 'writing' instead of 'thinking' because telling people 'I'm going to help you think better' causes them to go 'Oh my gosh, I forgot! I gotta go wash my hair.' 'I'm going to help you write better' - that they'll stick around for. I rarely conform to what normal people want, but occasionally I make exceptions." style="info" %}
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
-- [The Foundations of CHOW](#the-foundations-of-chow)
-  - [The Art of Writing](#the-art-of-writing)
-  - [The Enabling Environment](#the-enabling-environment)
-  - [Learning from CHOP](#learning-from-chop)
-  - [The Evolution of AI Writing](#the-evolution-of-ai-writing)
-- [What is CHOW?](#what-is-chow)
-  - [The Evolution of AI Writing](#the-evolution-of-ai-writing-1)
-  - [Core Concepts](#core-concepts)
-  - [Key Tools](#key-tools)
-- [CHOW and the Four Writing Personas](#chow-and-the-four-writing-personas)
+- [CHOW is Thinking](#chow-is-thinking)
+  - [Why Writing = Thinking](#why-writing--thinking)
+  - [The Risk: Outsourcing Your Thinking](#the-risk-outsourcing-your-thinking)
+  - [For You vs. For Them](#for-you-vs-for-them)
+- [The Four Thinking Modes](#the-four-thinking-modes)
   - [The Madman: Unleashing Creative Chaos](#the-madman-unleashing-creative-chaos)
   - [The Architect: Structuring Your Thoughts](#the-architect-structuring-your-thoughts)
   - [The Carpenter: Crafting Your Words](#the-carpenter-crafting-your-words)
   - [The Judge: Polishing Your Work](#the-judge-polishing-your-work)
-  - [Key Principles for AI-Enhanced Writing](#key-principles-for-ai-enhanced-writing)
+  - [Key Principles for AI-Enhanced Thinking](#key-principles-for-ai-enhanced-thinking)
 - [The Art of the Back-and-Forth](#the-art-of-the-back-and-forth)
   - [Filtering Is Easier Than Creating](#filtering-is-easier-than-creating)
   - [The Collaboration Patterns](#the-collaboration-patterns)
@@ -43,98 +40,56 @@ The concept emerged from the realization that traditional writing processes are 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
 
-## The Foundations of CHOW
+## CHOW is Thinking
 
-Before we explore how AI transforms writing, let's understand the foundations that CHOW builds upon. After all, even the most sophisticated AI kitchen needs to understand the basics of cooking!
-
-### The Art of Writing
+### Why Writing = Thinking
 
 {% include summarize-page.html src="/writing" %}
 
-### The Enabling Environment
+The act of putting ideas into words forces clarity. Vague notions that feel profound in your head reveal themselves as muddled when you try to explain them. This is why writing matters - not for the artifact, but for the thinking it produces.
 
-{% include summarize-page.html src="/enable" %}
-
-### Learning from CHOP
-
-CHOW builds on the principles of Chat-Oriented Programming (CHOP). While CHOP revolutionizes how we write code, CHOW applies similar patterns to writing prose:
+CHOW builds on the principles of Chat-Oriented Programming (CHOP):
 
 {% include summarize-page.html src="/chop" %}
 
-### The Evolution of AI Writing
+### The Risk: Outsourcing Your Thinking
 
-The journey to CHOW has been remarkable:
+AI makes writing easy. That's the obvious part. The less obvious part: the thinking that writing forced on you - the struggle to clarify, to find the gap in your logic, to articulate what you actually mean - that was the point.
 
-1. **Basic Assistance (The Prep Cook)**
-   - Simple grammar checking
-   - Spell checking
-   - Basic synonym suggestions
-   - Word count tools
+When AI writes for you, you skip the struggle. And the struggle was doing the work.
 
-2. **Interactive Support (The Line Cook)**
-   - Style suggestions
-   - Tone analysis
-   - Content organization help
-   - Research assistance
+This is why CHOW matters. The goal isn't "get AI to write stuff." The goal is "use AI to think better." The difference:
 
-3. **Full Content Generation (The Sous Chef)**
-   - Complete draft generation
-   - Style-aware writing
-   - Convention-driven content
-   - Structure suggestions
+| Outsourcing | Partnering |
+|-------------|------------|
+| "Write me a blog post about X" | "Help me figure out what I actually think about X" |
+| AI generates, you approve | AI challenges, you clarify |
+| Words appear, thinking optional | Thinking required, words are the receipt |
 
-## What is CHOW?
+### For You vs. For Them
 
-CHOW (Chat-Oriented Writing) represents a fundamental shift in how we create written content. Instead of staring at a blank page or struggling with writer's block, we engage in a high-level dialogue with AI about our writing goals. Think of it as having a writing partner who can understand your style, research topics instantly, and help craft compelling narratives through natural conversation.
+Every piece of writing serves two audiences:
 
-### The Evolution of AI Writing
+**For You (Understanding)** - Writing to figure out what you actually think. The reader is future-you or maybe no one. The goal is clarity in your own head.
 
-The journey to CHOW has been remarkable:
+**For Them (Being Understood)** - Writing to transfer understanding to someone else. The reader is a real audience. The goal is clarity in their head.
 
-1. **Basic Assistance (The Prep Cook)**
-   - Simple grammar checking
-   - Spell checking
-   - Basic synonym suggestions
-   - Word count tools
+These aren't separate activities - they're interleaved. You can't explain something clearly until you understand it yourself. And the act of trying to explain often reveals you didn't understand it as well as you thought.
 
-2. **Interactive Support (The Line Cook)**
-   - Style suggestions
-   - Tone analysis
-   - Content organization help
-   - Research assistance
+AI can help with both, but you have to know which mode you're in.
 
-3. **Full Content Generation (The Sous Chef)**
-   - Complete draft generation
-   - Style-aware writing
-   - Convention-driven content
-   - Structure suggestions
+## The Four Thinking Modes
 
-### Core Concepts
+The Madman, Architect, Carpenter, and Judge aren't just writing phases - they're thinking phases. Each serves two purposes: helping *you* understand, and helping *others* understand.
 
-1. **Natural Language Collaboration**
-   - Express writing goals conversationally
-   - Iterative refinement through dialogue
-   - Style-aware responses
+| Persona | For You (Understanding) | For Them (Being Understood) |
+|---------|------------------------|----------------------------|
+| **Madman** | Explore what you're confused about, dump half-formed thoughts | Brainstorm what the reader needs, what angles might resonate |
+| **Architect** | Organize your own mental model, find gaps in your logic | Structure the reader's journey, decide what order they need things |
+| **Carpenter** | Precision forces clarity - "I can't write this, so I don't actually understand it" | Choose words for the reader, craft sentences they'll follow |
+| **Judge** | Poke holes in your own reasoning, find where you're fooling yourself | Edit for clarity, catch what will confuse the reader |
 
-2. **Content Understanding**
-   - AI comprehends your writing style
-   - Follows established conventions
-   - Maintains consistency across pieces
-
-3. **Convention-Driven Writing**
-   - Uses style guides as knowledge base
-   - Learns from your preferences
-   - Maintains consistent voice and tone
-
-### Key Tools
-
-The landscape of AI writing tools is evolving rapidly. Rather than provide a potentially outdated list of specific tools, I'll update this section periodically with current best practices and tool recommendations. The key is to focus on the principles and patterns of CHOW, which can be applied regardless of which specific AI assistant you're using.
-
-For now, experiment with the major AI platforms (you know the ones), and find what works best for your writing style and needs. Remember: the best tool is the one that helps you maintain your creative vision while enhancing your productivity.
-
-## CHOW and the Four Writing Personas
-
-Writing breaks down into four distinct phases, each with its own persona: the Madman, Architect, Carpenter, and Judge. AI can be a powerful partner in each phase, enhancing your natural abilities while maintaining your creative control. Let's explore how CHOW can amplify each role:
+AI can be a powerful partner in each phase. Let's explore how:
 
 ### The Madman: Unleashing Creative Chaos
 
@@ -259,7 +214,7 @@ Consider the audience's viewpoint:
 - Identify potential points of confusion
 - Suggest clarifications where needed
 
-### Key Principles for AI-Enhanced Writing
+### Key Principles for AI-Enhanced Thinking
 
 1. **Keep the Phases Separate**:
    - Don't let AI's capabilities tempt you to mix phases

--- a/back-links.json
+++ b/back-links.json
@@ -58,6 +58,7 @@
         "/chat-tony": "/tesla",
         "/chilliwack": "/bc",
         "/chop-igor": "/how-igor-chops",
+        "/chot": "/chow",
         "/classact": "/class-act",
         "/coach": "/coaching",
         "/cocaine": "/mania",
@@ -284,7 +285,7 @@
         "/vacation": "/timeoff",
         "/vancouver": "/bc",
         "/vibe": "/how-igor-chops",
-        "/vibe-coding": "/vibe",
+        "/vibe-coding": "/how-igor-chops",
         "/video-player": "/vlc",
         "/videoplayer": "/vlc",
         "/virus": "/covid",
@@ -694,7 +695,7 @@
             "incoming_links": [
                 "/ai-developer"
             ],
-            "last_modified": "2025-12-07T02:37:56+00:00",
+            "last_modified": "2026-01-02T15:26:54+00:00",
             "markdown_path": "_d/ai.md",
             "outgoing_links": [
                 "/ai-art",
@@ -771,7 +772,7 @@
             "incoming_links": [
                 "/ai"
             ],
-            "last_modified": "2025-12-21T16:27:51+00:00",
+            "last_modified": "2026-01-02T15:26:54+00:00",
             "markdown_path": "_d/ai-developer.md",
             "outgoing_links": [
                 "/ai",
@@ -840,7 +841,7 @@
         },
         "/ai-security": {
             "description": "Security is super interesting, AI is super interesting, the combination, is super-duper interesting!\n\n",
-            "doc_size": 32000,
+            "doc_size": 33000,
             "file_path": "_site/ai-security.html",
             "incoming_links": [
                 "/ai",
@@ -1490,12 +1491,11 @@
                 "/y24",
                 "/y25"
             ],
-            "last_modified": "2026-01-02T14:45:11+00:00",
+            "last_modified": "2026-01-02T15:26:54+00:00",
             "markdown_path": "_d/ai-coder.md",
             "outgoing_links": [
                 "/ai-journal",
                 "/ai-testing",
-                "/chow",
                 "/how-igor-chops",
                 "/humans-are-underrated",
                 "/process-journal",
@@ -1506,25 +1506,23 @@
             "url": "/chop"
         },
         "/chow": {
-            "description": "Welcome to The CHOW Kitchen! CHOW - or Chat-Oriented Writing - is transforming how we create content. Think of those bustling restaurant kitchens: AI started as the prep cook, chopping vegetables and measuring ingredients. Then it became a line cook, helping with recipes and plating. Now? It’s becoming a sous chef, capable of crafting entire dishes from your creative vision. Our AIs are getting more sophisticated daily, and we’ll explore how to make the most of this culinary revolution in writing.\n\n",
-            "doc_size": 33000,
+            "description": "I used to stare at blank pages. Now I have a different problem: AI will happily fill those pages for me, but my brain stays empty. CHOW - Chat-Oriented Writing - is my answer: using AI to think better, not just write faster. The written artifact is a side effect. The real product is clarity in your head. This post covers why writing equals thinking, the risk of outsourcing that thinking to AI, and the four thinking modes - Madman, Architect, Carpenter, Judge - that help you partner with AI instead of just delegating to it.\n\n",
+            "doc_size": 32000,
             "file_path": "_site/chow.html",
             "incoming_links": [
                 "/ai",
                 "/ai-journal",
-                "/chop",
                 "/how-igor-chops"
             ],
             "last_modified": "2026-01-02T02:18:59+00:00",
             "markdown_path": "_d/chow.md",
             "outgoing_links": [
                 "/chop",
-                "/enable",
                 "/td/data-systems",
                 "/writing"
             ],
             "redirect_url": "",
-            "title": "The CHOW Kitchen: Where AI Meets Writing",
+            "title": "CHOW: Chat-Oriented Writing",
             "url": "/chow"
         },
         "/class-act": {
@@ -2269,7 +2267,6 @@
             "doc_size": 21000,
             "file_path": "_site/enable.html",
             "incoming_links": [
-                "/chow",
                 "/how-igor-chops",
                 "/writing"
             ],
@@ -3012,7 +3009,7 @@
                 "/chop",
                 "/pet-projects"
             ],
-            "last_modified": "2026-01-02T01:44:02+00:00",
+            "last_modified": "2026-01-02T15:26:54+00:00",
             "markdown_path": "_d/how-igor-chops.md",
             "outgoing_links": [
                 "/40yo",

--- a/content_guidelines.md
+++ b/content_guidelines.md
@@ -801,3 +801,71 @@ alias:
 ```
 
 **IMPORTANT IMPLEMENTATION RULE:** Always use these technical elements consistently. Alert boxes for important notices, redirects for memorable URLs, affiliate links for books, proper image includes for formatting, summarize-page includes for internal references, and quadrant-matrix includes for 2x2 visualizations.
+
+---
+
+## PR Review Checklist
+
+At the end of a content PR review, include this summary format. These checks map to the [thinking phases in CHOW](/chow#the-four-thinking-modes).
+
+```
+Architect: 🟢 headers 🟢 front-matter 🟢 internal-links
+Carpenter: 🟢 opening 🟢 voice 🟢 ai-patterns
+Judge: 🟢 alerts 🟢 images ⚪ books ⚪ ai-slop
+Workflow: 🟢 rebased 🟢 backlinks
+
+Issues:
+- [list any 🔴 items with actionable fix]
+```
+
+**Status indicators:**
+- 🟢 Pass
+- 🔴 Fail (requires fix)
+- ⚪ N/A (not applicable to this PR)
+
+**Checklist items by phase:**
+
+**Architect** (structure):
+
+| Key | Check |
+|-----|-------|
+| `headers` | Headers used for easy scanning |
+| `front-matter` | Complete front matter (title, permalink, tags) |
+| `internal-links` | Internal links use permalinks (not redirects), relative paths (no hostname), proper format |
+
+**Carpenter** (prose):
+
+| Key | Check |
+|-----|-------|
+| `opening` | First paragraph is plain text (no includes/alerts) for excerpt generation |
+| `voice` | Consistent voice throughout (no "I"/"we" mixing, consistent tone) |
+| `ai-patterns` | No AI writing patterns (undue emphasis, "it's important to note", etc.) |
+
+**Judge** (polish):
+
+| Key | Check |
+|-----|-------|
+| `alerts` | Alert boxes placed AFTER opening paragraph |
+| `images` | Images use proper includes (`blob_image.html`, etc.) |
+| `books` | Book links use `{% include amazon.html asin="..." %}` |
+| `ai-slop` | AI slop notice (if needed) placed after first paragraph |
+
+**Workflow** (process):
+
+| Key | Check |
+|-----|-------|
+| `rebased` | Branch rebased onto upstream main |
+| `backlinks` | Backlinks regenerated (`just back-links`) |
+
+**Example with issues:**
+
+```
+Architect: 🟢 headers 🟢 front-matter 🟢 internal-links
+Carpenter: 🟢 opening 🟢 voice 🔴 ai-patterns
+Judge: 🟢 alerts 🟢 images ⚪ books ⚪ ai-slop
+Workflow: 🟢 rebased 🔴 backlinks
+
+Issues:
+- ai-patterns — line 42: remove "it's important to note that"
+- backlinks — run `just backlinks` to regenerate
+```


### PR DESCRIPTION
## Summary

- **CHOW post restructure**: Reframes the post around "writing = thinking" instead of kitchen metaphors
- **New intro**: Personal hook about AI filling pages while brain stays empty
- **New sections**: "The Risk: Outsourcing Your Thinking" and "For You vs. For Them" audience framework
- **Four personas reorganized**: Grouped under "CHOW is Thinking" with dual-purpose table (for you / for them)
- **PR review checklist**: Added to content_guidelines.md, organized by thinking phase (Architect/Carpenter/Judge/Workflow)

## PR Review

```
Architect: 🟢 headers 🟢 front-matter 🟢 internal-links
Carpenter: 🟢 opening 🟢 voice 🟢 ai-patterns
Judge: 🟢 alerts ⚪ images ⚪ books ⚪ ai-slop
Workflow: 🟢 rebased 🟢 backlinks
```

## Test plan

- [ ] Preview CHOW post at /chow
- [ ] Verify TOC links work
- [ ] Check content_guidelines.md PR checklist section renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured CHOW framework documentation to emphasize thinking processes over writing outputs, introducing a new thinking-focused structure with four collaborative modes.
  * Added PR Review Checklist to content guidelines for workflow management.

* **Updates**
  * Updated CHOW framework title and descriptions to reflect new thinking-centric approach.
  * Added new documentation redirect for improved content navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->