### PR TITLE
Add AI Cockpit definition, restructure manager appendices

### DIFF
--- a/_d/ai-native-manager.md
+++ b/_d/ai-native-manager.md
@@ -30,11 +30,14 @@ What does it mean to be an engineering manager when AI is rewriting every assump
   - [Divide and Conquer](#divide-and-conquer)
   - [Share the Learnings](#share-the-learnings)
   - [AI Free Zones](#ai-free-zones)
-- [Should EMs Code?](#should-ems-code)
 - [Open Questions](#open-questions)
 - [Appendix: New Words for a New World](#appendix-new-words-for-a-new-world)
   - [Functional Collapse](#functional-collapse)
-  - [Hot Take: Should XFN Code?](#hot-take-should-xfn-code)
+  - [AI Cockpit](#ai-cockpit)
+- [Appendix: Hot Takes](#appendix-hot-takes)
+  - [Should XFN Code?](#should-xfn-code)
+- [Appendix: Old Questions, New Answers](#appendix-old-questions-new-answers)
+  - [Should EMs Code?](#should-ems-code)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
@@ -147,14 +150,6 @@ There are two reasons to create AI-free zones, and both matter:
 
 The broader point: a team that only knows how to work with AI is fragile. They need the underlying skills to stay sharp, and they need the social fabric that comes from connecting as humans, not just as AI practitioners.
 
-## Should EMs Code?
-
-In the [old world](/manager-book#should-managers-code), my answer was: read code occasionally for spot-checking and context, but don't be on the critical path. AI changes this question completely.
-
-With AI, an EM can vibe-code a prototype in an afternoon that would have taken a week to spec and assign. You can build team tools, automate toil, and stay closer to the technical reality. The cost of coding dropped so much that the old "you can't afford to code, you have people to manage" calculus is different now.
-
-But the trap is real: if you're vibe-coding all day, you're not managing. The AI Vampire doesn't care about your title. You can burn out just as fast as your ICs, and then who's looking out for them?
-
 ## Open Questions
 
 Things I'm actively trying to figure out:
@@ -178,7 +173,13 @@ The same thing is happening now. In my world, TPM may have collapsed into the en
 
 So yes, AI enables functional collapse in the sense that anyone _can_ write a PRD or build a prototype or sketch a design. But "can" and "good at" are different things. The easy stuff gets democratized. The hard stuff still needs people who go deep. We might all be "builders" on paper, but we'll all have specialties where we're better than others.
 
-### Hot Take: Should XFN Code?
+### AI Cockpit
+
+{% include summarize-page.html src="/ai-cockpit" %}
+
+## Appendix: Hot Takes
+
+### Should XFN Code?
 
 Depends on why.
 
@@ -191,3 +192,13 @@ But if the goal is something else, then yes:
 - **To build agentic workflows** — XFN building agents that automate their own domain tasks (data analysis, user research synthesis, A/B test configuration). This is the real unlock — not coding for engineers, but coding for themselves.
 
 The line: are you producing code that engineers need to own and maintain? Then you're adding to their burden. Are you producing tools that make your own work better? Then go for it.
+
+## Appendix: Old Questions, New Answers
+
+### Should EMs Code?
+
+In the [old world](/manager-book#should-managers-code), my answer was: read code occasionally for spot-checking and context, but don't be on the critical path. AI changes this question completely.
+
+With AI, an EM can vibe-code a prototype in an afternoon that would have taken a week to spec and assign. You can build team tools, automate toil, and stay closer to the technical reality. The cost of coding dropped so much that the old "you can't afford to code, you have people to manage" calculus is different now.
+
+But the trap is real: if you're vibe-coding all day, you're not managing. The AI Vampire doesn't care about your title. You can burn out just as fast as your ICs, and then who's looking out for them?

--- a/_posts/2016-03-03-the-manager-book-2.md
+++ b/_posts/2016-03-03-the-manager-book-2.md
@@ -21,6 +21,7 @@ This post uses the word manager, but many topics apply to all job functions, reg
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
+- [AI Native Manager](#ai-native-manager)
 - [What does a manager do](#what-does-a-manager-do)
   - [What are a manager's responsibilities](#what-are-a-managers-responsibilities)
   - [How do you measure their success](#how-do-you-measure-their-success)
@@ -159,6 +160,10 @@ This post uses the word manager, but many topics apply to all job functions, reg
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
+
+## AI Native Manager
+
+{% include summarize-page.html src="/ai-native-manager" %}
 
 ## What does a manager do
 


### PR DESCRIPTION
## Summary
- Add AI Cockpit to the "New Words for a New World" appendix in ai-native-manager using `summarize-page` include
- Restructure single appendix into three: **New Words**, **Hot Takes**, **Old Questions New Answers**
- Move "Should EMs Code?" from standalone section to "Old Questions, New Answers" appendix
- Add AI Native Manager `summarize-page` link at top of manager-book

## Test plan
- [ ] Verify ai-native-manager renders correctly with new appendix structure
- [ ] Verify summarize-page include for AI Cockpit loads on ai-native-manager
- [ ] Verify manager-book shows AI Native Manager summary at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "AI Cockpit" section providing operational guidance on AI integration.
  * Introduced new appendices with hot takes and updated answers to common AI management questions.
  * Restructured content sections for improved clarity and navigation.
  * Updated table of contents to reflect organizational changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->