### PR TITLE
Warm up share links and fix pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged
+prek run --hook-stage pre-commit

--- a/src/header-copy-link.ts
+++ b/src/header-copy-link.ts
@@ -410,6 +410,9 @@ async function shareOrCopyHeaderLink(headerId: string, options: CopyLinkOptions)
       shareText = `From: ${breadcrumbFrom} ...\n\n${previewText}`;
     }
 
+    // Fire-and-forget: warm up the redirect chain so it loads fast for the recipient
+    fetch(tinyUrl).catch(() => {});
+
     // Check if this is a mobile device
     const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 


### PR DESCRIPTION
## Summary

- **Warm up share URLs**: After copying/sharing a header link, fires a background `fetch()` to the tinyurl redirect chain so the Azure destination is already warm when the recipient clicks
- **Fix pre-commit hook**: Replace broken husky/lint-staged hook (no lint-staged config existed) with `prek run` which uses the existing `.pre-commit-config.yaml`

## Test plan

- [x] All 32 header-copy-link tests pass
- [x] Pre-commit hooks run successfully (Biome, Vitest, typo check all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)