### PR TITLE
Remove deprecated beads-sync pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,13 +52,6 @@ repos:
   # 🧪 Local hooks
   - repo: local
     hooks:
-      - id: beads-sync
-        name: Flush beads changes
-        entry: bash -c 'command -v bd >/dev/null && [ -d .beads ] && bd sync --flush-only && git add .beads/issues.jsonl 2>/dev/null; true'
-        language: system
-        pass_filenames: false
-        always_run: true
-
       - id: test
         name: Run Fast Tests
         entry: just fast-test


### PR DESCRIPTION
## Summary
- Remove `beads-sync` hook from `.pre-commit-config.yaml`
- `bd sync --flush-only` is deprecated — beads now uses Dolt for persistence
- `.beads/` is gitignored so `git add .beads/issues.jsonl` was silently failing
- This hook was the root cause of stray `bd: backup` commits landing on code branches

## Test plan
- [x] All pre-commit hooks pass
- [x] `prek run --all-files` succeeds without the removed hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed pre-commit hook for automated beads synchronization, simplifying the local development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->