### PR TITLE
Redesign monitors section with dimension fundamentals

### DIFF
--- a/_data/asins.json
+++ b/_data/asins.json
@@ -789,5 +789,12 @@
     "price": null,
     "title": "RK ROYAL KLUDGE RKS70 Ergonomic Split Keyboard, Wireless RGB Mechanical Keyboard with Bluetooth/2.4GHz/Wired, 75% Hot Swappable Gaming Keyboards with Fixed Wrist Rest, Pre-lubed Linear Creamy Switches : Video Games",
     "updated": "2026-01-25"
+  },
+  "B0FJYNVR3R": {
+    "description": "View product details on Amazon",
+    "image": "https://images-na.ssl-images-amazon.com/images/P/B0FJYNVR3R.01._SCLZZZZZZZ__SL160_.jpg",
+    "price": null,
+    "title": "SAMSUNG 40\u201d Odyssey G7 (G75F) WUHD Resolution, 180Hz, Curved Gaming Monitor, 1ms Response Time (GtG), VESA DisplayHDR\u2122 600, AMD FreeSync\u2122 Premium Pro, LS40FG75DENXZA, 2025",
+    "updated": "2026-01-25"
   }
 }

--- a/_td/irl.md
+++ b/_td/irl.md
@@ -258,9 +258,32 @@ I've gotten 3 cheap pieces of aftermarket tech that transformed my car to awesom
 
 ### Monitors
 
-- 34" wide screen - not a huge fan. Good for widescreen movies (but Netflix/YouTube rarely has this resolution)
-- 40" 3840x2160 - Awesome, I love it! Highly recommend
-- [Beefy Monitor Stand](https://www.amazon.com/dp/B01BXP9LT6) - If you're getting a good monitor make sure it floats with a pneumatic monitor stand.
+**Understanding monitor dimensions:** Monitors are defined by three factors: aspect ratio, resolution, and diagonal size. The mental model that helps: ultrawides are basically standard monitors stretched wider (keeping height roughly the same).
+
+| Format | Aspect Ratio | Example Size | Resolution | Mental Model |
+|--------|-------------|--------------|------------|--------------|
+| **Standard** | 16:9 | 27" | 2560×1440 (QHD) | Baseline |
+| **Standard** | 16:9 | 32" | 3840×2160 (4K) | Bigger baseline |
+| **Ultrawide** | 21:9 | 34" | 3440×1440 | 27" × 1.33 wide |
+| **Ultrawide** | 21:9 | 40" | 5120×2160 | 32" × 1.32 wide |
+| **Super-ultrawide** | 32:9 | 49" | 5120×1440 | 27" × 2.0 wide |
+| **Super-ultrawide** | 32:9 | 57" | 7680×2160 | 32" × 2.0 wide |
+
+**My setup:**
+
+- **At work: 32" 4K (3840×2160, 16:9)** - Standard 4K monitor, excellent all-around
+- **At home: 43" 4K (3840×2160, 16:9)** - Same resolution as the 32", just bigger. Loved it! (discontinued)
+- **At home ultrawide: 40" Samsung Odyssey G7** (Upgraded from 34" ultrawide) - 5120×2160, 21:9, 180Hz, DisplayHDR 600. Think of it as a 32" 4K monitor stretched 32% wider. Excellent for productivity with vertical space of 4K but extra width for side-by-side windows.
+
+**Previous:**
+
+- **34" ultrawide (3440×1440, 21:9)** - Not a huge fan. Good for widescreen movies, but Netflix/YouTube rarely use this aspect ratio
+
+{%include amazon.html asin="B0FJYNVR3R" %}
+
+**Essential accessory:**
+
+[Beefy Monitor Stand](https://www.amazon.com/dp/B01BXP9LT6) - If you're getting a good monitor, make sure it floats with a pneumatic monitor stand.
 
 {%include amazon.html asin="B01BXP9LT6" %}
 


### PR DESCRIPTION
## Summary

- Add comprehensive table explaining monitor aspect ratios, resolutions, and mental models
- Show how ultrawides relate to standard monitors (40" ultrawide = 32" × 1.32 wide)
- Document Igor's current multi-monitor setup:
  - Work: 32" 4K standard
  - Home: 43" 4K standard + 40" Samsung Odyssey G7 ultrawide
- Add Samsung Odyssey G7 (40" 5K2K) with product metadata
- Move 34" ultrawide to "Previous" section
- Fix aspect ratio math with proper calculations

## Test plan

- [x] Verified aspect ratio math (1.32×, 1.33×, 2.0×)
- [x] Fetched Samsung Odyssey G7 product metadata (ASIN B0FJYNVR3R)
- [ ] Preview updated monitors section in Jekyll

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the product catalog with a new entry including comprehensive product specifications
  * Reorganized monitor specifications documentation with structured table format, displaying dimensions, resolution, aspect ratio, and equipment setup information for improved clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->