### PR TITLE
Add visual monitor size comparison to IRL page

### DIFF
--- a/_includes/monitor-comparison.html
+++ b/_includes/monitor-comparison.html
@@ -1,0 +1,36 @@
+<div style="margin: 2rem 0; padding: 1rem; background: #f5f5f5; border-radius: 8px;">
+  <div style="position: relative; height: 500px; padding: 1rem;">
+    <!-- 27" Standard (16:9) - baseline -->
+    <div style="position: absolute; top: 0; left: 0; width: 235px; height: 132px; border: 3px solid #666; background: rgba(200, 200, 200, 0.3); display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: bold;">
+      27" QHD<br>16:9
+    </div>
+
+    <!-- 32" Standard (16:9) -->
+    <div style="position: absolute; top: 150px; left: 0; width: 279px; height: 157px; border: 3px solid #0066cc; background: rgba(0, 102, 204, 0.2); display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: bold;">
+      32" 4K<br>16:9
+    </div>
+
+    <!-- 34" Ultrawide (21:9) -->
+    <div style="position: absolute; top: 320px; left: 0; width: 312px; height: 134px; border: 3px solid #cc6600; background: rgba(204, 102, 0, 0.2); display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: bold;">
+      34" Ultrawide<br>21:9
+    </div>
+
+    <!-- 40" Ultrawide (21:9) - Igor's home monitor -->
+    <div style="position: absolute; top: 0; left: 300px; width: 367px; height: 157px; border: 4px solid #00aa00; background: rgba(0, 170, 0, 0.2); display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: bold; box-shadow: 0 0 10px rgba(0, 170, 0, 0.5);">
+      40" Odyssey G7<br>21:9<br>(Igor's home)
+    </div>
+
+    <!-- 49" Super-ultrawide (32:9) -->
+    <div style="position: absolute; top: 170px; left: 300px; width: 472px; height: 133px; border: 3px solid #9900cc; background: rgba(153, 0, 204, 0.2); display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: bold;">
+      49" Super-wide<br>32:9
+    </div>
+
+    <!-- 57" Super-ultrawide (32:9) -->
+    <div style="position: absolute; top: 320px; left: 300px; width: 549px; height: 154px; border: 3px solid #cc0066; background: rgba(204, 0, 102, 0.2); display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: bold;">
+      57" Super-wide<br>32:9
+    </div>
+  </div>
+  <div style="margin-top: 1rem; font-size: 11px; color: #666;">
+    Scale: 1 inch = ~10 pixels. Green highlight = Igor's current setup.
+  </div>
+</div>

--- a/_td/irl.md
+++ b/_td/irl.md
@@ -269,6 +269,10 @@ I've gotten 3 cheap pieces of aftermarket tech that transformed my car to awesom
 | **Super-ultrawide** | 32:9 | 49" | 5120×1440 | 27" × 2.0 wide |
 | **Super-ultrawide** | 32:9 | 57" | 7680×2160 | 32" × 2.0 wide |
 
+**Visual size comparison (to scale):**
+
+{% include monitor-comparison.html %}
+
 **My setup:**
 
 - **At work: 32" 4K (3840×2160, 16:9)** - Standard 4K monitor, excellent all-around


### PR DESCRIPTION
## Summary

Add a to-scale visual comparison of monitor sizes to help readers understand the physical dimensions of different monitor formats.

## Changes

- Created `_includes/monitor-comparison.html` - reusable component for visualizing monitor sizes
- Updated `_td/irl.md` to use the new include
- Visual shows relative sizes of:
  - Standard 16:9 monitors (27", 32")
  - Ultrawide 21:9 monitors (34", 40" - Igor's setup)
  - Super-ultrawide 32:9 monitors (49", 57")
- Igor's 40" Odyssey G7 is highlighted in green for easy identification

## Why This Helps

The table explains aspect ratios and resolutions, but seeing the actual size differences makes it much clearer how ultrawides are "just standard monitors stretched wider" while maintaining similar height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)