### PR TITLE
Fix infinite Jekyll rebuild loop

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -115,6 +115,10 @@ exclude:
     "src/__tests__",
     "repo_tmp",
     ".beads",
+    ".claude",
+    ".uv-cache",
+    ".playwright-cli",
+    "__pycache__",
   ]
 
 permalink: /:title


### PR DESCRIPTION
## Summary

- Add `.claude`, `.uv-cache`, `.playwright-cli`, `__pycache__` to Jekyll exclude list
- **Root cause**: `.claude/worktrees/` contains 2 full repo clones (4,537 files) and `.uv-cache/` has symlink loops that corrupt the Listen gem's internal state, triggering phantom change events every ~2 seconds
- The server on port 4003 has burned ~11 hours of CPU since Feb 22 due to continuous rebuilds
- Server restart needed after merge for the fix to take effect

## Test plan

- [ ] Merge and restart Jekyll server
- [ ] Confirm `.jekyll-metadata` stops updating every 2s
- [ ] Verify page no longer auto-refreshes in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)