### PR TITLE
Add Explainers section to pet-projects

### DIFF
--- a/_d/pet-projects.md
+++ b/_d/pet-projects.md
@@ -112,11 +112,11 @@ In the past, we were constrained by format. Want to share an idea? Write an essa
 
 But now we can build **explainers** - interactive experiences that let you *do* the thing, not just read about it. This is richer. This sticks.
 
-| Explainer | What It Does | Instead Of |
-|-----------|--------------|------------|
-| [Monitor Explainer](https://monitor-explorer.surge.sh/) | Explains monitor dimensions, aspect ratios, and the "p" vs "K" confusion | Reading spec sheets |
-| [How Long Since AI](https://idvorkin-how-long-since-ai.surge.sh/) | Track time since AI milestones - ChatGPT, GPT-4, Claude, Gemini | Searching for release dates |
-| [Religion Evolution Explorer](https://religion-evolution-explorer.surge.sh/) | Interactive timeline of how religions evolved and influenced each other | Reading history books |
+| Explainer | What It Does | Instead Of | |
+|-----------|--------------|------------|---|
+| [Monitor Explainer](https://monitor-explorer.surge.sh/) | Explains monitor dimensions, aspect ratios, and the "p" vs "K" confusion | Reading spec sheets | [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer) |
+| [How Long Since AI](https://idvorkin-how-long-since-ai.surge.sh/) | Track time since AI milestones - ChatGPT, GPT-4, Claude, Gemini | Searching for release dates | [<i class="fa fa-github"></i>](https://github.com/idvorkin/how-long-since-ai) |
+| [Religion Evolution Explorer](https://religion-evolution-explorer.surge.sh/) | Interactive timeline of how religions evolved and influenced each other | Reading history books | [<i class="fa fa-github"></i>](https://github.com/idvorkin/religion-evolution-explorer) |
 
 ## Fun & Experiments
 


### PR DESCRIPTION
## Summary
- Adds new "Explainers" section near bottom of pet-projects page
- Frames explainers as the future of content: interactive experiences that replace passive formats
- Lists three explainers with live surge deployments:
  - Monitor Explainer (monitor-explorer.surge.sh)
  - How Long Since AI (idvorkin-how-long-since-ai.surge.sh)
  - Religion Evolution Explorer (religion-evolution-explorer.surge.sh)

## Test plan
- [ ] Preview at /pet-projects#explainers-the-future-of-content
- [ ] Verify all three surge links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Explainers: The Future of Content" section with descriptive text and a three-column reference table comparing explainers and alternatives.
  * The same section was inadvertently added twice (appears in two locations); content is purely informational with no functional changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->