### PR TITLE
Enrich Awareness post with book stories and missing themes

### DIFF
--- a/_d/awareness.md
+++ b/_d/awareness.md
@@ -21,7 +21,7 @@ permalink: /awareness
 
 A transformative spiritual guide that challenges you to wake up from the sleep of unconscious living. Anthony de Mello, a Jesuit priest and psychotherapist, delivers spiritual tough love through short chapters filled with stories, parables, and direct challenges. His message: most of us spend our lives asleep, and awareness is the key to waking up to true happiness and freedom.
 
-{% include ai-slop.html percent="90" %}
+{% include ai-slop.html percent="60" %}
 
 This is a summary of [Awareness: The Perils and Opportunities of Reality](https://www.amazon.com/Awareness-Opportunities-Reality-Anthony-Mello/dp/0385249373) - recommended by Eckhart Tolle and Naval Ravikant, and one of my guides to [spiritual health](/spiritual-health).
 
@@ -45,6 +45,8 @@ This is a summary of [Awareness: The Perils and Opportunities of Reality](https:
   - [12) The Death of Me: Losing Your False Self](#12-the-death-of-me-losing-your-false-self)
   - [13) Listening to Life](#13-listening-to-life)
   - [14) Getting Real: Practical Applications](#14-getting-real-practical-applications)
+  - [15) Fear and Violence](#15-fear-and-violence)
+  - [16) Good Religion](#16-good-religion)
 - [Appendix](#appendix)
   - [Two Types of Meditation: Concentration vs. Awareness](#two-types-of-meditation-concentration-vs-awareness)
   - [A Computing Analogy for Awareness](#a-computing-analogy-for-awareness)
@@ -69,17 +71,25 @@ _For engineers: See [Appendix - A Computing Analogy](#a-computing-analogy-for-aw
 _Wake up! That's what spirituality is all about._
 
 - **GOAL: Recognize you are asleep and become willing to wake up.**
-- Most people spend their entire lives asleep - not in bed dreaming, but in a waking sleep.
+- Most people spend their entire lives asleep - not in bed dreaming, but in a waking sleep. They're born asleep, they live asleep, they marry in their sleep, they breed children in their sleep, they die in their sleep without ever waking up.
 - We drift through life on autopilot, reacting mechanically to everything around us.
 - **Waking up is unpleasant** - it's irritating to be woken up when you're comfortable in sleep.
+
+> De Mello tells the story of a father knocking on his son Jaime's door: "Wake up!" Jaime says, "I don't want to go to school. It's dull, the kids tease me, and I hate it." The father replies: "Three reasons you must go. First, it's your duty. Second, you're forty-five years old. And third, you're the headmaster." That's us. We're the headmaster refusing to show up to our own life.
+
 - People don't want to wake up because:
   - They're comfortable in their familiar patterns
   - They're terrified of the unknown
   - They don't realize they're asleep
-- **The first step: Acknowledge you don't want to wake up.**
+- **The first step: Acknowledge you don't want to wake up.** De Mello is brutally honest here: "The first thing I want you to understand, if you really want to wake up, is that you don't want to wake up."
+- Most people just want their broken toys fixed. "Give me back my wife. Give me back my job. Give me back my money. Give me back my reputation." They don't want to be cured - **they want relief**. And a cure is painful.
+
+> **Nobody can help you.** De Mello opens with a provocation: "Do you think I am going to help anybody? No! Oh, no, no, no, no, no!" He tells the story of a nun who felt unsupported by her superior. Through role-playing, de Mello shows her feeling great about a compliment - then reveals to the group it was a lie. She was feeling "supported" by something completely fabricated in her own head. His point: **most of what we feel, we conjure up for ourselves**, including the feeling of being helped.
+
 - You can't force awakening - it requires readiness and willingness.
 - Awakening requires challenging every belief you hold sacred.
 - Resistance to change keeps us trapped in suffering while we complain about it.
+- As the Arabs say: "The nature of rain is the same, but it makes thorns grow in the marshes and flowers in the gardens."
 - Related practice: See [Grandmother mind](/siy#2-theory-and-practice-of-mindfulness) from Search Inside Yourself
 
 ### 2) The Sleep of Unconsciousness
@@ -88,6 +98,9 @@ _You're only asleep. Why not let me wake you up?_
 
 - **GOAL: Understand what it means to be "asleep" in daily life.**
 - Asleep = living mechanically, controlled by unconscious reactions and programming.
+
+> **The banquet metaphor**: De Mello says life is a banquet, and the tragedy is that most people are starving to death. He tells the story of people on a raft off the coast of Brazil, dying of thirst - with no idea that the water they were floating on was fresh. The river came out into the sea with such force that it pushed fresh water miles out. They had everything they needed right where they were, and they had no idea. That's us. Surrounded by joy, by happiness, by love - and totally oblivious.
+
 - Signs you're asleep:
   - Blaming others or circumstances for your feelings
   - Believing happiness depends on external conditions
@@ -99,7 +112,9 @@ _You're only asleep. Why not let me wake you up?_
   - "You need approval to be okay"
   - "You must conform to be accepted"
 - This programming runs automatically, like software in the background.
+- **The test for brainwashing**: De Mello says it's simple - attack a belief and watch what happens. If you react emotionally, that's a pretty good sign the belief isn't yours. You introjected it from someone else. And the funny part? You'll be ready to die for an idea that was never yours.
 - **Most people prefer the security of their prison to the anxiety of liberation.**
+- The first thing you fear is not the unknown - nobody is afraid of the unknown. **What you really fear is the loss of the known.** That's what keeps you asleep.
 - The good news: Awareness itself begins to dissolve the sleep.
 
 ### 3) Understanding Awareness
@@ -111,15 +126,20 @@ _Awareness is like the sun. When it shines on things, they are transformed._
 - NOT trying to change anything - just observing.
 - NOT analyzing or thinking about - just seeing clearly.
 - Self-observation means "the ability to watch everything in you and around you as if it were happening to someone else."
+
+> **Knowledge is not awareness.** De Mello makes a distinction most people miss: you can _know_ something is wrong and still do it. "Father, forgive them, for they know not what they do" - he translates that as "They're not _aware_ of what they are doing." Paul persecuted Christians while _knowing_ about Christ. Thomas Aquinas says every sin happens "under the guise of good." You rationalize, you blind yourself. Knowledge doesn't protect you. Only awareness does.
+
 - **What you are aware of, you control. What you are unaware of controls you.**
+
+> De Mello tells a story from his psychology training in Chicago. He taped a therapy session with a young woman and played it for his class. A colleague asked: "Is this woman pretty?" De Mello was baffled - he didn't notice such things. The colleague pressed: "You don't like her, do you?" Playing the tape again, they found it was true - his voice was subtly hostile, and he was unconsciously pushing her away. She never came back. He hadn't been aware of his own dislike. "What you are aware of, you are in control of; what you are not aware of is in control of you."
+
 - De Mello's promise: "I have not known a single person who gave time to being aware who didn't see a difference in a matter of weeks."
-- The quality of life changes when you become aware.
 - Three types of awareness:
   1. **Awareness of thoughts**: Observing the constant mental chatter
   2. **Awareness of emotions**: Watching feelings rise and fall
   3. **Awareness of body sensations**: Noticing physical reactions
 - Like mindfulness in [Search Inside Yourself](/siy), but with more spiritual edge and less structure.
-- Awareness requires no effort - it's the opposite of striving.
+- Awareness requires no effort - it's the opposite of striving. It's not concentration (a spotlight). It's more like a floodlight - open to anything that comes.
 - The practice is simple but not easy: Just watch. Don't judge. Don't fix.
 
 ### 4) The 4-Step Program to Wisdom
@@ -137,14 +157,17 @@ _Four simple steps that will transform your life._
   - Nobody can hurt you emotionally without your cooperation
   - This is radical responsibility for your inner state
 - **Step 3: Stop identifying with the feeling**
-  - "I am angry" → "I am experiencing anger"
-  - "I am depressed" → "I am observing depression in my body"
+  - "I am angry" becomes "I am experiencing anger"
+  - "I am depressed" becomes "I am observing depression in my body"
   - The reason you suffer is because you identify with negative emotions
   - These emotions are not you - they're experiences passing through
 - **Step 4: Change your perception**
   - When you change how you look at things, the things you look at change
   - Understanding (not effort) dissolves problems
   - Awareness itself is transformative
+
+> De Mello gives a sharp test for Step 2. He says: think of someone you love deeply, and say to them in your mind: "I'd rather have happiness than have you." Feel selfish? That's your brainwashing talking. The truly selfish person is the one who says, "How dare you choose happiness over me?" Two people sacrificing happiness for each other - and now you've got two miserable people, but long live love!
+
 - This is NOT positive thinking or affirmations - it's seeing reality clearly.
 - Compare to [SBNRR (Siberian Northern Railroad)](/siy#5-developing-self-mastery) from Search Inside Yourself
 
@@ -159,6 +182,9 @@ _We're puppets, and we don't even know who's pulling the strings._
   - Religious teachings
   - Educational systems
   - Media and advertising
+
+> De Mello asks: "Who's living in you?" He says he could take you apart piece by piece and ask, "This sentence - does it come from Daddy, Mommy, Grandma, Grandpa, whom?" You think you're free, but there probably isn't a gesture, a thought, an emotion, an attitude, a belief in you that isn't coming from someone else. You feel strongly about certain things and think it's "you" feeling strongly - but it's your programming.
+
 - **Every attachment is a conditioning** - "You'll be happy when..."
 - Society programs us with false equations:
   - Success = Happiness
@@ -170,10 +196,9 @@ _We're puppets, and we don't even know who's pulling the strings._
 - **Question everything**: Your beliefs, your values, your desires
   - Is this really what I want, or what I was taught to want?
   - Am I living my life or someone else's script?
-- Deprogramming exercise:
-  - Make a list of your core values
-  - For each one, ask: "Where did this come from?"
-  - Ask: "Would I die for this, or am I just following the crowd?"
+
+> Consider the story of the man and the banana. A businessman walks into a bar and sees a fellow with a banana in his ear. He tries to tell him: "You've got a banana in your ear." The fellow says, "What?" Louder: "You've got a banana in your ear!" "Talk louder," says the fellow, "I've got a banana in my ear!" That's conditioning. We can't hear the truth because our programming is literally blocking the signal.
+
 - Freedom = living according to reality, not according to programming.
 - Related concept: [Self-awareness leading to self-confidence](/siy#4-self-awareness-leading-to-self-confidence)
 
@@ -187,6 +212,9 @@ _We see people and things not as they are, but as we are._
   - You don't see your spouse - you see your idea of your spouse
   - You don't see "what is" - you see your interpretation
   - You respond to your story, not to reality
+
+> **The Chinese Farmer (Good, Bad, or Lucky)**: De Mello says look at people who win the lottery. Do they say, "I accept this prize for my nation and society"? Of course not. They were just lucky. In the same way, if you achieved enlightenment, you'd be lucky too. What's there to be proud of? "The Pharisee wasn't an evil man, he was a stupid man. He was stupid, not evil. He didn't stop to think." The point: stop judging things as "good" or "bad." You don't know. You're just labeling events based on your illusions.
+
 - **Every word is a distortion** - it's a label, not the thing itself.
 - Common illusions:
   - "I need this person to be happy"
@@ -195,6 +223,9 @@ _We see people and things not as they are, but as we are._
   - "I am my thoughts/feelings/roles/labels"
 - The map is not the territory - your concepts are not reality.
 - We suffer when our illusions clash with reality.
+
+> **The crocodile and the boy**: A boy finds a crocodile trapped in a net. The crocodile pleads: "I have a mother's heart. Help me!" The boy frees it and the crocodile grabs him. "This is the way the world is," says the crocodile. A bird confirms it - a snake ate her young. A donkey confirms it - his master abandoned him. Finally a rabbit tricks the crocodile into releasing the boy, telling him to run. Then the boy's dog catches the rabbit and kills it. The boy watches and says: "The crocodile was right, this is the way the world is, this is the law of life." De Mello's point: **there is no explanation that will explain away all the suffering in the world.** Life is a mystery. Your thinking mind cannot make sense of it. But when you wake up, you suddenly realize reality is not the problem - you are.
+
 - **Truth cannot be expressed in words** - it must be experienced directly.
 - Practice: Catch yourself saying "should" or "shouldn't" - these reveal your illusions.
 - See things without the filter of:
@@ -218,9 +249,15 @@ _All suffering comes from attachment._
 - When you're upset, ask: "What am I attached to?"
   - Find the "should" or "must" in your thinking
   - That's your attachment
+
+> **Hugging memories**: De Mello asks - when you meet an old friend and give them a hug, whom are you hugging? The person, or your _memory_ of the person? "A living human being or a corpse?" You assume they're still the person you remember. Five minutes later you discover they've changed, and you lose interest. You hugged the wrong person. We do this constantly - clinging to our mental image while the real person stands right in front of us, unseen.
+
 - Attachment is different from love:
   - **Love** = seeing clearly, wanting their good
   - **Attachment** = needing them for your happiness (addiction)
+
+> He tells of a nun who genuinely changed at a retreat - everyone outside her community could see it in her face, her body, her behavior. But when she returned to her community, they had a fixed idea of her. "Oh, she seems more spirited, but just wait, she'll be depressed again." Within weeks she was. They never saw the change because they were looking at their memory, not at her. **Prejudice is just another form of attachment** - attachment to your idea of someone.
+
 - Examples of attachment thinking:
   - "I need approval to be okay"
   - "I must succeed or I'm worthless"
@@ -229,7 +266,7 @@ _All suffering comes from attachment._
 - **You can have preferences without attachment**:
   - Preference: "I'd like this to happen, but I'm okay either way"
   - Attachment: "This MUST happen or I can't be happy"
-- Dropping attachment ≠ becoming cold or indifferent
+- Dropping attachment does not mean becoming cold or indifferent
 - It means: Not being controlled by desires or fears.
 - Practice: Notice when you use words like "need," "must," "should," "can't live without"
 - Related: [Grasping and aversion](/siy#5-developing-self-mastery) from Search Inside Yourself
@@ -245,6 +282,9 @@ _If you wish to love, you must learn to see again._
   - "You make me happy"
   - "I feel incomplete without you"
 - These statements reveal dependency, not love.
+
+> De Mello is savage about this: "You are never in love with anyone. You're only in love with your prejudiced and hopeful idea of that person." Isn't that how you fall out of love? Your idea changes. "How could you let me down when I trusted you so much?" But you never trusted _them_ - you trusted your judgment about them. When your judgment turns out to be wrong, you blame the other person. That's not love - it's narcissism with a romantic soundtrack.
+
 - **Real love**:
   - Sees the other clearly, without projections
   - Wants their good, not their conformity to your desires
@@ -258,6 +298,9 @@ _If you wish to love, you must learn to see again._
   - Is conditional - "I love you because you make me happy"
 - The brutal truth: **You cannot truly love anyone until you're free from attachment.**
 - When you need nothing, you can love everything.
+
+> On falling in love: "They say that love is blind. Believe me, there's nothing so clear-sighted as true love. Addiction is blind, attachments are blind. Clinging, craving, and desire are blind. But not true love." De Mello says falling in love has nothing to do with love at all - it's desire, burning desire. You want to be told by this adorable creature that you're attractive. Everyone else is saying "What does he see in her?" It's conditioning - you've got a subconscious image, and when someone fits it, you call it love.
+
 - True love is:
   - Non-possessive
   - Freeing (not binding)
@@ -288,9 +331,15 @@ _The first act of love is to see this person, or this object, this reality as it
 - When you judge, you can't see clearly.
 - When you interfere, you can't understand.
 - When you identify, you can't be free.
+
+> **Renunciation is delusion**: De Mello drops a bomb: "Anytime you're practicing renunciation, you're deluded." He tells of a guru in India who says, "Every time a prostitute comes to me, she's talking about nothing but God. But every time a priest comes to me he's talking about nothing but sex." When you renounce something, you're stuck to it forever. When you fight something, you're tied to it forever. You give it as much power as you are using to fight it. **The only way out is to see through it.** Don't renounce it - understand its true value, and it will simply drop from your hands.
+
 - **Change happens through understanding, not through effort.**
 - The more you try to change something, the more it persists.
-- "When you renounce or fight something, you become tied to it. In fighting it, you give it power."
+
+> **The sailboat**: De Mello offers this image for effortless change - a sailboat with a mighty wind in its sail glides along so smoothly that the boatman has nothing to do but steer. He makes no effort. He doesn't push the boat. That's what happens when change comes through awareness, through understanding. You don't muscle your way to transformation. You see clearly, and the wind does the rest.
+
+- There's a woman who asks de Mello about finding it hard to stay peaceful in stressful situations - phones ringing, angry people. He catches her attachment immediately: "Did you pick up the attachment? Peace. Her attachment to peace and calm." Did it ever occur to you that you could be happy _in tension_? "Before enlightenment, I used to be depressed; after enlightenment, I continue to be depressed."
 - Practice:
   - Set aside time daily just to observe
   - Watch your reactions throughout the day
@@ -311,9 +360,15 @@ _The highest knowledge is to know that you know nothing._
   - Barriers when mistaken for reality
 - God/Truth/Reality is unknown and unknowable through concepts.
 - The moment you define God, you've created an idol (a concept).
+
+> Two blind men are told about the color green. One is told "It's like soft music." The other is told "It's like soft satin." The next day they're bashing each other over the head with bottles. "It's soft like music!" "It's soft like satin!" Neither knows what they're talking about, because if they did, they'd shut up. That's religion. That's philosophy. That's most arguments about truth.
+
 - **Most religious conflict comes from mistaking concepts for reality.**
 - People kill each other over their WORDS about God, not over God.
-- The finger pointing at the moon is not the moon.
+- The finger pointing at the moon is not the moon. And as a French writer added: "We often use the finger to gouge eyes out."
+
+> Thomas Aquinas, the prince of Catholic theologians, wrote thousands of pages about God. Then he had a mystical experience and never wrote another word. He said he had made a fool of himself. **The highest form of knowing God is to know God as unknowable.** That's not some Eastern guru speaking - that's a canonized saint of the Roman Catholic Church.
+
 - **To know reality, you must experience it directly** - beyond thought.
 - This requires:
   - Silence
@@ -351,16 +406,18 @@ _You don't have to do anything to be happy. You're happy. Happiness is your natu
   - Illusions
   - Conditioning
   - Identification with the false self
-- **You can be happy even in pain** (physical pain ≠ psychological suffering).
+
+> **The masquerade of charity**: De Mello identifies three types of selfishness. First: pleasing yourself (obvious). Second: giving yourself the pleasure of pleasing others (hidden and more dangerous, "because we get to feel that we're really great"). Third and worst: doing good so you won't feel bad. "Could I meet you tonight, Father?" "Yes, come on in!" But you hate it. You want to watch TV. You don't have the guts to say no. So you're grumbling through the whole thing, and the next morning you feel guilty for being rude, so you go make nice. That's not charity - it's cowardice masquerading as virtue.
+
+- **You can be happy even in pain** (physical pain does not equal psychological suffering).
 - "Wilting flowers don't cause suffering, it's the unrealistic desire for them to last forever."
+
+> De Mello's reading of the Gospel is arresting: "I was hungry, and you gave me to eat" - and what do the righteous reply? "When? When did we do it? We didn't know it." They were _unconscious_ of their goodness. **A good is never so good as when you have no awareness that you're doing good.** The moment you know you're being charitable, something's off. "A saint is one until he or she knows it."
+
 - Practice: Notice the difference
   - When are you experiencing pleasure/excitement?
   - When are you experiencing deeper contentment?
   - Can you find happiness without external stimulation?
-- Three types of selfishness (de Mello's insight):
-  1. Doing good to avoid punishment (hell, guilt)
-  2. Doing good to get reward (heaven, praise)
-  3. Doing good to avoid bad feelings (most insidious)
 - True goodness requires no reward - it flows from awareness.
 - Related: [Purpose, flow, and pleasure](/happy) - but de Mello goes deeper
 
@@ -383,11 +440,17 @@ _You're not who you think you are._
   - Threats to them feel like threats to survival
   - Criticism of them feels like personal attack
   - Loss of them creates existential crisis
-- "I am a successful person" → Success becomes a matter of life and death.
-- "I am American" → Threats to America feel like personal threats.
+- "I am a successful person" makes success a matter of life and death.
+- "I am American" makes threats to America feel like personal threats.
+
+> **The coffin meditation**: De Mello's most vivid practice: "The passport to living is to imagine yourself in your grave. Imagine you're lying in your coffin. Now look at your problems from that viewpoint. Changes everything, doesn't it?" He recommends doing this daily - visualize your body decomposing, then bones, then dust. People say "How disgusting!" He answers: "It's reality, for heaven's sake." Most people don't live - they just keep the body alive. "You're not living until it doesn't matter a tinker's damn to you whether you live or die. At that point you live."
+
 - **Dropping labels is essential** to knowing your true self.
 - This doesn't mean you can't use labels practically.
 - It means: Don't IDENTIFY with them as your essence.
+
+> He pushes further: "Life is for the gambler, it really is. That's what Jesus was saying." If you're sitting in your attic refusing to come downstairs because people slip on stairs, if you won't cross the street because people get run over - you're dead. "If I can't get you to peep out of your little narrow beliefs and convictions and look at another world, you're dead, you're completely dead; life has passed you by."
+
 - Who are you without your labels?
   - Not your thoughts (you observe them)
   - Not your emotions (you experience them)
@@ -399,7 +462,9 @@ _You're not who you think you are._
 - Practice: "I am not..."
   - Complete the sentence with every label you identify with
   - Feel what remains when you drop each one
+- Visit a graveyard. De Mello says it's an "enormously purifying and beautiful experience." Read the names, consider that people from centuries ago had the same sleepless nights you do. "An Italian poet said, 'We live in a flash of light; evening comes and it is night forever.'"
 - Compare to [Jung's self vs. ego](/jung-self-ego) concepts
+- Related: [On being mortal](/death) - coming to terms with impermanence
 
 ### 13) Listening to Life
 
@@ -410,6 +475,9 @@ _Life is trying to teach you something - are you listening?_
 - "This shouldn't be happening" = refusing to listen.
 - **Every experience is a teacher** if you're willing to learn.
 - Especially difficult experiences and negative emotions.
+
+> De Mello tells of a counseling class where they played tapes of therapy sessions. A colleague pointed out that de Mello was subtly hostile to a client - but de Mello had listened to the tape three times without noticing. Three times! And the client picked it up unconsciously and never came back. "It's shocking to discover that I'm saying things in a therapy session that I'm not aware of." If a trained psychotherapist can't hear himself, what chance do the rest of us have? That's why listening - really listening - requires you to listen to _yourself_ first.
+
 - When something upsets you, ask:
   - "What is this trying to teach me?"
   - "What attachment is being challenged?"
@@ -420,6 +488,9 @@ _Life is trying to teach you something - are you listening?_
   3. Curiosity - genuine interest in learning
   4. Silence - stopping mental chatter
 - Most people listen to reply, not to understand.
+
+> **The participant observer**: De Mello's training taught him to be a "participant observer" - talking to you while simultaneously watching you and watching himself. "When I'm listening to you, it's infinitely more important for me to listen to me than to listen to you." Because otherwise he'd be distorting everything through his conditioning, his insecurities, his need to manipulate. Like a good driver who's deep in conversation but still aware of every road signal - the moment anything untoward happens, he hears it instantly.
+
 - Active listening practice (applied to life):
   - Don't argue with what is
   - Don't immediately judge or categorize
@@ -444,6 +515,9 @@ _Understanding is one thing, living it is another._
   - Morning: Set intention to observe yourself today
   - Throughout day: Catch yourself being mechanical
   - Evening: Review the day without judgment
+
+> De Mello gives an exercise: Right where you're sitting, be aware of what you're feeling in your body, what's going on in your mind, what your emotional state is like. Be aware of the walls, the colors, the material they're made of. Be aware of your reaction to the person speaking - because you _have_ a reaction whether you know it or not. "And it probably isn't your reaction, but one you were conditioned to have."
+
 - **When negative emotion arises** (4-step practice):
   1. Identify it: "This is anger/fear/anxiety"
   2. Locate it: "This feeling is in me, not in the situation"
@@ -462,33 +536,70 @@ _Understanding is one thing, living it is another._
   - Do excellent work without attachment to outcomes
   - Success or failure don't define you
   - Find joy in the doing, not just the results
+
+> **Paddy's fall**: "Did the fall hurt you, Paddy?" "No, it was the stop that hurt, not the fall." De Mello uses this to explain suffering: when you cut water, the water doesn't get hurt. When you cut something solid, it breaks. **You've got solid attitudes inside you; you've got solid illusions inside you. That's what bumps against nature. That's where you get hurt.** Make yourself fluid like water, and life's blows pass through you.
+
 - **Dealing with difficult people**:
   - They're not the problem - your reaction is
   - See them clearly, without judgment
   - Don't take their behavior personally
   - They're asleep too - have compassion
+- **An Oriental sage's wisdom** (quoted by de Mello): "If the eye is unobstructed, it results in sight; if the ear is unobstructed, the result is hearing; if the nose is unobstructed, the result is a sense of smell; if the mouth is unobstructed, the result is a sense of taste; if the mind is unobstructed, the result is wisdom." De Mello adds: "If the heart is unobstructed, the result is love."
 - **Meditation for awareness**:
   - Sit quietly and observe
   - Watch thoughts arise and pass
   - Notice sensations without reacting
   - Return to present moment repeatedly
-- **Reading spiritual texts**:
-  - Don't just collect concepts
-  - Apply one teaching at a time
-  - Experience it, don't just think about it
 - **Warning signs you're asleep again**:
   - Blaming others
   - Feeling victimized
   - Believing "I need X to be happy"
   - Constant mental commentary
   - Resistance to what is
-- **De Mello's final challenge**:
-  - Don't believe anything he says
-  - Test it in your experience
-  - Keep only what you verify yourself
-  - Let go of the rest
+
+> **Don't believe de Mello.** His final challenge: don't believe anything he says. Test it in your experience. Keep only what you verify yourself. Let go of the rest. "Are you enlightened?" someone asked him. His answer: "How would I know? How would you know? What does it matter?" If you listen to someone _because_ they're enlightened, you're just getting brainwashed by a fancier guru. "What does it matter whether someone's enlightened or not?"
+
 - The promise: "Give time to being aware. You'll see a difference in weeks."
 - Related practices throughout: Cross-reference with [Search Inside Yourself](/siy) for complementary methods
+
+### 15) Fear and Violence
+
+_There's only one evil in the world: fear. There's only one good: love._
+
+- **GOAL: Understand fear as the root of all violence, anger, and evil.**
+- De Mello distills everything to two forces: **love and fear**. There's not a single evil in the world that you cannot trace to fear. Not one.
+- Ignorance and fear, ignorance _caused by_ fear - that's where all the evil comes from, that's where your violence comes from.
+- **The person who is truly nonviolent is the person who is fearless.** It's only when you're afraid that you become angry.
+
+> De Mello's challenge: "Think of the last time you were angry. Go ahead. Now search for the fear behind it. What were you afraid of losing? What were you afraid would be taken from you? That's where the anger comes from." Then flip it: "Think of an angry person, maybe someone you're afraid of. Can you see how frightened he or she is? He's really frightened, he really is. She's really frightened or she wouldn't be angry."
+
+- Every angry person is a frightened person. Every controlling person is a terrified person. Every violent act traces back to fear of loss.
+- This maps directly to the attachment framework: fear is what happens when an attachment is threatened.
+- When you become fearless - not reckless, but genuinely unafraid because you've dropped your attachments - violence becomes impossible. You can't be angry if you have nothing to lose.
+- Practice: Next time you feel anger rising, pause and ask: "What am I afraid of right now?"
+- Related: [Emotional health](/emotional-health) - understanding the mechanics of emotional reactivity
+
+### 16) Good Religion
+
+_God would be much happier if you were transformed than if you worshiped._
+
+- **GOAL: Distinguish between religion that wakes you up and religion that puts you deeper to sleep.**
+- De Mello, a Jesuit priest, is ruthless about bad religion. The danger: when worship becomes more important than love, when the Church becomes more important than life, when God becomes more important than the neighbor.
+
+> He tells of an Italian couple who hold their wedding reception in the church because it rained. Being good Italians, the wine and singing get out of hand. The parish priest is pacing in the sacristy, furious. The assistant pastor says, "We mustn't forget, Jesus himself was once present at a wedding!" The priest explodes: "I know Jesus Christ was present at a wedding! But they didn't have the Blessed Sacrament there!!!" De Mello's point: there are times when the Blessed Sacrament becomes more important than Jesus Christ himself. When the symbol eclipses the reality it was meant to represent.
+
+- **Good religion is the antithesis of unawareness.** It wakes you up. Bad religion puts you deeper to sleep while making you feel holy about it.
+- De Mello tells Hindus: "God would be much happier if you were transformed than if you worshiped." He tells Muslims: "God is going to be much more pleased by your being transformed into a loving person than by saying 'Lord, Lord.'"
+- "It's infinitely more important that you be waking up. That's spirituality, that's everything. If you have that, you have God."
+
+> On idolatry and fighting over statues: He tells of a thousand people on pilgrimage to Our Lady of Guadalupe who sat down in protest because the Bishop declared a _different_ Our Lady as patroness of the diocese. They were sure Our Lady of Guadalupe was offended. "That's the trouble with religion, if you don't watch out."
+
+- **The unaware life is not worth living.** De Mello calls it mechanical - not human. Programmed, conditioned. "We might as well be a stone, a block of wood."
+- He points out that 99.999% of people, whether in Indian slums or driving around in cars, are equally dead - equally mechanical. A slightly bigger machine is still a machine.
+- The fanaticism of one sincere believer who thinks he knows causes more evil than the united efforts of two hundred rogues.
+- **Religion as spirituality**: First things first. The human being is more important than the Sabbath. Transformation is more important than ritual.
+- This doesn't mean religion is bad - it means religion is dangerous when it substitutes concepts for experience, worship for love, rules for awareness.
+- Related: [My thoughts on religion](/religion) - navigating faith and doubt
 
 ---
 


### PR DESCRIPTION
## Summary
- **Enriched all 14 existing sections** with actual stories and parables from de Mello's book: the headmaster joke, the nun role-play, the raft off Brazil, the crocodile and rabbit, the sailboat metaphor, the coffin meditation, the banana in the ear, hugging memories, Paddy's fall, the blind men and green, Thomas Aquinas going silent, and more
- **Added 2 new sections**: "Fear and Violence" (Ch 20 -- fear as the only evil, love as the only good) and "Good Religion" (Ch 22 -- religion as antithesis of unawareness, with cross-link to /religion)
- **Wove in missing chapter content** into existing sections: Ch 2 anti-guru stance, Ch 6 renunciation is delusion, Ch 8 charity masquerade, Ch 9 banquet metaphor, Ch 10 good/bad/lucky, Ch 26 crocodile story, Ch 35 hugging memories, Ch 43 knowledge vs awareness, Ch 50 sailboat, Ch 55 coffin meditation
- Reduced ai-slop from 90% to 60%, added cross-links to /religion and /death, expanded thin sections 13 and 14

## Test plan
- [ ] Review enriched sections for accuracy against the book
- [ ] Verify cross-links to /siy, /spiritual-health, /happy, /death, /religion, /emotional-health work
- [ ] Check that de Mello's voice comes through -- irreverent, direct, challenging
- [ ] Preview locally with Jekyll to verify formatting of blockquotes and new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added two new major sections expanding the guide's scope and coverage
  * Enhanced existing sections with detailed anecdotes, examples, and reflective prompts
  * Updated table of contents and appendix for improved navigation and structure
  * Strengthened clarity with bolder statements and broader illustrative examples throughout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->