### PR TITLE
Add 'Should I Become an EM?' section and ai-feed entry

### DIFF
--- a/_d/ai-feed.md
+++ b/_d/ai-feed.md
@@ -20,6 +20,15 @@ It's [GTD](/gtd) capture meets AI triage. And unlike passive consumption, this p
 
 ## Feed
 
+### 2026-03-04
+
+- **[Don't Become an Engineering Manager](https://newsletter.manager.dev/p/dont-become-an-engineering-manager)** — Anton Zaides on why the EM career path no longer makes sense
+  - _Summary_: Zaides argues that senior engineers should no longer pursue management roles — rapid tech change makes it hard for managers to stay current, flattened orgs mean fewer senior management positions, and Staff engineers now earn 20-30% more than EMs. He reverses his previous advice, positioning the IC track as more rational, though acknowledges genuine interest in management work should still outweigh financial optimization.
+  - _Why Randy thinks I'd like it_: Management/leadership in AI era — directly relevant to your ai-native-manager post. Contrarian reversal from someone who previously advocated for the EM path.
+  - _Cross-links_: [AI Native Manager](/ai-native-manager), [Manager Book](/manager-book), [Software Leadership Roles](/software-leadership-roles)
+  - _Tags_: #management #contrarian #career
+  - _Reaction_: This is good. These are the reasons — the only reason to be an EM is because you want to. Adding to "Should I become an EM?" on the AI native EM post.
+
 ### 2026-03-01
 
 _Source: [Joy & Curiosity #76](https://registerspill.thorstenball.com/p/joy-and-curiosity-76) by Thorsten Ball_

--- a/_d/ai-native-manager.md
+++ b/_d/ai-native-manager.md
@@ -41,6 +41,7 @@ What does it mean to be an engineering manager when AI is rewriting every assump
 - [Appendix: Hot Takes](#appendix-hot-takes)
   - [Should XFN Code?](#should-xfn-code)
 - [Appendix: Old Questions, New Answers](#appendix-old-questions-new-answers)
+  - [Should I Become an EM?](#should-i-become-an-em)
   - [How Should Hiring Change?](#how-should-hiring-change)
   - [Should EMs Code?](#should-ems-code)
 
@@ -242,6 +243,16 @@ In the [old world](/manager-book#should-managers-code), my answer was: read code
 With AI, an EM can vibe-code a prototype in an afternoon that would have taken a week to spec and assign. You can build team tools, automate toil, and stay closer to the technical reality. The cost of coding dropped so much that the old "you can't afford to code, you have people to manage" calculus is different now.
 
 But the trap is real: if you're vibe-coding all day, you're not managing. The AI Vampire doesn't care about your title. You can burn out just as fast as your ICs, and then who's looking out for them?
+
+### Should I Become an EM?
+
+In the old world, the answer was nuanced — it depends on what you want, what you're good at, the [usual trade-offs](/software-leadership-roles). AI changes the calculus significantly.
+
+The financial case is gone. Staff engineers now earn 20-30% more than EMs. The career ladder is shorter — flattened orgs mean fewer senior management positions. And the technical relevance half-life is brutal: the further you drift from the code, the faster the AI landscape leaves you behind.
+
+So why do it? One reason: because you genuinely want to help people build effectively. That's it. Not for the title, not for the comp, not because it's the "next step." If you're becoming an EM because you think it's a promotion, [don't](https://newsletter.manager.dev/p/dont-become-an-engineering-manager). The IC track is objectively better for most people right now.
+
+But if you're the person who lights up when someone on your team has a breakthrough? If you can't stop thinking about how to make the team better as a system? Then the role is still there, and it still matters — maybe more than ever, because helping humans navigate the AI chasm is genuinely hard, important work.
 
 ### How Should Hiring Change?
 


### PR DESCRIPTION
## Summary
- Curated Anton Zaides' "Don't become an Engineering Manager" into ai-feed with reaction
- Added new "Should I Become an EM?" section to ai-native-manager post — argues the only valid reason is genuine desire to help people build effectively
- Cross-linked between ai-feed entry and ai-native-manager

## Test plan
- [ ] Verify ai-feed entry renders correctly at /ai-feed
- [ ] Verify new section appears in /ai-native-manager TOC and body
- [ ] Check cross-links resolve (/manager-book, /software-leadership-roles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new feed entry highlighting "Don't Become an Engineering Manager" with curated metadata.
  * Added comprehensive section on engineering manager career considerations, including financial implications, career ladder impact, and guidance on when the role remains valuable in an AI-driven landscape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->