### PR TITLE
Add Work section to 2026 goals

### DIFF
--- a/_d/y2026.md
+++ b/_d/y2026.md
@@ -45,6 +45,7 @@ I like to begin with the end in mind, so let's write a report for 2026. This has
 Carried forward from 2024 and 2025. This year I'll be 48. Time to actually capture and share these lessons.
 
 Notes:
+
 - Start with what I wish I knew at 32
 - Consider making TikToks
 - Consider making TikTok version of [what I wish I knew at 22](/22)
@@ -101,16 +102,16 @@ Another memorable family vacation.
 
 Starting from 2025's ending point. Shoulder recovery is priority #1.
 
-| Metric          | Goal           | Jan | June | Dec | Status |
-| --------------- | -------------- | --- | ---- | --- | ------ |
-| Weight          | 170            | 180 | -    | -   | -      |
-| Sleep           | 9pm - 5am      | 5am | -    | -   | -      |
-| Gym             | 5d/week        | 4-5 | -    | -   | -      |
-| Swings          | 1H: 6x32       | -   | -    | -   | -      |
-| TGU             | 5x32           | -   | -    | -   | -      |
-| Chinups         | 3x10           | 3x8 | -    | -   | -      |
-| Touchdowns      | TBD            | -   | -    | -   | -      |
-| Half Lotus      | 300s from cold | 60s | -    | -   | -      |
+| Metric     | Goal           | Jan | June | Dec | Status |
+| ---------- | -------------- | --- | ---- | --- | ------ |
+| Weight     | 170            | 180 | -    | -   | -      |
+| Sleep      | 9pm - 5am      | 5am | -    | -   | -      |
+| Gym        | 5d/week        | 4-5 | -    | -   | -      |
+| Swings     | 1H: 6x32       | -   | -    | -   | -      |
+| TGU        | 5x32           | -   | -    | -   | -      |
+| Chinups    | 3x10           | 3x8 | -    | -   | -      |
+| Touchdowns | TBD            | -   | -    | -   | -      |
+| Half Lotus | 300s from cold | 60s | -    | -   | -      |
 
 See [shoulder pain](/shoulder-pain) for recovery plan. Continuing hip mobility and glute med work from 2025.
 
@@ -130,11 +131,13 @@ Restarted meditation and journalling on 12/30/2025. Maintain the momentum.
 Deepen my awareness and concentration through rebuilding my meditation practice for both skills and spirituality.
 
 **Q1 2026 Goals:**
+
 1. Restart daily meditation practice
 2. Read "Awareness" by Anthony De Mello
 3. Read "Waking Up" by Sam Harris
 
 **Longer-term goals to define:**
+
 - Build consistent concentration practice (Samatha) - keeping focus from paging out
 - Develop awareness practice (Vipassana) - observing without judgment
 - Explore the intersection of meditation and spiritual insight
@@ -157,6 +160,10 @@ Related reading: [Awareness](/awareness), [Search Inside Yourself](/siy), [Spiri
 - Biking: Get back on the bike despite the Tesla temptation
 - Keep the goofy shirts and mismatched crocs going
 - Balloon more, especially while travelling
+
+#### Work
+
+- [Keep work at work](/mind-at-home-body-at-work) - The bar isn't "not checking my phone at home." It's not thinking about work—not replaying the tough conversation I'm afraid of, not being angry at something that triggered me.
 
 ## Stuff I'm really proud of
 

--- a/back-links.json
+++ b/back-links.json
@@ -6620,7 +6620,7 @@
             "doc_size": 21000,
             "file_path": "_site/y26.html",
             "incoming_links": [],
-            "last_modified": "2026-01-06T03:52:36+00:00",
+            "last_modified": "2026-01-18T22:12:38.506217+00:00",
             "markdown_path": "_d/y2026.md",
             "outgoing_links": [
                 "/22",
@@ -6634,6 +6634,7 @@
                 "/how-igor-chops",
                 "/last-year",
                 "/manager-book",
+                "/mind-at-home-body-at-work",
                 "/mortality-software",
                 "/shoulder-pain",
                 "/siy",


### PR DESCRIPTION
## Summary

- Adds a new "Work" section under the Identity/Goals area of the 2026 goals document
- Introduces the "Keep work at work" goal focusing on mental separation from work
- The goal emphasizes not just physical absence from work devices, but mental detachment from work stressors

## Test plan

- [ ] Verify the new Work section renders correctly on the site
- [ ] Confirm the link to `/mind-at-home-body-at-work` works correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Enhanced 2026 personal goals with new work-life balance initiatives and expanded spiritual growth objectives
  * Improved formatting and structure across goals and notes sections for better readability
  * Updated internal link references to support improved content organization and cross-referencing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->