### PR TITLE
Migrate from pre-commit to prek

### DIFF
--- a/CLAUDE-CODING.md
+++ b/CLAUDE-CODING.md
@@ -97,7 +97,7 @@ YOU MUST find the root cause - NEVER fix symptoms or add workarounds.
 
 ### Commit Guidelines
 
-- **ALWAYS run pre-commit checks before committing**: `pre-commit run --files <files>`
+- **ALWAYS run pre-commit checks before committing**: `prek run --files <files>`
 - **Generated JS files ARE committed** (assets/js/index.js, assets/js/index.js.map)
 - Run `just js-build` before committing to ensure JS bundle is up to date
 - Break commits into logical changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ For testing includes and components with Playwright, use `/test-includes`.
 - Correct: `[Voices in My Head](/voices)`
 - Wrong: `[Voices in My Head](/voices-in-my-head)`
 
-Run pre-commit to check: `pre-commit run --files <your-files>`
+Run pre-commit to check: `prek run --files <your-files>`
 
 ## Fetching Web Content
 

--- a/_d/changelog.md
+++ b/_d/changelog.md
@@ -66,7 +66,7 @@ New entry on AI value capture ([blog](/ai-journal#2026-02-14)):
 
 Rewrote the spiritual health intro as exploratory rather than prescriptive, and added four meaning traps ([blog](/spiritual-health#the-meaning-traps)):
 
-- **The motivation test** - "Are you sustainably motivated in a way you'd be proud to see in your child?" Motivation is the proof that meaning is present — not the philosophy, not the framework. Frankl said *motivational* force, not intellectual force. When meaning is present, [activation energy](/activation) for meaningful activities drops dramatically. [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/772bc2169)
+- **The motivation test** - "Are you sustainably motivated in a way you'd be proud to see in your child?" Motivation is the proof that meaning is present — not the philosophy, not the framework. Frankl said _motivational_ force, not intellectual force. When meaning is present, [activation energy](/activation) for meaningful activities drops dramatically. [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/772bc2169)
 - **Four traps** - (1) Philosophy Pit: you can define all three dimensions perfectly and still be spiritually empty. (2) Motivation Test You Keep Failing: beautiful eulogy document but no behavior change in months. (3) Meaning Without Motion: clinging to a meaning source that dried up. (4) Borrowed Meaning: adopted someone else's purpose — doesn't survive contact with a hard Tuesday morning. [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/772bc2169)
 - **2026 goals updated** - Added the motivation test as a Q1 goal, linked spiritual health dimensions to specific diagnostic questions, added walking-with-god as a daily practice anchor ([blog](/y2026#spiritual-health)) [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/e50920005)
 
@@ -78,6 +78,7 @@ Rewrote the spiritual health intro as exploratory rather than prescriptive, and 
 ### Other Projects
 
 **[chop-conventions](https://github.com/idvorkin/chop-conventions)** (CHOP workflow docs)
+
 - `ammon` skill: checks time in Denmark (Europe/Copenhagen) with sleep warning for coordinating across time zones [<i class="fa fa-github"></i>](https://github.com/idvorkin/chop-conventions/commit/190f2bc87)
 - up-to-date skill: offer `/clear` after sync since users typically run this at session start when old context is stale [<i class="fa fa-github"></i>](https://github.com/idvorkin/chop-conventions/commit/d73d7e0c1)
 
@@ -103,7 +104,7 @@ New section: "Getting Started: For Those Who've Never Done This" ([blog](/spirit
 
 - **The Lifecycle Pattern** - James Fowler's research: spiritual interest rises predictably in midlife. Young adults reject religion's contradictions; by 40s-50s they see beauty where they once saw superstition. [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/6961c1423)
 - **Vanaprastha Framework** - Hindu 4-stage life model: Brahmacharya (learning) → Grihastha (career/family) → Vanaprastha (spirituality/wisdom) → Sannyasa (enlightenment). The Grihastha trap: trying to make stage 2 last forever. [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/6961c1423)
-- **Three Obstacles** - (1) "None" identity trap, (2) Santa in the Church (childish impressions), (3) Tyranny of Time. Solutions from Arthur Brooks' *From Strength to Strength* chapter 7. [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/dd1a34e66)
+- **Three Obstacles** - (1) "None" identity trap, (2) Santa in the Church (childish impressions), (3) Tyranny of Time. Solutions from Arthur Brooks' _From Strength to Strength_ chapter 7. [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/dd1a34e66)
 
 ### Addiction vs Opportunity Cost
 
@@ -131,13 +132,13 @@ New framework distinguishing compulsion from choice ([blog](/addiction#is-doing-
 
 ### How Igor CHOPs
 
-**8 Stages of AI Coding** diagram from Yegge's Gas Town ([blog](/chop#the-8-stages-of-ai-coding)):
+**8 Stages of AI Coding** diagram from Yegge's Gas Town ([blog](/how-igor-chops#the-8-stages-of-ai-coding)):
 
 - Stages 1-4: Manual → Approval-based → YOLO mode → Full autonomy
 - Stages 5-8: Single agent → Parallel agents → Specialized tools → Orchestrated system
 - "Where I am: somewhere between 6 and 7, learning to avoid merge hell" [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/56e96e9a6)
 
-**What Works Well** principles ([blog](/chop#what-works-well---review-this-weekly)):
+**What Works Well** principles ([blog](/how-igor-chops#what-works-well---review-this-weekly)):
 
 - Rent the most expensive brain you can—$200/month is nothing vs force multiplication
 - Maximize time between interventions (Tesla self-driving metric)
@@ -153,6 +154,7 @@ New framework distinguishing compulsion from choice ([blog](/addiction#is-doing-
 Updates across the ecosystem:
 
 **[Settings](https://github.com/idvorkin/Settings)** (dotfiles & tools)
+
 - `ter` command: 432-line addition to y.py for terminal tab switching between named sessions [<i class="fa fa-github"></i>](https://github.com/idvorkin/Settings/commit/c5a71186c)
 - Neovim `:PRStatus` and `:PRDiff` commands to view all changes in current PR against main [<i class="fa fa-github"></i>](https://github.com/idvorkin/Settings/commit/9caa71bcd)
 - Fix tmux `C-o` binding reset: explicit bind-key so config reload preserves rotate-window [<i class="fa fa-github"></i>](https://github.com/idvorkin/Settings/commit/d41d98f38)
@@ -161,11 +163,13 @@ Updates across the ecosystem:
 - Parameter completion infrastructure for y.py CLI [<i class="fa fa-github"></i>](https://github.com/idvorkin/Settings/commit/2d7e81279)
 
 **[nlp](https://github.com/idvorkin/nlp)** (AI/NLP tools)
+
 - Local MLX TTS: text-to-speech on Apple Silicon without cloud API calls [<i class="fa fa-github"></i>](https://github.com/idvorkin/nlp/commit/61aa07c58)
 
 **[monitor-explainer](https://monitor-explorer.surge.sh)** (new project!) [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer)
 
 Built from scratch this week - React + TypeScript + Vite interactive tool:
+
 - SVG visualization comparing monitors by aspect ratio (16:9, 21:9, 32:9) and size [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer/commit/3945f2323)
 - Pan and zoom functionality for the visualization [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer/commit/01ee334d8)
 - Individual monitor dragging with snapping + duplicate monitors [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer/commit/dd0ac4254)
@@ -175,9 +179,11 @@ Built from scratch this week - React + TypeScript + Vite interactive tool:
 - Surge deployment with PR previews [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer/commit/9ceeaea4a)
 
 **[how-long-since-ai](https://idvorkin-how-long-since-ai.surge.sh)** (time tracker) [<i class="fa fa-github"></i>](https://github.com/idvorkin/how-long-since-ai)
+
 - Added deployment docs: Surge.sh production + PR preview URLs [<i class="fa fa-github"></i>](https://github.com/idvorkin/how-long-since-ai/commit/93061f9d7)
 
 **[chop-conventions](https://github.com/idvorkin/chop-conventions)** (CHOP workflow docs)
+
 - up-to-date skill: detect commits on feature branch not in main after PR merge [<i class="fa fa-github"></i>](https://github.com/idvorkin/chop-conventions/commit/8c0290552)
 
 ---

--- a/_d/how-igor-chops.md
+++ b/_d/how-igor-chops.md
@@ -125,7 +125,7 @@ Claude Code is really about autonomous agents that run in your terminal. As a te
 
 ### The Future: Multi-Agent Dashboard
 
-I was surprised when Steve Yegge mentioned this is the future - orchestrating multiple specialized agents. Surprised because I'd been accidentally building toward this. The [Agent Dashboard](#agent-dashboard) I mentioned earlier? By the way, I didn't build that at all. I just gave the requirements and Claude built it itself.
+I was surprised when Steve Yegge mentioned this is the future - orchestrating multiple specialized agents. Surprised because I'd been accidentally building toward this. The [Agent Dashboard](#the-future-multi-agent-dashboard) I mentioned earlier? By the way, I didn't build that at all. I just gave the requirements and Claude built it itself.
 
 ### The 8 Stages of AI Coding
 
@@ -153,7 +153,7 @@ This diagram perfectly captures the evolution I've lived through. Let me break d
 
 1. **Specialized Tools** - Different agents have different capabilities. One handles tests, another docs, another deployment. You're orchestrating specialists, not generalists. The [optimal number of agents](#what-im-still-figuring-out) becomes critical.
 
-1. **Orchestrated System** - This is the vision: a central dashboard managing dozens of specialized agents. The [Agent Dashboard](#agent-dashboard) is an early step toward this. You're no longer coordinating individual agents - you're managing the system that coordinates them.
+1. **Orchestrated System** - This is the vision: a central dashboard managing dozens of specialized agents. The [Agent Dashboard](#the-future-multi-agent-dashboard) is an early step toward this. You're no longer coordinating individual agents - you're managing the system that coordinates them.
 
 **Where I Am Today:** Somewhere between stages 6 and 7. Running 2-3 parallel agents on different features, learning how to avoid merge hell, figuring out when to use specialized vs. generalist agents. Stage 8 is the dream, but the tooling isn't quite there yet.
 
@@ -397,6 +397,7 @@ The SDETs were ahead of their time.
 With coding so easy, might as well make a tool just for your use case. No need to find an app that's 80% right - build exactly what you want in an afternoon.
 
 I think there's a pendulum here:
+
 - 90s: Every company needed their own IT department
 - 2000s: SaaS - rent the same software as everyone else
 - 2030s: Single dev does all the required tooling, personalized to their exact needs
@@ -449,6 +450,6 @@ At that point, two problems:
 
 Steve Yegge describes using [MCP Agent Mail](https://github.com/Dicklesworthstone/mcp_agent_mail) for multi-agent coordination: "You just give them a task and tell them to sort it out amongst themselves. There's no ego, so they quickly decide on a leader and split things up... Although it seems crazy to work that way, the agents just figure it out—they're quite resilient." See his [Beads Best Practices](https://steve-yegge.medium.com/beads-best-practices-2db636b9760c) post.
 
-This raises uncomfortable questions: If agents can recover from any workflow mess, do we still need disciplined processes? We've spent decades building guardrails to prevent non-deterministic states because *humans* can't handle the chaos. But agents can. Maybe the discipline shifts from *how you work* to *what you produce*. Maybe it's fine if your agents are sloppy, leave garbage lying around, and get into weird states - as long as the output is correct. The craftsmanship moves from the process to the artifact. I don't know what to do with this yet.
+This raises uncomfortable questions: If agents can recover from any workflow mess, do we still need disciplined processes? We've spent decades building guardrails to prevent non-deterministic states because _humans_ can't handle the chaos. But agents can. Maybe the discipline shifts from _how you work_ to _what you produce_. Maybe it's fine if your agents are sloppy, leave garbage lying around, and get into weird states - as long as the output is correct. The craftsmanship moves from the process to the artifact. I don't know what to do with this yet.
 
-(By the way, this is how I use voice. My voice input ends up being garbage - half-formed thoughts, wrong words, trailing off mid-sentence - but agents figure out what I meant and respond to my intent, not my mangled transcription. Even the *input* can be sloppy now.)
+(By the way, this is how I use voice. My voice input ends up being garbage - half-formed thoughts, wrong words, trailing off mid-sentence - but agents figure out what I meant and respond to my intent, not my mangled transcription. Even the _input_ can be sloppy now.)

--- a/_d/y2026.md
+++ b/_d/y2026.md
@@ -20,7 +20,7 @@ I like to begin with the end in mind, so let's write a report for 2026. This has
   - [Content Creation](#content-creation)
     - [EM Handbook: TikTok Edition](#em-handbook-tiktok-edition)
   - [AI Projects](#ai-projects)
-  - [Time.ltd - Mortality Software](#timeltd---mortality-software)
+  - [Time.ltd and Larry](#timeltd-and-larry)
   - [Summer Vacation](#summer-vacation)
 - [Health & Personal Goals](#health--personal-goals)
   - [Physical Health](#physical-health)

--- a/back-links.json
+++ b/back-links.json
@@ -1190,7 +1190,7 @@
         },
         "/awareness": {
             "description": "A transformative spiritual guide that challenges you to wake up from the sleep of unconscious living. Anthony de Mello, a Jesuit priest and psychotherapist, delivers spiritual tough love through short chapters filled with stories, parables, and direct challenges. His message: most of us spend our lives asleep, and awareness is the key to waking up to true happiness and freedom.\n\n",
-            "doc_size": 56000,
+            "doc_size": 104000,
             "file_path": "_site/awareness.html",
             "incoming_links": [
                 "/siy",
@@ -1200,11 +1200,11 @@
             "markdown_path": "_d/awareness.md",
             "outgoing_links": [
                 "/anxiety",
+                "/death",
                 "/emotional-health",
                 "/happy",
                 "/idle",
-                "/jung-self-ego",
-                "/psychic-shadows",
+                "/religion",
                 "/siy",
                 "/spiritual-health"
             ],
@@ -1267,7 +1267,7 @@
         },
         "/balloon": {
             "description": "Want to plaster a huge smile on someone’s face with 10 cents of material and 20 seconds of work? Make them a balloon! In 2022, I discovered ballooning, and have used it in my joy-delivering arsenal ever since.\n\n",
-            "doc_size": 22000,
+            "doc_size": 21000,
             "file_path": "_site/balloon.html",
             "incoming_links": [
                 "/eulogy",
@@ -1301,7 +1301,7 @@
         },
         "/be-proactive": {
             "description": "I choose ‘.’ I am responsible for my own life ‘.’ My behavior is a function of my decisions, not my conditions ‘.’ I can subordinate feelings to values ‘.’ I have the initiative and the responsibility to make things happen. These are my insights from 7 habits Chapter 1.\n\n",
-            "doc_size": 23000,
+            "doc_size": 22000,
             "file_path": "_site/be-proactive.html",
             "incoming_links": [
                 "/7-habits",
@@ -1438,7 +1438,7 @@
         },
         "/books-that-defined-me": {
             "description": "Books allow great thoughts to enter our mind and mold us into who we want to become. These are the books that are molding me.\n\n",
-            "doc_size": 17000,
+            "doc_size": 16000,
             "file_path": "_site/books-that-defined-me.html",
             "incoming_links": [
                 "/being-a-great-manager",
@@ -1621,7 +1621,7 @@
             "doc_size": 34000,
             "file_path": "_site/changelog.html",
             "incoming_links": [],
-            "last_modified": "2026-02-17T08:32:01-08:00",
+            "last_modified": "2026-02-22T22:09:55+00:00",
             "markdown_path": "_d/changelog.md",
             "outgoing_links": [
                 "/activation",
@@ -1629,7 +1629,7 @@
                 "/ai-cockpit",
                 "/ai-journal",
                 "/ai-native-manager",
-                "/chop",
+                "/how-igor-chops",
                 "/product",
                 "/recent",
                 "/shoulder-pain",
@@ -1697,7 +1697,6 @@
                 "/ai-hiring",
                 "/ai-journal",
                 "/ai-native-manager",
-                "/changelog",
                 "/chow",
                 "/gtd",
                 "/how-igor-chops",
@@ -2210,6 +2209,7 @@
             "doc_size": 24000,
             "file_path": "_site/death.html",
             "incoming_links": [
+                "/awareness",
                 "/chasing-daylight",
                 "/covid",
                 "/elder",
@@ -2229,7 +2229,7 @@
         },
         "/debug": {
             "description": "Igor's Blog",
-            "doc_size": 24000,
+            "doc_size": 23000,
             "file_path": "_site/debug.html",
             "incoming_links": [],
             "last_modified": "2025-03-16T16:15:36+00:00",
@@ -2739,7 +2739,7 @@
         },
         "/first-things-first": {
             "description": "The key to effective management, is allocating energy through the lens of importance rather than urgency. E.g, ask yourself what one thing could you do that if you did on a regular basis, would make a tremendous positive difference in your life? Lemme guess, it’s important, but not urgent so you’re not doing it. These are my insights based on the 7 habits Chapter 3.\n\n",
-            "doc_size": 26000,
+            "doc_size": 25000,
             "file_path": "_site/first-things-first.html",
             "incoming_links": [
                 "/4dx",
@@ -2994,7 +2994,7 @@
         },
         "/goals": {
             "description": "Goals are critical, there are multiple goal systems and they have consequences. They are mechanisms to deliver without micro management.\n\n",
-            "doc_size": 21000,
+            "doc_size": 20000,
             "file_path": "_site/goals.html",
             "incoming_links": [
                 "/4dx",
@@ -3152,7 +3152,7 @@
         },
         "/happy": {
             "description": "Happy is a 5 letter word that many use as the answer to what is the point of life. The follow up question of “How can you be happy” is usually followed by a blank stare, so here’s my study of the subject. Probably the most important thing is happiness is not a mood, it’s journey - Like the weather vs the climate.\n\n",
-            "doc_size": 33000,
+            "doc_size": 32000,
             "file_path": "_site/happy.html",
             "incoming_links": [
                 "/awareness",
@@ -3242,12 +3242,13 @@
                 "/ai",
                 "/ai-cockpit",
                 "/ai-journal",
+                "/changelog",
                 "/chop",
                 "/pet-projects",
                 "/y25",
                 "/y26"
             ],
-            "last_modified": "2026-02-17T18:51:28-08:00",
+            "last_modified": "2026-02-22T22:09:55+00:00",
             "markdown_path": "_d/how-igor-chops.md",
             "outgoing_links": [
                 "/40yo",
@@ -3640,7 +3641,7 @@
         },
         "/learn-code": {
             "description": "Coding is way easier than people think. Here’s some pointers.\n\n",
-            "doc_size": 14000,
+            "doc_size": 13000,
             "file_path": "_site/learn-code.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T02:47:07+00:00",
@@ -3897,7 +3898,7 @@
         },
         "/mind-at-work": {
             "description": "I have a problem, an addiction, an addiction so detrimental to quality of life, it should be described as a disease. This disease is not being present. There are many symptoms of the disease, but today I’m going to talk about my most frequent symptoms, my body at home, but my mind at work.\n\n",
-            "doc_size": 20000,
+            "doc_size": 19000,
             "file_path": "_site/mind-at-work.html",
             "incoming_links": [
                 "/addiction",
@@ -4685,7 +4686,6 @@
             "file_path": "_site/psychic-shadows.html",
             "incoming_links": [
                 "/anxiety-management",
-                "/awareness",
                 "/caring",
                 "/depression",
                 "/idle",
@@ -4870,6 +4870,7 @@
             "doc_size": 57000,
             "file_path": "_site/religion.html",
             "incoming_links": [
+                "/awareness",
                 "/four-healths",
                 "/spiritual-health",
                 "/walking-with-god",
@@ -6508,7 +6509,7 @@
         },
         "/walking-with-god": {
             "description": "Someone important to me has been reading a daily devotional. Even though I’m not religious, I’m studying with them to be able to have conversations about the insights - whether in a secular or religious context. This is my attempt to bridge two worlds: honoring the spiritual wisdom they’re finding while translating it into language that works for my engineer brain.\n\n",
-            "doc_size": 82000,
+            "doc_size": 81000,
             "file_path": "_site/walking-with-god.html",
             "incoming_links": [
                 "/religion",
@@ -6798,7 +6799,7 @@
             "incoming_links": [
                 "/changelog"
             ],
-            "last_modified": "2026-02-15T09:21:54-08:00",
+            "last_modified": "2026-02-22T22:09:55+00:00",
             "markdown_path": "_d/y2026.md",
             "outgoing_links": [
                 "/22",

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ default:
 
 # Setup development environment (run once after clone)
 setup:
-    pre-commit install
+    prek install
 
 # ===== JavaScript/TypeScript Build System =====
 # For JavaScript/TypeScript development, use these commands:


### PR DESCRIPTION
## Summary

- Replace Python `pre-commit` with `prek` (Rust-based, faster, no Python runtime needed)
- Update `justfile`, `CLAUDE.md`, `CLAUDE-CODING.md` to reference `prek` instead of `pre-commit`
- Fix 5 pre-existing broken anchors caught by the anchor checker
- Regenerate `back-links.json` (was corrupted by double-write during hook run)

`.pre-commit-config.yaml` is unchanged — prek reads it as-is.

A `pre-commit` shim is installed at the brew bin path that errors with "use prek instead" to catch muscle memory.

## Test plan

- [x] `prek run --files justfile CLAUDE.md CLAUDE-CODING.md` — all hooks pass
- [x] `prek list` — shows all 13 configured hooks
- [x] `git commit` with hooks enabled — bd → prek chain works
- [x] Anchor checker passes (0 broken anchors in changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new pages: "Browsers for Machines" and "Awareness" hubs with cross-links across the site.

* **Documentation**
  * Updated anchor links in blog sections for improved navigation.
  * Updated "Time.ltd - Mortality Software" to "Time.ltd and Larry".
  * Reformatted markdown emphasis throughout documentation.

* **Chores**
  * Updated setup commands in guidelines and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->