### PR TITLE
Add CHOW link to AI slop notice

### DIFF
--- a/_includes/ai-slop.html
+++ b/_includes/ai-slop.html
@@ -1,3 +1,3 @@
 <div class="alert alert-info" role="alert">
-  <strong>AI Slop Notice:</strong> This post is approximately {{include.percent}}% AI slop. I'm using this as an experiment in AI-augmented learning and book processing. Working on refining it!
+  <strong>AI Slop Notice:</strong> This post is approximately {{include.percent}}% AI slop. I'm using this as an experiment in AI-augmented learning and book processing. See <a href="/how-igor-chops">how I work with AI (CHOW)</a>. Working on refining it!
 </div>


### PR DESCRIPTION
## Summary

Updates the AI slop notice to include a link to /how-igor-chops so readers can learn about CHOW (Claude Helps Out Work) - how Igor works with AI.

## Changes

- Modified  to add link: "See how I work with AI (CHOW)"

## Test plan

- [x] Link points to correct page (/how-igor-chops)
- [x] HTML syntax correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)