### PR TITLE
Add motivation test and meaning traps to spiritual health

### DIFF
--- a/_d/spiritual-health.md
+++ b/_d/spiritual-health.md
@@ -7,7 +7,7 @@ tags:
   - how igor ticks
 ---
 
-Ever felt directionless despite achieving everything you "should" want? Burned out treating every setback like catastrophe? Exhausted trying to control what you can't? These are manifestations of a lack of spiritual health. "Spiritual health" is poorly defined, so I'll define it practically: **spiritual health means having a north star** (purpose/direction), **knowing you're NOT the center of the universe** (transcendence/perspective), and **accepting you have influence, not control** (coherence/acceptance). Miss any one and you'll find yourself spiritually malnourished in problems as old as time.
+Here's the test for spiritual health: **are you sustainably motivated in a way that would make you proud to see in your child?** If yes, you've probably cracked it. If no, be careful — the word to focus on is *motivated*, not *meaning*. You can philosophize about meaning forever and never become more spiritually healthy. That's the biggest trap. Motivation is the proof that meaning is present. This page is here to help you muddle through when it's not — diagnosing whether you're missing purpose, transcendence, or coherence, and what to do about it.
 
 {% include ai-slop.html percent="85" %}
 
@@ -17,6 +17,11 @@ Ever felt directionless despite achieving everything you "should" want? Burned o
 - [What Do We Mean by "Meaning"?](#what-do-we-mean-by-meaning)
   - [Three Dimensions of Meaning](#three-dimensions-of-meaning)
   - [How Different Frameworks Define Meaning](#how-different-frameworks-define-meaning)
+- [The Meaning Traps](#the-meaning-traps)
+  - [Trap 1: The Philosophy Pit](#trap-1-the-philosophy-pit)
+  - [Trap 2: The Motivation Test You Keep Failing](#trap-2-the-motivation-test-you-keep-failing)
+  - [Trap 3: Meaning Without Motion](#trap-3-meaning-without-motion)
+  - [Trap 4: Borrowed Meaning](#trap-4-borrowed-meaning)
 - [Common Spiritual Problems](#common-spiritual-problems)
   - [Problem 1: "You Lack a North Star" (Purpose)](#problem-1-you-lack-a-north-star-purpose)
   - [Problem 2: "You Are the Center of the Universe" (Transcendence)](#problem-2-you-are-the-center-of-the-universe-transcendence)
@@ -183,6 +188,54 @@ This grid reveals a crucial insight: **searching for meaning isn't a sign of lac
 - Direction (purpose)
 
 And when different books promise to help you "find meaning," they might be addressing completely different problems. This explains why advice that transforms one person's life leaves another cold - they're solving different equations.
+
+## The Meaning Traps
+
+All those definitions are useful, but they come with a warning: most people who struggle with meaning aren't struggling because they can't define it properly. They're stuck in one of these traps.
+
+### Trap 1: The Philosophy Pit
+
+"What does meaning *mean*?" You read Frankl. You compare three dimensions of meaning. You debate whether purpose and transcendence are separate dimensions or developmental stages. You build a beautiful mental model of spiritual health. And you're still sitting on the couch.
+
+This is the most seductive trap because it feels like progress. You're *thinking* about meaning! You're *learning*! But philosophizing about meaning is not the same as having it. You can define all three dimensions perfectly and still be spiritually empty.
+
+**The tell:** You can explain what meaning is but can't point to what gets you out of bed tomorrow.
+
+**The escape:** Stop asking "what is meaning?" and start asking "what would I do if I were motivated?" That second question is uncomfortable because it usually has an obvious answer you're avoiding.
+
+### Trap 2: The Motivation Test You Keep Failing
+
+Here's the uncomfortable truth: **motivation is the proof that meaning has been found.** Not the philosophy, not the framework, not the ability to articulate your three dimensions of meaning. If you're motivated — actually moving, actually engaged, actually doing things — you've cracked meaning, even if you can't explain how.
+
+And if you're not motivated? No amount of reading about meaning will fix it.
+
+This works because motivation and meaning are connected at the root. Frankl himself said it: "The primary motivational force of individuals is to find meaning in life." He didn't say the primary *intellectual* force or the primary *philosophical* force. He said *motivational*. When meaning is present, motivation follows. When motivation is absent, meaning is missing — no matter what your journal says.
+
+The [activation energy](/activation) model explains why this matters practically. Every activity requires willpower to start. When you have genuine meaning — when your purpose is alive, not just written down — the [activation energy](/activation) for meaningful activities drops dramatically. You don't need to force yourself to do what matters. The meaning provides the energy. But when meaning is absent, even low-effort activities feel impossible because there's no underlying "why" to power through the [activation threshold](/activation#activation-energy).
+
+**The tell:** You have a beautiful eulogy document but haven't changed any behavior in months. You know your values but your calendar doesn't reflect them.
+
+**The escape:** Treat motivation as a diagnostic tool, not a prerequisite. If you're unmotivated, don't ask "how do I get motivated?" Ask "what meaning have I lost?" and "what would I be doing right now if I felt alive?" Then do that thing — even badly, even briefly. Motivation often follows action, not the other way around.
+
+### Trap 3: Meaning Without Motion
+
+You found meaning once. Maybe it was when the kids were small and needed you. Maybe it was a job that mattered. Maybe it was a cause that lit you up. But circumstances changed, and the meaning source dried up. You still *remember* having meaning but you don't *have* it anymore.
+
+This is the [Grihastha trap](#the-lifecycle-pattern-why-faith-rises-with-age) in a different form — clinging to a meaning source that's no longer available instead of finding a new one. The person whose kids left home and who built their entire identity around parenting. The retiree who was their job title. The activist whose cause was won (or lost).
+
+**The tell:** You talk about meaning in the past tense. "I used to feel so purposeful when..."
+
+**The escape:** Meaning isn't found once and banked forever. It requires continuous renewal through new responsibilities, new service, new commitments. As Frankl showed, you answer life's question about your purpose with what you *decide to be responsible for* — and that answer needs updating as life changes. See [What's the meaning of life?](#whats-the-meaning-of-life)
+
+### Trap 4: Borrowed Meaning
+
+You adopted someone else's purpose because it sounded right. Your parents' expectations. Your company's mission statement. A self-help book's prescription. It looked like meaning from the outside, but it never generated real motivation because it was never yours.
+
+This is why Frankl insisted on Socratic dialogue — discovering your OWN meaning through questioning — rather than being told what it should be. And it's why the [MLQ quadrant](#how-different-frameworks-define-meaning) matters: you can have high "presence of meaning" on a questionnaire (because you've adopted a convincing story) while actually running on empty.
+
+**The tell:** You can articulate your purpose perfectly but it doesn't survive contact with a hard Tuesday morning. When things get difficult, the borrowed meaning evaporates because it was never connected to your actual self.
+
+**The escape:** Use the Frankl test — you answer life's question not with words borrowed from a book, but with what you actually choose to do when nobody's watching. Your real meaning is visible in your calendar, your relationships, and where your energy naturally flows. If those don't match your stated purpose, trust the behavior over the narrative.
 
 ## Common Spiritual Problems
 


### PR DESCRIPTION
## Summary
- Rewrite intro to lead with a practical spiritual health test: "are you sustainably motivated in a way that would make you proud to see in your child?"
- Add warning that philosophizing about meaning is itself the biggest trap
- Add new "Meaning Traps" section with four common traps: the philosophy pit, motivation as proof of meaning, meaning without motion, and borrowed meaning
- Each trap has a "tell" (how to diagnose) and "escape" (what to do)

## Test plan
- [ ] Preview /spiritual-health page renders correctly
- [ ] New section appears between "What Do We Mean by Meaning?" and "Common Spiritual Problems"
- [ ] TOC links work
- [ ] Cross-links to /activation and internal anchors resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded spiritual health guidance with a new section identifying four common obstacles to meaningful living, including diagnostic indicators and practical recovery steps.
  * Added clarification distinguishing spiritual health from emotional health.
  * Enhanced navigation and cross-references throughout the content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->