### PR TITLE
Fix Playwright tests broken by LiveReload page reloads

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -110,6 +110,7 @@ exclude:
     "docs",
     "tech_graveyard",
     "test-results",
+    "playwright-report",
     "tests",
     "src/__tests__",
     "repo_tmp",

--- a/tests/e2e/404-page-links.spec.ts
+++ b/tests/e2e/404-page-links.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 test("404 page loads correctly", async ({ page }) => {
@@ -7,7 +7,7 @@ test("404 page loads correctly", async ({ page }) => {
 
   // Check that we get the 404 page by looking for the title or unique content
   await expect(page).toHaveTitle(/PAGE NOT FOUND/);
-  
+
   // Verify the monkey message appears
   await expect(page.locator("body")).toContainText("The Monkey has eaten the page you are looking for");
 });
@@ -17,45 +17,45 @@ test("All links on 404 page work correctly", async ({ page }) => {
   await page.goto("/this-page-does-not-exist");
 
   // Test About link (get the one in the main content, not navigation)
-  const aboutLink = page.getByRole('link', { name: 'About' });
+  const aboutLink = page.getByRole("link", { name: "About" });
   await expect(aboutLink).toBeVisible();
   await aboutLink.click();
   await expect(page.locator("h1")).toContainText("Where am I?");
-  
+
   // Go back to 404
   await page.goto("/another-non-existent-page");
 
   // Test Search link (home page)
-  const searchLink = page.getByRole('link', { name: 'Search' });
+  const searchLink = page.getByRole("link", { name: "Search" });
   await expect(searchLink).toBeVisible();
   await searchLink.click();
   // Just check we're on the home page by looking for the search input or featured content
   await expect(page.locator("body")).toContainText("Featured");
-  
+
   // Go back to 404
   await page.goto("/yet-another-missing-page");
 
   // Test Random post link
-  const randomLink = page.getByRole('link', { name: 'Random post' });
+  const randomLink = page.getByRole("link", { name: "Random post" });
   await expect(randomLink).toBeVisible();
   await randomLink.click();
   // Random page should redirect to some blog post, just check we're not on 404
   await expect(page).not.toHaveTitle(/PAGE NOT FOUND/);
-  
+
   // Go back to 404
   await page.goto("/missing-page-for-toc-test");
 
   // Test Table of Contents link
-  const tocLink = page.getByRole('link', { name: 'Table of Contents' });
+  const tocLink = page.getByRole("link", { name: "Table of Contents" });
   await expect(tocLink).toBeVisible();
   await tocLink.click();
   await expect(page.locator("body")).toContainText("Table of Contents");
-  
+
   // Go back to 404
   await page.goto("/missing-page-for-all-test");
 
   // Test All posts link
-  const allLink = page.getByRole('link', { name: 'All posts' });
+  const allLink = page.getByRole("link", { name: "All posts" });
   await expect(allLink).toBeVisible();
   await allLink.click();
   await expect(page.locator("h1")).toContainText("All Blog Posts");
@@ -68,12 +68,12 @@ test("404 page has no JavaScript errors", async ({ page }) => {
 
 test("404 page image loads correctly", async ({ page }) => {
   await page.goto("/non-existent-page");
-  
+
   // Check that the monkey image is present
   const monkeyImage = page.locator('img[src*="pinimg.com"]');
   await expect(monkeyImage).toBeVisible();
-  
+
   // Verify the image loads successfully (not broken)
-  const response = await page.request.get(await monkeyImage.getAttribute('src') || '');
+  const response = await page.request.get((await monkeyImage.getAttribute("src")) || "");
   expect(response.status()).toBe(200);
 });

--- a/tests/e2e/about-page.spec.ts
+++ b/tests/e2e/about-page.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 test("About page loads correctly", async ({ page }) => {

--- a/tests/e2e/all-posts-github-links.spec.ts
+++ b/tests/e2e/all-posts-github-links.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 test("All posts page loads correctly", async ({ page }) => {
@@ -13,31 +13,31 @@ test("GitHub source links are visible and functional", async ({ page }) => {
   await page.goto("/all/");
 
   // Check that GitHub links exist
-  const githubLinks = page.locator('.github-link');
+  const githubLinks = page.locator(".github-link");
   const linkCount = await githubLinks.count();
-  
+
   // Should have at least some GitHub links (assuming there are posts/pages)
   expect(linkCount).toBeGreaterThan(0);
 
   // Test the first few GitHub links
   const linksToTest = Math.min(3, linkCount);
-  
+
   for (let i = 0; i < linksToTest; i++) {
     const link = githubLinks.nth(i);
-    
+
     // Check that the link is visible
     await expect(link).toBeVisible();
-    
+
     // Check that the link has the correct href pattern
-    const href = await link.getAttribute('href');
+    const href = await link.getAttribute("href");
     expect(href).toMatch(/^https:\/\/github\.com\/idvorkin\/idvorkin\.github\.io\/blob\/main\/.+$/);
-    
+
     // Check that the link opens in a new tab
-    const target = await link.getAttribute('target');
-    expect(target).toBe('_blank');
-    
+    const target = await link.getAttribute("target");
+    expect(target).toBe("_blank");
+
     // Check that the link has the GitHub icon
-    const icon = link.locator('i.fab.fa-github');
+    const icon = link.locator("i.fab.fa-github");
     await expect(icon).toBeVisible();
   }
 });
@@ -46,26 +46,26 @@ test("GitHub links point to valid repository paths", async ({ page }) => {
   await page.goto("/all/");
 
   // Get the first GitHub link to test
-  const firstGithubLink = page.locator('.github-link').first();
+  const firstGithubLink = page.locator(".github-link").first();
   await expect(firstGithubLink).toBeVisible();
-  
-  const href = await firstGithubLink.getAttribute('href');
+
+  const href = await firstGithubLink.getAttribute("href");
   expect(href).toBeTruthy();
 
   // Extract the file path from the GitHub URL
   const pathMatch = href?.match(/\/blob\/main\/(.+)$/);
   expect(pathMatch).toBeTruthy();
-  
+
   if (pathMatch) {
     const filePath = pathMatch[1];
-    
+
     // The file path should have a valid extension
     expect(filePath).toMatch(/\.(md|html)$/);
-    
+
     // Make a HEAD request to check if the GitHub file exists
     // Note: This tests the URL structure is valid, not the actual file existence
     const response = await page.request.head(href);
-    
+
     // GitHub should respond (either 200 for valid file or 404 for missing file)
     // Both are acceptable responses indicating the URL structure is correct
     expect([200, 404]).toContain(response.status());
@@ -81,27 +81,27 @@ test("GitHub links are grouped correctly by collection", async ({ page }) => {
     { heading: "Pages", selector: "h2:has-text('Pages')" },
     { heading: "D Collection", selector: "h2:has-text('D Collection')" },
     { heading: "IG66 Collection", selector: "h2:has-text('IG66 Collection')" },
-    { heading: "TD Collection", selector: "h2:has-text('TD Collection')" }
+    { heading: "TD Collection", selector: "h2:has-text('TD Collection')" },
   ];
 
   for (const section of sections) {
     const sectionHeading = page.locator(section.selector);
-    
+
     // Check if this section exists (some collections might be empty)
-    if (await sectionHeading.count() > 0) {
+    if ((await sectionHeading.count()) > 0) {
       // Find the ul that follows this heading
-      const sectionList = sectionHeading.locator('+ ul');
-      
-      if (await sectionList.count() > 0) {
+      const sectionList = sectionHeading.locator("+ ul");
+
+      if ((await sectionList.count()) > 0) {
         // Check if there are any items in this section
-        const listItems = sectionList.locator('li');
+        const listItems = sectionList.locator("li");
         const itemCount = await listItems.count();
-        
+
         if (itemCount > 0) {
           // Each item should have a GitHub link
-          const githubLinksInSection = sectionList.locator('.github-link');
+          const githubLinksInSection = sectionList.locator(".github-link");
           const githubLinkCount = await githubLinksInSection.count();
-          
+
           // Should have at least one GitHub link in this section
           expect(githubLinkCount).toBeGreaterThan(0);
           expect(githubLinkCount).toBeLessThanOrEqual(itemCount);
@@ -118,11 +118,11 @@ test("All posts page has no JavaScript errors", async ({ page }) => {
 test("GitHub link styling is correct", async ({ page }) => {
   await page.goto("/all/");
 
-  const firstGithubLink = page.locator('.github-link').first();
+  const firstGithubLink = page.locator(".github-link").first();
   await expect(firstGithubLink).toBeVisible();
 
   // Check CSS styling
-  await expect(firstGithubLink).toHaveCSS('color', 'rgb(102, 102, 102)'); // #666
-  await expect(firstGithubLink).toHaveCSS('text-decoration-line', 'none');
-  await expect(firstGithubLink).toHaveCSS('margin-left', '10px');
+  await expect(firstGithubLink).toHaveCSS("color", "rgb(102, 102, 102)"); // #666
+  await expect(firstGithubLink).toHaveCSS("text-decoration-line", "none");
+  await expect(firstGithubLink).toHaveCSS("margin-left", "10px");
 });

--- a/tests/e2e/amazon-links.spec.ts
+++ b/tests/e2e/amazon-links.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Amazon affiliate links", () => {
   test("should display Amazon links with proper affiliate tags", async ({ page }) => {

--- a/tests/e2e/base-test.ts
+++ b/tests/e2e/base-test.ts
@@ -1,0 +1,18 @@
+import { test as base } from "@playwright/test";
+
+/**
+ * Custom test fixture that blocks LiveReload to prevent Jekyll dev server
+ * rebuilds from destroying execution contexts during tests.
+ *
+ * LiveReload sends WebSocket "reload" commands whenever Jekyll rebuilds a page,
+ * which causes full page navigations that break test assertions.
+ */
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    // Block LiveReload script requests at the network level
+    await page.route("**/livereload.js*", (route) => route.abort());
+    await use(page);
+  },
+});
+
+export { expect, type Page } from "@playwright/test";

--- a/tests/e2e/blog-posts.spec.ts
+++ b/tests/e2e/blog-posts.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 test.describe("Blog post functionality", () => {

--- a/tests/e2e/dev-banner.spec.ts
+++ b/tests/e2e/dev-banner.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Dev Info Banner", () => {
   test("should display branch and port info on dev server", async ({ page }) => {
@@ -57,7 +57,7 @@ test.describe("Dev Info Banner", () => {
     if (prInfo) {
       const prLink = await page.locator("#dev-info-banner a[href*='/pull/']");
       await expect(prLink).toBeVisible();
-      
+
       const href = await prLink.getAttribute("href");
       expect(href).toContain(`/pull/${prInfo}`);
       console.log("PR link href:", href);
@@ -73,7 +73,7 @@ test.describe("Dev Info Banner", () => {
     await page.waitForLoadState("networkidle");
 
     const prInfo = await page.evaluate(() => (window as any).__GIT_PR__);
-    
+
     if (prInfo) {
       const banner = await page.locator("#dev-info-banner");
       await expect(banner).toBeVisible();

--- a/tests/e2e/featured-collapse.spec.ts
+++ b/tests/e2e/featured-collapse.spec.ts
@@ -1,113 +1,113 @@
-import { test, expect, Page } from '@playwright/test';
+import { type Page, expect, test } from "./base-test";
 
-test.describe('Featured Section Collapse Functionality', () => {
+test.describe("Featured Section Collapse Functionality", () => {
   let page: Page;
 
   test.beforeEach(async ({ page: testPage }) => {
     page = testPage;
-    await page.goto('/');
-    
+    await page.goto("/");
+
     // Wait for the featured section to be loaded
-    await page.waitForSelector('#featured-section', { state: 'visible' });
+    await page.waitForSelector("#featured-section", { state: "visible" });
   });
 
-  test('collapse button should be visible and properly styled', async () => {
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    
+  test("collapse button should be visible and properly styled", async () => {
+    const collapseBtn = page.locator("#featured-collapse-btn");
+
     // Check button exists and is visible
     await expect(collapseBtn).toBeVisible();
-    
+
     // Check initial state
-    await expect(collapseBtn).toHaveText('Collapse −');
-    await expect(collapseBtn).toHaveAttribute('title', 'Collapse section');
-    
+    await expect(collapseBtn).toHaveText("Collapse −");
+    await expect(collapseBtn).toHaveAttribute("title", "Collapse section");
+
     // Check it has the correct class
-    await expect(collapseBtn).toHaveClass('action-link');
+    await expect(collapseBtn).toHaveClass("action-link");
   });
 
-  test('should collapse and expand featured section on button click', async () => {
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    const featuredResults = page.locator('#featured-results');
-    
+  test("should collapse and expand featured section on button click", async () => {
+    const collapseBtn = page.locator("#featured-collapse-btn");
+    const featuredResults = page.locator("#featured-results");
+
     // Initial state - expanded
     await expect(featuredResults).toBeVisible();
-    await expect(collapseBtn).toHaveText('Collapse −');
-    
+    await expect(collapseBtn).toHaveText("Collapse −");
+
     // Click to collapse
     await collapseBtn.click();
     await expect(featuredResults).not.toBeVisible();
-    await expect(collapseBtn).toHaveText('Expand +');
-    await expect(collapseBtn).toHaveAttribute('title', 'Expand section');
-    
+    await expect(collapseBtn).toHaveText("Expand +");
+    await expect(collapseBtn).toHaveAttribute("title", "Expand section");
+
     // Click to expand
     await collapseBtn.click();
     await expect(featuredResults).toBeVisible();
-    await expect(collapseBtn).toHaveText('Collapse −');
-    await expect(collapseBtn).toHaveAttribute('title', 'Collapse section');
+    await expect(collapseBtn).toHaveText("Collapse −");
+    await expect(collapseBtn).toHaveAttribute("title", "Collapse section");
   });
 
-  test('should handle multiple rapid clicks', async () => {
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    const featuredResults = page.locator('#featured-results');
-    
+  test("should handle multiple rapid clicks", async () => {
+    const collapseBtn = page.locator("#featured-collapse-btn");
+    const featuredResults = page.locator("#featured-results");
+
     // Perform rapid clicks
     await collapseBtn.click(); // collapse
     await collapseBtn.click(); // expand
     await collapseBtn.click(); // collapse
-    
+
     // Should end up collapsed
     await expect(featuredResults).not.toBeVisible();
-    await expect(collapseBtn).toHaveText('Expand +');
+    await expect(collapseBtn).toHaveText("Expand +");
   });
 
-  test('collapsed state should persist during content loading', async () => {
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    const featuredResults = page.locator('#featured-results');
-    
+  test("collapsed state should persist during content loading", async () => {
+    const collapseBtn = page.locator("#featured-collapse-btn");
+    const featuredResults = page.locator("#featured-results");
+
     // Collapse the section
     await collapseBtn.click();
     await expect(featuredResults).not.toBeVisible();
-    
+
     // Wait for content to potentially load
     await page.waitForTimeout(2000);
-    
+
     // Should still be collapsed
     await expect(featuredResults).not.toBeVisible();
-    await expect(collapseBtn).toHaveText('Expand +');
+    await expect(collapseBtn).toHaveText("Expand +");
   });
 
-  test('should show results when searching even if collapsed', async () => {
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    const featuredResults = page.locator('#featured-results');
-    const searchInput = page.locator('#search-input');
-    
+  test("should show results when searching even if collapsed", async () => {
+    const collapseBtn = page.locator("#featured-collapse-btn");
+    const featuredResults = page.locator("#featured-results");
+    const searchInput = page.locator("#search-input");
+
     // Collapse the section
     await collapseBtn.click();
     await expect(featuredResults).not.toBeVisible();
-    
+
     // Perform a search
-    await searchInput.fill('test search');
+    await searchInput.fill("test search");
     await page.waitForTimeout(1000); // Wait for search debounce
-    
+
     // The section should become visible when search results are shown
     await expect(featuredResults).toBeVisible();
-    
+
     // Clear search
     await searchInput.clear();
     await page.waitForTimeout(1000);
-    
+
     // Featured section should restore to collapsed state after clearing search
     await expect(featuredResults).not.toBeVisible();
-    await expect(collapseBtn).toHaveText('Expand +');
+    await expect(collapseBtn).toHaveText("Expand +");
   });
 
-  test('should not interfere with other action links', async () => {
+  test("should not interfere with other action links", async () => {
     // Check if other action links still work
-    const randomRefreshBtn = page.locator('#random-section .action-link');
-    
+    const randomRefreshBtn = page.locator("#random-section .action-link");
+
     // Collapse featured section
-    await page.locator('#featured-collapse-btn').click();
-    
+    await page.locator("#featured-collapse-btn").click();
+
     // Other action links should still be clickable
     if (await randomRefreshBtn.isVisible()) {
       await expect(randomRefreshBtn).toBeEnabled();
@@ -115,146 +115,142 @@ test.describe('Featured Section Collapse Functionality', () => {
     }
   });
 
-  test('should be keyboard accessible', async () => {
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    const featuredResults = page.locator('#featured-results');
-    
+  test("should be keyboard accessible", async () => {
+    const collapseBtn = page.locator("#featured-collapse-btn");
+    const featuredResults = page.locator("#featured-results");
+
     // Focus the button
     await collapseBtn.focus();
-    
+
     // Press Enter to collapse
-    await page.keyboard.press('Enter');
+    await page.keyboard.press("Enter");
     await expect(featuredResults).not.toBeVisible();
-    
+
     // Press Enter to expand
-    await page.keyboard.press('Enter');
+    await page.keyboard.press("Enter");
     await expect(featuredResults).toBeVisible();
   });
 
-  test('should maintain proper ARIA attributes', async () => {
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    const featuredSection = page.locator('#featured-section');
-    
+  test("should maintain proper ARIA attributes", async () => {
+    const collapseBtn = page.locator("#featured-collapse-btn");
+    const featuredSection = page.locator("#featured-section");
+
     // Check that the button is properly labeled
-    await expect(collapseBtn).toHaveAttribute('href', '#');
-    
+    await expect(collapseBtn).toHaveAttribute("href", "#");
+
     // The title attribute serves as the accessible name
-    await expect(collapseBtn).toHaveAttribute('title');
+    await expect(collapseBtn).toHaveAttribute("title");
   });
 
-  test('should work on mobile viewport', async () => {
+  test("should work on mobile viewport", async () => {
     // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
-    
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    const featuredResults = page.locator('#featured-results');
-    
+
+    const collapseBtn = page.locator("#featured-collapse-btn");
+    const featuredResults = page.locator("#featured-results");
+
     // Button should still be visible and functional
     await expect(collapseBtn).toBeVisible();
-    
+
     // Test collapse/expand on mobile
     await collapseBtn.click();
     await expect(featuredResults).not.toBeVisible();
-    
+
     await collapseBtn.click();
     await expect(featuredResults).toBeVisible();
   });
 
-  test('should not cause JavaScript errors', async () => {
+  test("should not cause JavaScript errors", async () => {
     const errors: string[] = [];
-    
+
     // Listen for console errors
-    page.on('pageerror', (error) => {
+    page.on("pageerror", (error) => {
       errors.push(error.message);
     });
-    
+
     // Perform various interactions
-    const collapseBtn = page.locator('#featured-collapse-btn');
+    const collapseBtn = page.locator("#featured-collapse-btn");
     await collapseBtn.click();
     await collapseBtn.click();
     await collapseBtn.click();
-    
+
     // Check no errors occurred
     expect(errors).toHaveLength(0);
   });
 
-  test('collapse button should have consistent styling with other action links', async () => {
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    const otherActionLink = page.locator('.section-header .action-link').first();
-    
+  test("collapse button should have consistent styling with other action links", async () => {
+    const collapseBtn = page.locator("#featured-collapse-btn");
+    const otherActionLink = page.locator(".section-header .action-link").first();
+
     // Get computed styles
-    const collapseBtnColor = await collapseBtn.evaluate(el => 
-      window.getComputedStyle(el).color
-    );
-    
-    const otherLinkColor = await otherActionLink.evaluate(el => 
-      window.getComputedStyle(el).color
-    );
-    
+    const collapseBtnColor = await collapseBtn.evaluate((el) => window.getComputedStyle(el).color);
+
+    const otherLinkColor = await otherActionLink.evaluate((el) => window.getComputedStyle(el).color);
+
     // Colors should match
     expect(collapseBtnColor).toBe(otherLinkColor);
   });
 
-  test('should handle edge case of missing content gracefully', async () => {
+  test("should handle edge case of missing content gracefully", async () => {
     // Remove the featured results div to simulate edge case
     await page.evaluate(() => {
-      const elem = document.getElementById('featured-results');
+      const elem = document.getElementById("featured-results");
       if (elem) elem.remove();
     });
-    
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    
+
+    const collapseBtn = page.locator("#featured-collapse-btn");
+
     // Clicking should not cause errors
     await collapseBtn.click();
-    
+
     // Button should still update its text
-    await expect(collapseBtn).toHaveText('Expand +');
+    await expect(collapseBtn).toHaveText("Expand +");
   });
 
-  test('should persist collapse state across page reloads', async () => {
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    const featuredResults = page.locator('#featured-results');
-    
+  test("should persist collapse state across page reloads", async () => {
+    const collapseBtn = page.locator("#featured-collapse-btn");
+    const featuredResults = page.locator("#featured-results");
+
     // Collapse the section
     await collapseBtn.click();
     await expect(featuredResults).not.toBeVisible();
-    
+
     // Reload the page
     await page.reload();
-    await page.waitForSelector('#featured-section', { state: 'visible' });
-    
+    await page.waitForSelector("#featured-section", { state: "visible" });
+
     // Should still be collapsed after reload
     await expect(featuredResults).not.toBeVisible();
-    await expect(collapseBtn).toHaveText('Expand +');
-    
+    await expect(collapseBtn).toHaveText("Expand +");
+
     // Expand it
     await collapseBtn.click();
     await expect(featuredResults).toBeVisible();
-    
+
     // Reload again
     await page.reload();
-    await page.waitForSelector('#featured-section', { state: 'visible' });
-    
+    await page.waitForSelector("#featured-section", { state: "visible" });
+
     // Should be expanded after reload
     await expect(featuredResults).toBeVisible();
-    await expect(collapseBtn).toHaveText('Collapse −');
+    await expect(collapseBtn).toHaveText("Collapse −");
   });
 
-  test('should clear localStorage state when appropriate', async () => {
+  test("should clear localStorage state when appropriate", async () => {
     // Set a collapsed state
     await page.evaluate(() => {
-      localStorage.setItem('featured-section-collapsed', 'true');
+      localStorage.setItem("featured-section-collapsed", "true");
     });
-    
+
     // Navigate to the page
-    await page.goto('/');
-    await page.waitForSelector('#featured-section', { state: 'visible' });
-    
-    const featuredResults = page.locator('#featured-results');
-    const collapseBtn = page.locator('#featured-collapse-btn');
-    
+    await page.goto("/");
+    await page.waitForSelector("#featured-section", { state: "visible" });
+
+    const featuredResults = page.locator("#featured-results");
+    const collapseBtn = page.locator("#featured-collapse-btn");
+
     // Should be collapsed based on localStorage
     await expect(featuredResults).not.toBeVisible();
-    await expect(collapseBtn).toHaveText('Expand +');
+    await expect(collapseBtn).toHaveText("Expand +");
   });
 });

--- a/tests/e2e/featured-posts.spec.ts
+++ b/tests/e2e/featured-posts.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 test.describe("Featured Posts functionality", () => {

--- a/tests/e2e/graph-page.spec.ts
+++ b/tests/e2e/graph-page.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 test.describe("Graph page functionality", () => {

--- a/tests/e2e/header-copy-link.spec.ts
+++ b/tests/e2e/header-copy-link.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Header Copy Link Feature", () => {
   test.beforeEach(async ({ page }) => {
@@ -97,12 +97,12 @@ test.describe("Header Copy Link Feature", () => {
 
       // Verify breadcrumb format: From: [page name]: header hierarchy
       // Check for new format or old format (for backwards compatibility during deployment)
-      const hasBreadcrumbFormat = clipboardText.includes("From: [manager book]:") || 
-                                   clipboardText.includes("From: What does a manager do");
+      const hasBreadcrumbFormat =
+        clipboardText.includes("From: [manager book]:") || clipboardText.includes("From: What does a manager do");
       expect(hasBreadcrumbFormat).toBeTruthy();
-      
+
       // If it's the new format and an H3, it should have hierarchy with >
-      const tagName = await deepHeader.evaluate(el => el.tagName);
+      const tagName = await deepHeader.evaluate((el) => el.tagName);
       if (tagName === "H3" && clipboardText.includes("[manager book]:")) {
         expect(clipboardText).toContain(" > ");
       }
@@ -166,7 +166,7 @@ test.describe("Header Copy Link Feature", () => {
 
       // Move away from header
       await page.locator("body").hover({ position: { x: 0, y: 0 } });
-      
+
       // Wait a moment for the hover effect to clear
       await page.waitForTimeout(300);
 
@@ -203,7 +203,7 @@ test.describe("Header Copy Link Feature", () => {
       const titleInput = popup.locator(".github-issue-title");
       const commentTextarea = popup.locator(".github-issue-comment");
       const submitButton = popup.locator(".github-issue-submit");
-      
+
       await expect(titleInput).toBeVisible();
       await expect(commentTextarea).toBeVisible();
       await expect(submitButton).toBeVisible();
@@ -244,7 +244,7 @@ test.describe("Header Copy Link Feature", () => {
 
       // Close the new page
       await newPage.close();
-      
+
       // Verify popup is closed
       await expect(popup).not.toBeVisible();
     }

--- a/tests/e2e/image-zoom.spec.ts
+++ b/tests/e2e/image-zoom.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Image Zoom Functionality", () => {
   test("images should be clickable and open in lightbox", async ({ page }) => {

--- a/tests/e2e/irl-keyboards-layout.spec.ts
+++ b/tests/e2e/irl-keyboards-layout.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("IRL Keyboards Section - Layout Testing", () => {
   test("desktop layout - full width", async ({ page }) => {
@@ -8,7 +8,7 @@ test.describe("IRL Keyboards Section - Layout Testing", () => {
     await page.waitForTimeout(3000);
 
     // Find the keyboards section
-    const keyboardsSection = page.locator('h3:has-text("Keyboards")').locator('..');
+    const keyboardsSection = page.locator('h3:has-text("Keyboards")').locator("..");
     await keyboardsSection.scrollIntoViewIfNeeded();
     await page.waitForTimeout(1000);
 
@@ -27,7 +27,7 @@ test.describe("IRL Keyboards Section - Layout Testing", () => {
     await page.waitForTimeout(3000);
 
     // Find the keyboards section
-    const keyboardsSection = page.locator('h3:has-text("Keyboards")').locator('..');
+    const keyboardsSection = page.locator('h3:has-text("Keyboards")').locator("..");
     await keyboardsSection.scrollIntoViewIfNeeded();
     await page.waitForTimeout(1000);
 
@@ -60,7 +60,7 @@ test.describe("IRL Keyboards Section - Layout Testing", () => {
     await page.waitForLoadState("domcontentloaded");
 
     // Navigate to keyboards section
-    await page.locator('#keyboards').scrollIntoViewIfNeeded();
+    await page.locator("#keyboards").scrollIntoViewIfNeeded();
     await page.waitForTimeout(2000);
 
     // Check both keyboard images exist with alt text
@@ -72,8 +72,8 @@ test.describe("IRL Keyboards Section - Layout Testing", () => {
     await expect(blobImg).toHaveCount(1);
 
     // Get alt text
-    const ipasteAlt = await ipasteImg.getAttribute('alt');
-    const blobAlt = await blobImg.getAttribute('alt');
+    const ipasteAlt = await ipasteImg.getAttribute("alt");
+    const blobAlt = await blobImg.getAttribute("alt");
 
     // Verify both have alt text (not null, not empty)
     expect(ipasteAlt).toBeTruthy();

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "@playwright/test";
 import _ from "lodash";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 const SERVER_PORT = process.env.SERVER_PORT || "4000";

--- a/tests/e2e/mathjax-rendering.spec.ts
+++ b/tests/e2e/mathjax-rendering.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 test.describe("MathJax rendering", () => {

--- a/tests/e2e/performance-check.spec.ts
+++ b/tests/e2e/performance-check.spec.ts
@@ -1,77 +1,77 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Performance Analysis", () => {
   test("measure and log all load times", async ({ page }) => {
     // Capture console logs
     const consoleLogs: string[] = [];
-    page.on('console', msg => {
+    page.on("console", (msg) => {
       const text = msg.text();
-      if (text.includes('[') || text.includes('ms')) {
+      if (text.includes("[") || text.includes("ms")) {
         consoleLogs.push(text);
       }
     });
-    
+
     // Navigate to page
     await page.goto("/");
-    
+
     // Wait for all content to load
     await page.waitForTimeout(3000);
-    
+
     // Print all timing logs
     console.log("\n========== PERFORMANCE TIMING LOGS ==========");
-    consoleLogs.forEach(log => console.log(log));
+    consoleLogs.forEach((log) => console.log(log));
     console.log("==============================================\n");
-    
+
     // Analyze the logs
     const timings = consoleLogs
-      .filter(log => log.includes('ms'))
-      .map(log => {
+      .filter((log) => log.includes("ms"))
+      .map((log) => {
         const match = log.match(/(\d+)ms/);
-        return match ? parseInt(match[1]) : 0;
+        return match ? Number.parseInt(match[1]) : 0;
       })
-      .filter(time => time > 0);
-    
+      .filter((time) => time > 0);
+
     if (timings.length > 0) {
       const max = Math.max(...timings);
       const avg = timings.reduce((a, b) => a + b, 0) / timings.length;
-      console.log(`📊 Performance Summary:`);
+      console.log("📊 Performance Summary:");
       console.log(`   Max time: ${max}ms`);
       console.log(`   Avg time: ${avg.toFixed(0)}ms`);
       console.log(`   Number of timed operations: ${timings.length}`);
     }
-    
+
     // Check that something loaded
     const hasContent = await page.locator("#featured-results .result-item").count();
     expect(hasContent).toBeGreaterThan(0);
   });
-  
+
   test("measure cold cache performance", async ({ page, context }) => {
     // Clear cache
     await context.clearCookies();
-    
+
     const consoleLogs: string[] = [];
-    page.on('console', msg => {
+    page.on("console", (msg) => {
       const text = msg.text();
-      if (text.includes('[') || text.includes('ms')) {
+      if (text.includes("[") || text.includes("ms")) {
         consoleLogs.push(text);
       }
     });
-    
+
     const startTime = Date.now();
     await page.goto("/");
-    
+
     // Wait for featured content
     await page.waitForSelector("#featured-results .result-item a", { timeout: 10000 });
     const initialLoadTime = Date.now() - startTime;
-    
+
     console.log(`\n🥶 COLD CACHE: Initial content visible in ${initialLoadTime}ms`);
-    
+
     // Wait for everything to finish
     await page.waitForTimeout(2000);
-    
+
     // Show logs
     console.log("\n========== COLD CACHE TIMING LOGS ==========");
-    consoleLogs.forEach(log => console.log(log));
+    consoleLogs.forEach((log) => console.log(log));
     console.log("=============================================\n");
   });
 });

--- a/tests/e2e/prompt-randomizer.spec.ts
+++ b/tests/e2e/prompt-randomizer.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 const SERVER_PORT = process.env.SERVER_PORT || "4000";

--- a/tests/e2e/random-page.spec.ts
+++ b/tests/e2e/random-page.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Random Page Navigation", () => {
   test("should redirect from /random to a content page", async ({ page }) => {

--- a/tests/e2e/redirect-url.spec.ts
+++ b/tests/e2e/redirect-url.spec.ts
@@ -1,29 +1,29 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Modal.run Redirect URL Generation", () => {
   test("makeRedirectUrl function should be available and generate correct URLs", async ({ page }) => {
     // Navigate to any page that loads the shared.ts module
     await page.goto("/");
-    
+
     // Wait for the page to load
     await page.waitForLoadState("networkidle");
-    
+
     // Test the makeRedirectUrl function via console
     const result = await page.evaluate(() => {
       // Check if the function exists in the global scope
       // Note: This assumes the function is exposed globally or we can import it
       // In a real scenario, we might need to expose it via window object
-      if (typeof window.makeRedirectUrl === 'function') {
+      if (typeof window.makeRedirectUrl === "function") {
         return {
           exists: true,
           test1: window.makeRedirectUrl("timeoff"),
           test2: window.makeRedirectUrl("timeoff", "very-vegetating"),
-          test3: window.makeRedirectUrl("page", "section", false)
+          test3: window.makeRedirectUrl("page", "section", false),
         };
       }
       return { exists: false, message: "Function not exposed to window" };
     });
-    
+
     // For now, we just verify the module loads without errors
     // In a full implementation, we'd expose the function to window for testing
     expect(result).toBeDefined();
@@ -32,27 +32,27 @@ test.describe("Modal.run Redirect URL Generation", () => {
   test("page should load without JavaScript errors when using shared module", async ({ page }) => {
     // Listen for any JavaScript errors (not console.log messages)
     const errors: string[] = [];
-    
+
     // Known warnings that shouldn't fail the test
     const warningPatterns = [
       /Cannot read properties of null \(reading 'classList'\)/,
       /ResizeObserver loop limit exceeded/,
     ];
-    
-    page.on('pageerror', error => {
+
+    page.on("pageerror", (error) => {
       // Only track as error if it's not a known warning
-      const isWarning = warningPatterns.some(pattern => pattern.test(error.message));
+      const isWarning = warningPatterns.some((pattern) => pattern.test(error.message));
       if (!isWarning) {
         errors.push(error.message);
       }
     });
-    
+
     // Navigate to the main page
     await page.goto("/");
-    
+
     // Wait for the page to fully load
     await page.waitForLoadState("networkidle");
-    
+
     // Check that no critical errors occurred
     expect(errors).toHaveLength(0);
   });
@@ -60,14 +60,14 @@ test.describe("Modal.run Redirect URL Generation", () => {
   test("should be able to use makeRedirectUrl in header copy functionality", async ({ page }) => {
     // Navigate to a page with headers
     await page.goto("/timeoff");
-    
+
     // Wait for the page to load
     await page.waitForLoadState("networkidle");
-    
+
     // Check that headers are present and copy icons work
     const headers = await page.locator("h2, h3, h4").count();
     expect(headers).toBeGreaterThan(0);
-    
+
     // Verify the page loads without errors
     const pageTitle = await page.title();
     expect(pageTitle).toBeTruthy();

--- a/tests/e2e/search-empty-check.spec.ts
+++ b/tests/e2e/search-empty-check.spec.ts
@@ -1,55 +1,55 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Homepage initial load experience", () => {
   test("should show content immediately on page load", async ({ page }) => {
     // Navigate to homepage
     await page.goto("/");
-    
+
     // Check if sections have any visible content immediately (no waiting)
     const featuredContent = await page.locator("#featured-results .result-item").count();
     const recentContent = await page.locator("#recent-results .result-item").count();
     const randomContent = await page.locator("#random-results .result-item").count();
-    
+
     console.log("Initial content counts:");
     console.log("Featured:", featuredContent);
     console.log("Recent:", recentContent);
     console.log("Random:", randomContent);
-    
+
     // At least one section should have content or loading indicator immediately
     const hasAnyContent = featuredContent > 0 || recentContent > 0 || randomContent > 0;
-    
+
     if (!hasAnyContent) {
       // Check if there are loading indicators
       const loadingIndicators = await page.locator(".result-item:has-text('Loading')").count();
       console.log("Loading indicators:", loadingIndicators);
-      
+
       expect(loadingIndicators).toBeGreaterThan(0);
     }
   });
 
   test("visual check - page should not appear empty", async ({ page }) => {
     await page.goto("/");
-    
+
     // Take screenshot immediately
-    await page.screenshot({ 
+    await page.screenshot({
       path: "/home/developer/gits/idvorkin.github.io/repo_tmp/initial-load.png",
-      fullPage: false 
+      fullPage: false,
     });
-    
+
     // Check what's visible in the viewport
     const resultsContainer = page.locator("#results-container");
     const boundingBox = await resultsContainer.boundingBox();
-    
+
     if (boundingBox) {
       console.log("Results container height:", boundingBox.height);
       // Container should have some height (not collapsed)
       expect(boundingBox.height).toBeGreaterThan(50);
     }
-    
+
     // Count any visible text immediately
     const visibleText = await page.locator("#results-container").textContent();
     console.log("Visible text length:", visibleText?.length);
-    
+
     // Should have more than just headers
     expect(visibleText?.length).toBeGreaterThan(100);
   });

--- a/tests/e2e/search-redirect.spec.ts
+++ b/tests/e2e/search-redirect.spec.ts
@@ -1,67 +1,67 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from "./base-test";
 
-test.describe('Search Redirect', () => {
+test.describe("Search Redirect", () => {
   test('pressing "s" key should redirect to main search page', async ({ page }) => {
     // Go to any page on the site that's not the main page
-    await page.goto('/about');
-    
+    await page.goto("/about");
+
     // Press the 's' key
-    await page.keyboard.press('s');
-    
+    await page.keyboard.press("s");
+
     // Should redirect to the main page
-    await expect(page).toHaveURL('/');
-    
+    await expect(page).toHaveURL("/");
+
     // The search input should be visible
-    const searchInput = page.locator('#search-input');
+    const searchInput = page.locator("#search-input");
     await expect(searchInput).toBeVisible();
   });
 
-  test('clicking bunny ears icon should redirect to main search page', async ({ page }) => {
+  test("clicking bunny ears icon should redirect to main search page", async ({ page }) => {
     // Go to any page on the site that's not the main page
-    await page.goto('/about');
-    
+    await page.goto("/about");
+
     // Click the bunny ears icon (logo)
-    await page.click('#autocomplete-search-box-button');
-    
+    await page.click("#autocomplete-search-box-button");
+
     // Should redirect to the main page
-    await expect(page).toHaveURL('/');
-    
+    await expect(page).toHaveURL("/");
+
     // The search input should be visible
-    const searchInput = page.locator('#search-input');
+    const searchInput = page.locator("#search-input");
     await expect(searchInput).toBeVisible();
   });
 
-  test('search functionality on main page works', async ({ page }) => {
+  test("search functionality on main page works", async ({ page }) => {
     // Go to the main page
-    await page.goto('/');
-    
+    await page.goto("/");
+
     // The search input should be visible
-    const searchInput = page.locator('#search-input');
+    const searchInput = page.locator("#search-input");
     await expect(searchInput).toBeVisible();
-    
+
     // Type in the search box
-    await searchInput.fill('test search');
-    
+    await searchInput.fill("test search");
+
     // Wait a moment for search to trigger
     await page.waitForTimeout(500);
-    
+
     // Search results should appear (featured posts section should have results)
-    const featuredResults = page.locator('#featured-results');
+    const featuredResults = page.locator("#featured-results");
     await expect(featuredResults).toBeVisible();
   });
 
   test('pressing "s" on main page keeps user on main page', async ({ page }) => {
     // Go to the main page
-    await page.goto('/');
-    
+    await page.goto("/");
+
     // Press the 's' key
-    await page.keyboard.press('s');
-    
+    await page.keyboard.press("s");
+
     // Should stay on the main page (no redirect)
-    await expect(page).toHaveURL('/');
-    
+    await expect(page).toHaveURL("/");
+
     // The search input should still be visible
-    const searchInput = page.locator('#search-input');
+    const searchInput = page.locator("#search-input");
     await expect(searchInput).toBeVisible();
   });
 });

--- a/tests/e2e/search-ux-visual.spec.ts
+++ b/tests/e2e/search-ux-visual.spec.ts
@@ -1,58 +1,58 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Search page UX verification", () => {
   test("page should never appear empty during load", async ({ page }) => {
     // Slow down network to simulate real-world conditions
-    await page.route('**/*', route => {
+    await page.route("**/*", (route) => {
       setTimeout(() => route.continue(), 100);
     });
-    
+
     await page.goto("/");
-    
+
     // Take screenshots at different intervals
     const timestamps = [0, 100, 300, 500, 1000];
-    
+
     for (const delay of timestamps) {
       if (delay > 0) await page.waitForTimeout(delay);
-      
+
       // Check visible content
       const visibleContent = await page.locator("#results-container").textContent();
       console.log(`At ${delay}ms: ${visibleContent?.substring(0, 100)}...`);
-      
+
       // Should always have some text visible (placeholders or content)
       expect(visibleContent?.length).toBeGreaterThan(50);
-      
-      await page.screenshot({ 
+
+      await page.screenshot({
         path: `/home/developer/gits/idvorkin.github.io/repo_tmp/load-${delay}ms.png`,
-        fullPage: false 
+        fullPage: false,
       });
     }
   });
-  
+
   test("clean UI with integrated actions", async ({ page }) => {
     await page.goto("/");
     await page.waitForTimeout(2000); // Let everything load
-    
+
     // Verify the clean header structure
     const recentHeader = page.locator("#recent-section .section-header");
     await expect(recentHeader).toContainText("Recent");
     await expect(recentHeader).toContainText("View all");
-    
+
     const randomHeader = page.locator("#random-section .section-header");
     await expect(randomHeader).toContainText("Random");
     await expect(randomHeader).toContainText("Refresh");
-    
+
     // Verify no duplicate action links in content
     const recentDuplicates = await page.locator("#recent-results a:has-text('View all')").count();
     expect(recentDuplicates).toBe(0);
-    
+
     const randomDuplicates = await page.locator("#random-results a:has-text('Load new')").count();
     expect(randomDuplicates).toBe(0);
-    
+
     // Take final screenshot
-    await page.screenshot({ 
-      path: `/home/developer/gits/idvorkin.github.io/repo_tmp/final-ui.png`,
-      fullPage: true 
+    await page.screenshot({
+      path: "/home/developer/gits/idvorkin.github.io/repo_tmp/final-ui.png",
+      fullPage: true,
     });
   });
 });

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 test.describe("Homepage search functionality", () => {
@@ -10,11 +10,11 @@ test.describe("Homepage search functionality", () => {
     // Check that the search input exists
     const searchInput = page.locator("#search-input");
     await expect(searchInput).toBeVisible();
-    
+
     // Check placeholder text
     await expect(searchInput).toHaveAttribute(
       "placeholder",
-      "Search Igor's Blog, or browse featured/recent/random posts below..."
+      "Search Igor's Blog, or browse featured/recent/random posts below...",
     );
   });
 
@@ -23,21 +23,21 @@ test.describe("Homepage search functionality", () => {
     await expect(page.locator("#featured-section .section-header h3")).toContainText("Featured");
     await expect(page.locator("#recent-section .section-header h3")).toContainText("Recent");
     await expect(page.locator("#random-section .section-header h3")).toContainText("Random");
-    
+
     // Check action links are visible
     await expect(page.locator("#recent-section .action-link")).toContainText("View all");
     await expect(page.locator("#random-section .action-link")).toContainText("Refresh");
-    
+
     // Wait for lazy loading to complete
     await page.waitForTimeout(1000);
-    
+
     // Check that each section has content (now just posts, no extra links)
     const featuredItems = page.locator("#featured-results .result-item");
     await expect(featuredItems).toHaveCount(3);
-    
+
     const recentItems = page.locator("#recent-results .result-item");
     await expect(recentItems).toHaveCount(4); // 4 posts now
-    
+
     const randomItems = page.locator("#random-results .result-item");
     await expect(randomItems).toHaveCount(4); // 4 posts now
   });
@@ -46,13 +46,13 @@ test.describe("Homepage search functionality", () => {
     // Type in the search box
     const searchInput = page.locator("#search-input");
     await searchInput.fill("eulogy");
-    
+
     // Wait for search results to appear
     await page.waitForTimeout(500);
-    
+
     // Check that featured section title changes to search results
     await expect(page.locator("#featured-section .section-header h3")).toContainText("Search Results");
-    
+
     // Check that there are some results
     const searchResults = page.locator("#featured-results .result-item");
     const count = await searchResults.count();
@@ -63,10 +63,10 @@ test.describe("Homepage search functionality", () => {
     // Type nonsense in the search box
     const searchInput = page.locator("#search-input");
     await searchInput.fill("xyzabc123nonsense");
-    
+
     // Wait for search to complete
     await page.waitForTimeout(500);
-    
+
     // Check that it shows no results message
     await expect(page.locator("#featured-results")).toContainText("No results found");
   });
@@ -76,11 +76,11 @@ test.describe("Homepage search functionality", () => {
     const searchInput = page.locator("#search-input");
     await searchInput.fill("test");
     await page.waitForTimeout(500);
-    
+
     // Clear the search
     await searchInput.clear();
     await page.waitForTimeout(500);
-    
+
     // Check that original sections are restored
     await expect(page.locator("#featured-section .section-header h3")).toContainText("Featured");
     await expect(page.locator("#recent-section .section-header h3")).toContainText("Recent");
@@ -90,11 +90,11 @@ test.describe("Homepage search functionality", () => {
   test("Mobile view has compact spacing", async ({ page }) => {
     // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
-    
+
     // Check that search input is visible
     const searchInput = page.locator("#search-input");
     await expect(searchInput).toBeVisible();
-    
+
     // Check that sections are visible
     await expect(page.locator("#featured-section")).toBeVisible();
     await expect(page.locator("#recent-section")).toBeVisible();
@@ -106,27 +106,26 @@ test.describe("Homepage search functionality", () => {
   });
 
   test("Random posts can be refreshed", async ({ page }) => {
-    // Wait for initial load
-    await page.waitForTimeout(1000);
-    
+    // Wait for random posts to actually load (not just timeout)
+    await page.waitForSelector("#random-results .result-item a", { timeout: 5000 });
+    await expect(page.locator("#random-results .result-item")).toHaveCount(4);
+
     // Get initial random post titles
     const initialPosts = await page.locator("#random-results .result-item a").allTextContents();
-    const initialTitles = initialPosts.slice(0, 4); // All 4 are posts now
-    
+    const initialTitles = initialPosts.slice(0, 4);
+
     // Click the refresh button in the header
     const refreshButton = page.locator("#random-section .action-link");
     await refreshButton.click();
-    
-    // Wait for new posts to load
-    await page.waitForTimeout(1000);
-    
+
+    // Wait for content to change (the innerHTML will be replaced)
+    await page.waitForSelector("#random-results .result-item a", { timeout: 5000 });
+    await expect(page.locator("#random-results .result-item")).toHaveCount(4);
+
     // Get new random post titles
     const newPosts = await page.locator("#random-results .result-item a").allTextContents();
     const newTitles = newPosts.slice(0, 4);
-    
-    // Check that we still have 4 items
-    await expect(page.locator("#random-results .result-item")).toHaveCount(4);
-    
+
     // Verify that at least one post is different (very unlikely to get same 4 random posts)
     const hasChanged = initialTitles.some((title, index) => title !== newTitles[index]);
     expect(hasChanged).toBeTruthy();
@@ -135,16 +134,16 @@ test.describe("Homepage search functionality", () => {
   test("Recent posts link navigates to recent page", async ({ page }) => {
     // Wait for initial load
     await page.waitForTimeout(1000);
-    
+
     // Find and click the "View all" link in the header
     const recentLink = page.locator("#recent-section .action-link");
     await expect(recentLink).toBeVisible();
     await expect(recentLink).toContainText("View all");
-    
+
     // Click should navigate to /recent
     await recentLink.click();
     await page.waitForURL("**/recent");
-    
+
     // Verify we're on the recent page
     expect(page.url()).toContain("/recent");
     await expect(page.locator("h1")).toContainText("Recently Modified Content");
@@ -153,19 +152,19 @@ test.describe("Homepage search functionality", () => {
   test("Lazy loading shows loading state", async ({ page }) => {
     // Navigate to page and immediately check for loading states
     await page.goto("/");
-    
+
     // At least one section should show "Loading..." initially
     const loadingStates = await page.locator(".result-item").filter({ hasText: "Loading..." }).count();
-    
+
     // If IntersectionObserver is supported, we should see loading states
     // Note: This test might be flaky if content loads too fast
     if (loadingStates > 0) {
       expect(loadingStates).toBeGreaterThanOrEqual(1);
     }
-    
+
     // Wait for content to load
     await page.waitForTimeout(1500);
-    
+
     // No loading states should remain
     const remainingLoadingStates = await page.locator(".result-item").filter({ hasText: "Loading..." }).count();
     expect(remainingLoadingStates).toBe(0);
@@ -174,24 +173,24 @@ test.describe("Homepage search functionality", () => {
   test("Search hides recent and random sections", async ({ page }) => {
     // Wait for initial load
     await page.waitForTimeout(1000);
-    
+
     // Verify sections are initially visible
     await expect(page.locator("#recent-section")).toBeVisible();
     await expect(page.locator("#random-section")).toBeVisible();
-    
+
     // Perform a search
     const searchInput = page.locator("#search-input");
     await searchInput.fill("test");
     await page.waitForTimeout(500);
-    
+
     // Verify recent and random sections are hidden during search
     await expect(page.locator("#recent-section")).not.toBeVisible();
     await expect(page.locator("#random-section")).not.toBeVisible();
-    
+
     // Clear search
     await searchInput.clear();
     await page.waitForTimeout(500);
-    
+
     // Verify sections are visible again
     await expect(page.locator("#recent-section")).toBeVisible();
     await expect(page.locator("#random-section")).toBeVisible();
@@ -200,22 +199,22 @@ test.describe("Homepage search functionality", () => {
   test("Sections load in parallel", async ({ page }) => {
     // Clear browser cache to ensure fresh load
     await page.context().clearCookies();
-    
+
     // Start timing
     const startTime = Date.now();
-    
+
     // Navigate to page
     await page.goto("/");
-    
+
     // Wait for all sections to have content
     await Promise.all([
       page.waitForSelector("#featured-results .result-item", { timeout: 5000 }),
       page.waitForSelector("#recent-results .result-item", { timeout: 5000 }),
-      page.waitForSelector("#random-results .result-item", { timeout: 5000 })
+      page.waitForSelector("#random-results .result-item", { timeout: 5000 }),
     ]);
-    
+
     const loadTime = Date.now() - startTime;
-    
+
     // If sections load in parallel, total time should be less than sequential loading would take
     // This is a rough check - parallel loading should be faster than 3x the slowest section
     expect(loadTime).toBeLessThan(5000);

--- a/tests/e2e/sidebar-toc.spec.ts
+++ b/tests/e2e/sidebar-toc.spec.ts
@@ -1,133 +1,135 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from "./base-test";
 
-test.describe('Sidebar TOC rendering', () => {
-  test('sidebar TOC entries should have normal spacing without icon text', async ({ page }) => {
-    await page.goto('http://localhost:4000/eulogy');
-    
+test.describe("Sidebar TOC rendering", () => {
+  test("sidebar TOC entries should have normal spacing without icon text", async ({ page }) => {
+    await page.goto("http://localhost:4000/eulogy");
+
     // Wait for sidebar to be visible
-    await page.waitForSelector('#right-sidebar', { timeout: 5000 });
-    
+    await page.waitForSelector("#right-sidebar", { timeout: 5000 });
+
     // Wait for TOC to be generated
-    await page.waitForSelector('#ui-toc-affix li', { timeout: 5000 });
-    
+    await page.waitForSelector("#ui-toc-affix li", { timeout: 5000 });
+
     // Get all sidebar TOC entries
-    const tocEntries = await page.locator('#ui-toc-affix li').all();
-    
+    const tocEntries = await page.locator("#ui-toc-affix li").all();
+
     // Verify we have TOC entries
     expect(tocEntries.length).toBeGreaterThan(0);
-    
+
     // Check that TOC entries have reasonable height (not inflated by icon content)
     for (let i = 0; i < Math.min(3, tocEntries.length); i++) {
       const entry = tocEntries[i];
       const box = await entry.boundingBox();
-      
+
       // Normal TOC entries should be between 20-40px tall
       // The bug caused them to be 144px+ tall
       expect(box?.height).toBeLessThan(50);
       expect(box?.height).toBeGreaterThan(15);
     }
-    
+
     // Check that TOC link text doesn't contain SVG path data or extra whitespace
-    const firstLink = await page.locator('#ui-toc-affix li a').first();
+    const firstLink = await page.locator("#ui-toc-affix li a").first();
     const linkText = await firstLink.textContent();
-    const linkTitle = await firstLink.getAttribute('title');
-    
+    const linkTitle = await firstLink.getAttribute("title");
+
     // Text should be clean without SVG artifacts
-    expect(linkText).not.toContain('M8 2'); // SVG path data
+    expect(linkText).not.toContain("M8 2"); // SVG path data
     expect(linkText).not.toMatch(/\n\s+\n/); // Multiple newlines with spaces
-    
+
     // Title attribute should also be clean
-    expect(linkTitle).not.toContain('M8 2');
+    expect(linkTitle).not.toContain("M8 2");
     expect(linkTitle).not.toMatch(/\n\s+\n/);
-    
+
     // Verify the text is trimmed properly
     expect(linkText?.trim()).toBe(linkText);
     expect(linkTitle?.trim()).toBe(linkTitle);
   });
 
-  test('TOC should exclude header icons but include other inline elements', async ({ page }) => {
+  test("TOC should exclude header icons but include other inline elements", async ({ page }) => {
     // Create a test page with various header types
-    await page.goto('http://localhost:4000/7h');
-    
+    await page.goto("http://localhost:4000/7h");
+
     // Wait for TOC
-    await page.waitForSelector('#ui-toc-affix', { timeout: 5000 });
-    
+    await page.waitForSelector("#ui-toc-affix", { timeout: 5000 });
+
     // Check that headers with icons still appear in TOC
-    const tocLinks = await page.locator('#ui-toc-affix a').all();
+    const tocLinks = await page.locator("#ui-toc-affix a").all();
     expect(tocLinks.length).toBeGreaterThan(0);
-    
+
     // Get the headers on the page that have icons
-    const headersWithIcons = await page.locator('h1 .header-copy-link, h2 .header-copy-link, h3 .header-copy-link').count();
-    
+    const headersWithIcons = await page
+      .locator("h1 .header-copy-link, h2 .header-copy-link, h3 .header-copy-link")
+      .count();
+
     if (headersWithIcons > 0) {
       // If there are headers with icons, verify TOC entries don't contain icon text
       for (const link of tocLinks.slice(0, 3)) {
         const text = await link.textContent();
-        expect(text).not.toContain('Share this section');
-        expect(text).not.toContain('Create GitHub issue');
+        expect(text).not.toContain("Share this section");
+        expect(text).not.toContain("Create GitHub issue");
       }
     }
   });
 
-  test('TOC links should navigate to correct sections', async ({ page }) => {
-    await page.goto('http://localhost:4000/eulogy');
-    
+  test("TOC links should navigate to correct sections", async ({ page }) => {
+    await page.goto("http://localhost:4000/eulogy");
+
     // Wait for TOC
-    await page.waitForSelector('#ui-toc-affix a', { timeout: 5000 });
-    
+    await page.waitForSelector("#ui-toc-affix a", { timeout: 5000 });
+
     // Get first TOC link
-    const firstLink = await page.locator('#ui-toc-affix a').first();
-    const href = await firstLink.getAttribute('href');
+    const firstLink = await page.locator("#ui-toc-affix a").first();
+    const href = await firstLink.getAttribute("href");
     const linkText = await firstLink.textContent();
-    
+
     // Click the link
     await firstLink.click();
-    
+
     // Verify navigation - the URL should update with the hash
     await expect(page).toHaveURL(new RegExp(`.*${href}$`));
-    
+
     // Verify the target header exists and matches the TOC text
     if (href) {
       const targetHeader = await page.locator(href);
       await expect(targetHeader).toBeVisible();
-      
+
       // Get the header text excluding icons
       const headerText = await targetHeader.evaluate((el) => {
         // Extract only text nodes and non-icon element text
         const textParts: string[] = [];
         for (const node of el.childNodes) {
           if (node.nodeType === Node.TEXT_NODE) {
-            textParts.push(node.textContent || '');
+            textParts.push(node.textContent || "");
           } else if (
             node.nodeType === Node.ELEMENT_NODE &&
-            !(node as HTMLElement).classList.contains('header-copy-link') &&
-            !(node as HTMLElement).classList.contains('header-github-issue')
+            !(node as HTMLElement).classList.contains("header-copy-link") &&
+            !(node as HTMLElement).classList.contains("header-github-issue")
           ) {
-            textParts.push(node.textContent || '');
+            textParts.push(node.textContent || "");
           }
         }
-        return textParts.join('').trim();
+        return textParts.join("").trim();
       });
-      
+
       expect(headerText).toBe(linkText?.trim());
     }
   });
 
-  test('TOC should update when navigating between pages', async ({ page }) => {
+  test("TOC should update when navigating between pages", async ({ page }) => {
     // Start on one page
-    await page.goto('http://localhost:4000/eulogy');
-    await page.waitForSelector('#ui-toc-affix a', { timeout: 5000 });
-    
-    const eulogyFirstLink = await page.locator('#ui-toc-affix a').first();
+    await page.goto("http://localhost:4000/eulogy");
+    await page.waitForSelector("#ui-toc-affix a", { timeout: 5000 });
+
+    const eulogyFirstLink = await page.locator("#ui-toc-affix a").first();
     const eulogyFirstText = await eulogyFirstLink.textContent();
-    
+
     // Navigate to a different page
-    await page.goto('http://localhost:4000/7h');
-    await page.waitForSelector('#ui-toc-affix a', { timeout: 5000 });
-    
-    const habitsFirstLink = await page.locator('#ui-toc-affix a').first();
+    await page.goto("http://localhost:4000/7h");
+    await page.waitForSelector("#ui-toc-affix a", { timeout: 5000 });
+
+    const habitsFirstLink = await page.locator("#ui-toc-affix a").first();
     const habitsFirstText = await habitsFirstLink.textContent();
-    
+
     // TOC content should be different between pages
     expect(eulogyFirstText).not.toBe(habitsFirstText);
   });

--- a/tests/e2e/sitenav.spec.ts
+++ b/tests/e2e/sitenav.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 test.describe("Site Navigation", () => {

--- a/tests/e2e/test-7-habits.spec.ts
+++ b/tests/e2e/test-7-habits.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 test.describe("7 habits", () => {

--- a/tests/e2e/test-auto-sunburst.spec.ts
+++ b/tests/e2e/test-auto-sunburst.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Auto-generated Sunburst", () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/e2e/test-include-amazon.spec.ts
+++ b/tests/e2e/test-include-amazon.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Amazon Include Test Page", () => {
   test("should take screenshot of full page", async ({ page }) => {

--- a/tests/e2e/todo-enjoy-path-click.spec.ts
+++ b/tests/e2e/todo-enjoy-path-click.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Sunburst path element clicks", () => {
   test("Clicking sunburst text div can trigger prompt change", async ({ page }) => {
@@ -26,17 +26,17 @@ test.describe("Sunburst path element clicks", () => {
     await page.waitForTimeout(500);
 
     let newText = await promptElement.textContent();
-    
+
     // If text didn't change from clicking the div, try clicking a path element
     if (newText?.trim() === initialText?.trim()) {
       const pathElements = page.locator("#sunburst path");
       const pathCount = await pathElements.count();
-      
+
       // Try clicking different path elements until we find one that triggers a change
       for (let i = 1; i < Math.min(pathCount, 5); i++) {
         await pathElements.nth(i).click({ force: true });
         await page.waitForTimeout(500);
-        
+
         newText = await promptElement.textContent();
         if (newText?.trim() !== initialText?.trim()) {
           break; // Found a path that triggers a change
@@ -91,9 +91,9 @@ test.describe("Sunburst path element clicks", () => {
     // Test passes if we could click multiple elements without errors
     // The texts may or may not change depending on whether prompts are available
     expect(texts.length).toBeGreaterThan(0);
-    
+
     // Log for debugging but don't fail if all texts are the same
-    if (texts.every(t => t === "Click in any box or circle")) {
+    if (texts.every((t) => t === "Click in any box or circle")) {
       console.log("Note: All clicks resulted in the same text - might be due to no prompts for clicked elements");
     }
   });

--- a/tests/e2e/todo-enjoy.spec.ts
+++ b/tests/e2e/todo-enjoy.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 import { checkForJsErrors } from "./js-error-checker";
 
 test.describe("Things I enjoy page", () => {
@@ -106,15 +106,15 @@ test.describe("Things I enjoy page", () => {
     // Try clicking on different path elements to trigger prompt changes
     const pathElements = page.locator("#sunburst path");
     const pathCount = await pathElements.count();
-    
+
     let textChanged = false;
     let lastText = originalText;
-    
+
     // Try clicking different paths to find one that has prompts
     for (let i = 1; i < Math.min(pathCount, 10); i++) {
       await pathElements.nth(i).click({ force: true });
       await page.waitForTimeout(500);
-      
+
       const newText = await promptElement.textContent();
       if (newText?.trim() !== lastText?.trim() && newText?.trim() !== "Click in any box or circle") {
         textChanged = true;
@@ -122,13 +122,13 @@ test.describe("Things I enjoy page", () => {
         break;
       }
     }
-    
+
     // If we found a path with prompts, try to verify randomization
     if (textChanged) {
       // Click the same path again to see if it randomizes
       await promptElement.click();
       await page.waitForTimeout(500);
-      
+
       const secondText = await promptElement.textContent();
       // It might give the same prompt sometimes, so we just verify it's still a valid prompt
       expect(secondText).toBeTruthy();
@@ -137,7 +137,7 @@ test.describe("Things I enjoy page", () => {
       // No prompts available is also a valid state
       console.log("Note: No prompts available for clicked elements - this is acceptable");
     }
-    
+
     // Test passes either way - with or without prompt changes
     expect(true).toBe(true);
   });

--- a/tests/e2e/vapi-widget.spec.ts
+++ b/tests/e2e/vapi-widget.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("Vapi Widget on Tesla Page", () => {
   test("should load Vapi widget script and render widget element", async ({ page }) => {

--- a/tests/e2e/verify-irl-keyboards.spec.ts
+++ b/tests/e2e/verify-irl-keyboards.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./base-test";
 
 test.describe("IRL Page Keyboards Section", () => {
   test("should take screenshot of keyboard products", async ({ page }) => {


### PR DESCRIPTION
## Summary
- **Root cause**: Jekyll LiveReload sends WebSocket reload commands during test runs (triggered by file writes like `playwright-report/`), destroying Playwright execution contexts mid-test
- **Fix**: Created `base-test.ts` fixture that blocks LiveReload at the network level via `page.route()`, updated all 31 test files to use it
- **Also fixed**: "Random posts can be refreshed" test used fragile `waitForTimeout` instead of `waitForSelector`, causing flaky failures under load
- Added `playwright-report` to Jekyll's exclude list to reduce unnecessary rebuilds

## Test plan
- [x] All 20 search tests pass consistently (`npx playwright test tests/e2e/search*.spec.ts`)
- [x] Pre-commit hooks pass (Biome, Vitest, typo checks)
- [x] No changes to production code — only test infrastructure and `_config.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure stability by implementing a custom base test setup that prevents LiveReload interruptions during automated testing.
  * Standardized test code formatting and imports across the entire test suite for consistency.

* **Chores**
  * Updated build configuration to exclude test reports from the build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->