### PR TITLE
docs: add running-servers tool to CLAUDE-CODING.md

### DIFF
--- a/CLAUDE-CODING.md
+++ b/CLAUDE-CODING.md
@@ -72,6 +72,29 @@ Names MUST tell what code does, not how it's implemented or its history:
 - **Run in background**: `just jekyll-serve 4002 35730 > /tmp/jekyll.log 2>&1 &`
 - **On c-500X machines**: Use `http://c-500X:4000/page-name`
 
+### Checking Running Servers
+
+Use `running-servers` to discover what's running:
+
+```bash
+running-servers status              # List all servers (compact)
+running-servers status --full       # Full process tree with command lines
+running-servers status --json       # JSON output for scripts
+running-servers port 4000           # Check what's on port 4000
+running-servers check .             # Check if server running for current dir
+```
+
+Example output with `--full`:
+```
+:4000 (pid 675062)
+  dir: /home/developer/gits/blog2
+  url: http://c-5001.squeaker-teeth.ts.net:4000
+  tree:
+    [675041] just jekyll-serve 4000 35729
+    └─ [675045] sh /tmp/just-I1g70G/jekyll-serve
+        └─ [675062] jekyll server --incremental --livereload ...
+```
+
 ## Systematic Debugging Process
 
 YOU MUST find the root cause - NEVER fix symptoms or add workarounds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,17 +136,26 @@ See `_d/tesla.md` for implementation. Backend: [github.com/idvorkin/tony_tesla](
 
 ## Previewing Pages
 
-**Use `jekyll_server.py` to manage Jekyll servers across multiple directories:**
+**Use `running-servers` to discover and manage servers:**
 
 ```bash
 # Check if a server is running for this directory
-python3 ~/gits/settings/py/jekyll_server.py check
+running-servers check .
 
-# See all running Jekyll servers
-python3 ~/gits/settings/py/jekyll_server.py status
+# See all running servers (compact view)
+running-servers status
 
-# Get suggested command to start server (finds available port)
-python3 ~/gits/settings/py/jekyll_server.py suggest
+# See full process tree with command lines
+running-servers status --full
+
+# JSON output for scripts
+running-servers status --json
+
+# Check what's on a specific port
+running-servers port 4000
+
+# Get suggested available port
+running-servers suggest
 ```
 
 The script automatically detects the Tailscale hostname and provides clickable URLs.


### PR DESCRIPTION
## Summary
- Documents the `running-servers` CLI for discovering running servers
- Shows status, port, check commands
- Includes example output with full process tree

## Example
```bash
running-servers status --full

:4000 (pid 675062)
  dir: /home/developer/gits/blog2
  url: http://c-5001.squeaker-teeth.ts.net:4000
  tree:
    [675041] just jekyll-serve 4000 35729
    └─ [675045] sh /tmp/just-I1g70G/jekyll-serve
        └─ [675062] jekyll server --incremental --livereload ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)