### PR TITLE
Remove redundant /awareness redirect

### DIFF
--- a/_d/awareness.md
+++ b/_d/awareness.md
@@ -8,7 +8,6 @@ tags:
   - meditation
 imagefeaturelocal: raccoon-meditate.png
 redirect_from:
-  - /awareness
   - /demello
   - /de-mello
 alias:


### PR DESCRIPTION
## Summary
- Remove `/awareness` from `redirect_from` in `_d/awareness.md` — the permalink already handles this route

## Test plan
- [ ] Verify `/awareness` still resolves correctly via the permalink

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a redirect entry to streamline site navigation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->