### PR TITLE
Add addiction vs opportunity cost framework

### DIFF
--- a/_d/addiction.md
+++ b/_d/addiction.md
@@ -16,7 +16,11 @@ Addiction is not about drugs or alcohol - it is about escape. Quoting "Do the Wo
 
 <!-- vim-markdown-toc-start -->
 
+- [Is doing the thing you want to be doing an addiction?](#is-doing-the-thing-you-want-to-be-doing-an-addiction)
+  - [The logical approach](#the-logical-approach)
+  - [Examples from my life](#examples-from-my-life)
 - [Current Addictions](#current-addictions)
+  - [TikTok (Thought Escape)](#tiktok-thought-escape)
 - [Hypo Addictions](#hypo-addictions)
   - [Social Media Analytics](#social-media-analytics)
     - [LinkedIn friend count](#linkedin-friend-count)
@@ -31,7 +35,7 @@ Addiction is not about drugs or alcohol - it is about escape. Quoting "Do the Wo
   - [Truckers](#truckers)
 - [Beaten addictions (for now)](#beaten-addictions-for-now)
   - [Pokemon Go](#pokemon-go)
-  - [TikTok](#tiktok)
+  - [TikTok (and it's back)](#tiktok-and-its-back)
   - [Covid 19 News](#covid-19-news)
   - [Alcohol](#alcohol)
     - ["Zero proof" drinks](#zero-proof-drinks)
@@ -45,7 +49,49 @@ Addiction is not about drugs or alcohol - it is about escape. Quoting "Do the Wo
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
 
+## Is doing the thing you want to be doing an addiction?
+
+Here's a framework I've been working through: there's both addiction and there's opportunity cost, and they're different things.
+
+**Addiction:** You DON'T want to do the thing you're doing, but you feel compelled to inside. The rest of your life is suffering as a result.
+
+**Opportunity cost:** You DO want to do it, and the rest of your life is suffering because you're choosing this over other things.
+
+The key difference is compulsion versus choice. With addiction, you're running from something - escaping thoughts, avoiding feelings, numbing pain. With opportunity cost, you're running toward something you genuinely value, but you're paying a price in other areas of your life.
+
+### The logical approach
+
+Once you identify which one you're dealing with, you can respond appropriately:
+
+- **If it's addiction:** The work is to address the underlying thing you're avoiding. What are you escaping from? What pain or fear are you numbing?
+- **If it's opportunity cost:** Weigh the costs logically. Is what you're gaining worth what you're losing? Are you making a conscious trade-off or just drifting into an imbalanced life?
+
+### Examples from my life
+
+The clearest distinction for me is **TikTok vs Vibe Coding**.
+
+**TikTok = Addiction**
+
+I don't actually want to scroll TikTok. I'm not excited about watching strangers do kettlebell lifts or give retirement advice. But when I have a moment of quiet, or finish one thing before starting the next, I feel compelled to scroll. I'm escaping my thoughts - avoiding the discomfort of being present with my internal experience. I can't stand NOT scrolling in those moments. That's addiction: running from something, not toward something.
+
+**Vibe Coding = Opportunity Cost**
+
+When I'm in flow writing code, building something, solving a problem - I genuinely want to be doing it. I love it. I'm not escaping anything; I'm engaged in something meaningful. But the rest of my life suffers - I miss family time, skip workouts, stay up too late. That's opportunity cost: I'm choosing this over other things, and I need to weigh whether the trade-off is worth it.
+
+The test is simple: If I had to stop right now, which one would feel like relief and which would feel like loss? TikTok would be relief. Vibe coding would be loss.
+
+**The question to ask:** Am I doing this because I genuinely want to, or because I can't stand NOT doing it?
+
 ## Current Addictions
+
+### TikTok (Thought Escape)
+
+I recently became aware of something subtle: my urge to scroll TikTok isn't about getting dopamine hits from entertaining content. It's about escaping my thoughts.
+
+When I sit down and have a moment of quiet, or when I finish one thing and before I start the next, there's this pull to open TikTok. Not because I want to watch content, but because I don't want to sit with whatever's on my mind. The scrolling gives me something external to focus on so I don't have to be present with my internal experience.
+
+This is textbook addiction as escape. I'm not seeking pleasure - I'm avoiding discomfort. The thing I'm escaping from isn't even necessarily bad thoughts or painful feelings. Sometimes it's just... thoughts. The act of having an inner mental life feels uncomfortable, so I scroll.
+
 
 ## Hypo Addictions
 
@@ -93,9 +139,11 @@ I think my favorite is someone says I'm not doing this to enjoy the outdoors, I'
 
 I was pretty depressed, and needed an escape from reality. Pokemon Go was great, I could just get out and do it. Then one day at Legoland I realized I just wanted to zone out and play Pokemon Go, and I was like, OK this is crazy and stopped cold turkey.
 
-### TikTok
+### TikTok (and it's back)
 
-This platform sucked me in before I realized how much of my time I'd spent sucked in.
+This platform sucked me in before I realized how much of my time I'd spent sucked in. I quit cold turkey.
+
+But it came back. Turns out my personality pattern - get addicted, beat it, assume it's gone forever - doesn't account for the fact that if the underlying need (escaping thoughts) isn't addressed, the addiction just resurfaces. See [Current Addictions](#tiktok-thought-escape) for the current bout.
 
 ### Covid 19 News
 
@@ -117,18 +165,45 @@ This comes and goes depending on how well/poorly work is going. But I used to be
 
 ### Work Addiction and Success Addiction
 
+Workaholism is one of the trickiest addictions because it looks productive. People praise you for it, you get promoted, you build things. But using the [addiction vs opportunity cost framework](#is-doing-the-thing-you-want-to-be-doing-an-addiction) helps clarify what's really happening.
+
+**Signs it's addiction (not just hard work):**
+
+- You DON'T want to be working but feel compelled to
+- You're checking email at 10pm not because you want to, but because you can't stand the anxiety of not checking
+- You're thinking about work during family time not because the work is fascinating, but because you're escaping the discomfort of being present
+- The rest of your life is suffering - relationships, health, hobbies all deteriorating
+- You feel "out of control" - you can't stop even when you know you should
+
+**When it's opportunity cost (not addiction):**
+
+- You DO want to work on the problem - it's genuinely interesting
+- You're making conscious trade-offs about where to spend your time
+- You could stop if you chose to, you're just choosing not to
+- You're aware of what you're sacrificing and weighing whether it's worth it
+
+The test: Can you stop? If you genuinely can't stop working even when you want to, even when you know it's hurting you - that's addiction. If you can stop but choose not to because the work matters to you more than the alternatives right now - that's opportunity cost.
+
+**Success Addiction**
+
 See midlife notes on from strength to strength.
 
 {%include summarize-page.html src="/midlife" %}
+
+Success addiction is particularly insidious because it's culturally rewarded. The classic definition from Arthur Brooks:
 
 - Success => Having more than others
 - Failure => Having Less
 
 A few problems of course: 1. You change your definition of others 1. It gets hard and harder as you get into midlife
 
-Far better is to define satisfaction as
+This becomes addiction when you're not pursuing success because you want it, but because you can't stand the feeling of "falling behind" or "not measuring up." You're running from inadequacy, not toward achievement.
+
+Far better is to define satisfaction as:
 
 1.  What you want / what you have
+
+This shifts the frame from external comparison (addiction fuel) to internal alignment (conscious choice).
 
 ## Getting Rid of 'em
 
@@ -142,7 +217,24 @@ Perhaps, boredom is the [pain](/mental-pain) of lack of connection, and addictio
 
 ## Addiction to flow/production/productivity
 
-Being addicted to flow and production sounds like a perfect hack. After all, isn't that the goal? Being productive? Close, I think addiction has this element of "out of control", and escape. Meaning you're skipping the thing you should be doing to do your addiction, so by definition it's bad. Certainly less bad than it can be, but still bad
+Being addicted to flow and production sounds like a perfect hack. After all, isn't that the goal? Being productive?
+
+Not quite. The [addiction vs opportunity cost framework](#is-doing-the-thing-you-want-to-be-doing-an-addiction) applies here too:
+
+**Productive work as addiction:**
+- You're using productivity to escape emotional discomfort
+- You can't stop working even when you want to
+- You're "skipping the thing you should be doing" (family time, rest, addressing underlying issues) to stay busy
+- The work feels compulsive, not joyful
+- You're running from something, not toward something
+
+**Productive work as opportunity cost:**
+- You genuinely love the flow state and the work itself
+- You're making conscious trade-offs about time allocation
+- You could stop if you chose to
+- You're running toward something meaningful, just perhaps at the expense of other things
+
+The key difference: addiction has this element of "out of control" and escape. You're using the productive work to numb or avoid something else. That's certainly less destructive than many addictions, but it's still bad because it prevents you from addressing whatever you're avoiding.
 
 ## Other Resources
 


### PR DESCRIPTION
## Summary

- Introduce framework distinguishing **addiction** (compulsion/escape) from **opportunity cost** (conscious trade-off)
- Key insight: addiction is running FROM something, opportunity cost is running TOWARD something
- Add concrete examples: TikTok (addiction) vs vibe coding (opportunity cost)
- Expand work addiction and success addiction sections with clearer diagnostic tests
- Link TikTok relapse to underlying thought-escape pattern

## Test plan

- [ ] Preview the addiction page and verify new sections render correctly
- [ ] Check internal links work (addiction vs opportunity cost framework anchor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded addiction framework documentation with new sections on work and success addiction.
  * Introduced framework for distinguishing addiction from opportunity cost.
  * Reorganized and expanded current addictions and hypo-addictions sections.
  * Enhanced table of contents with new subsections for improved navigation.
  * Added cross-links to related documentation for better content discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->