### PR TITLE
Add Heresies, Infinite Loop, and Loop terms to AI native EM

### DIFF
--- a/_d/ai-native-manager.md
+++ b/_d/ai-native-manager.md
@@ -41,6 +41,9 @@ What does it mean to be an engineering manager when AI is rewriting every assump
   - [AI Cockpit](#ai-cockpit)
   - [Cognitive Debt](#cognitive-debt)
   - [Deep Blue](#deep-blue)
+  - [Heresies](#heresies)
+  - [Infinite Loop](#infinite-loop)
+  - [Human In, On, and Out of the Loop](#human-in-on-and-out-of-the-loop)
 - [Appendix: Hot Takes](#appendix-hot-takes)
   - [Should XFN Code?](#should-xfn-code)
 - [Appendix: Old Questions, New Answers](#appendix-old-questions-new-answers)
@@ -244,6 +247,48 @@ The good news: the same AI that creates cognitive debt can pay it down. Willison
 My take: this is the emotion underneath the [Fear](#the-ai-chasm-assessment-and-adoption-stages) stage. When someone on your team is stuck in Fear, they're probably experiencing Deep Blue — they just don't have a word for it. Giving it a name makes it easier to discuss in 1:1s. "I think you might be feeling some Deep Blue" is more useful than "are you worried about AI?" Chess players and Go players went through this and came out stronger. But they needed time, space, and the realization that being good at chess still mattered even after machines were better at it. Same thing here — the skills still matter, the role just changes.
 
 But here's the really good news: there's a new type of mastery to be had. DHH talks about [coding as mastery](/chop#reasons-to-program---mastery-vs-getting-shit-done) — the joy of VIM combos feeling like Street Fighter II joystick combos, the craft of the thing. Deep Blue assumes that mastery is over because the machine can do it. But that's wrong. The mastery shifts — from writing code to orchestrating AI to build things that were previously impractical. And the payoff is real: you can genuinely do 10x as much. That's not hype, that's more good in the world, more problems solved, more things built. This is especially true for senior folks. The people with the deepest understanding of systems, architecture, and trade-offs are exactly the ones who get the most leverage from AI. All that experience doesn't become worthless — it becomes the judgment layer that makes AI-assisted work actually good instead of just fast.
+
+### Heresies
+
+Yegge nails this one in his [Gas Town Emergency User Manual](https://steve-yegge.medium.com/gas-town-emergency-user-manual-cf0e4556d74b). A heresy is when AI develops a compelling but wrong belief about your system — not a hallucination about the world, but a false conviction about _your_ codebase. And the killer property is that they spread and persist:
+
+{% include quote.html text="Agents are very approximate workers and they like to guess at stuff. They will often make wrong guesses about how your system is supposed to work. If that wrong guess makes it into the code, sneaking through the review process, then it becomes enshrined and other agents may notice it and propagate the heresy in their own work." author="Steve Yegge" url="https://steve-yegge.medium.com/gas-town-emergency-user-manual-cf0e4556d74b" %}
+
+His example is "idle polecats" — a concept that doesn't exist in Gas Town but keeps reappearing:
+
+{% include quote.html text='"Idle polecats" is an example of a heresy that plagues Gas Town. There is no such thing as an idle polecat; it&apos;s not a pool, and they vanish when their work is done. So "idle polecats" make it back into the code base, comments, and docs all the time.' author="Steve Yegge" url="https://steve-yegge.medium.com/gas-town-emergency-user-manual-cf0e4556d74b" %}
+
+That's the part that makes heresies so maddening. You correct it. It comes back. You correct it again. It comes back in a different file. You add it to your CLAUDE.md. It _still_ comes back, because some other agent read the enshrined heresy in a comment before it read your instructions. It's not a one-time fix — it's a recurring battle against false beliefs that have infected your codebase.
+
+{% include quote.html text="I've found the most helpful way to rid yourself of persistent heresies is to capture your guiding principles in the agent priming (onboarding). The more coverage you can get with them, the more classes of heresy you can avoid or easily correct simply by pointing at the principle they violate." author="Steve Yegge" url="https://steve-yegge.medium.com/gas-town-emergency-user-manual-cf0e4556d74b" %}
+
+In other words, your CLAUDE.md and onboarding docs aren't just nice-to-haves — they're your immune system against heresies.
+
+### Infinite Loop
+
+When AI gets stuck cycling between broken solutions — oscillating between two approaches that don't work, or repeatedly applying the same wrong fix because it's acting on a [heresy](#heresies). The AI isn't making progress; it's burning tokens and time while going nowhere.
+
+The real damage isn't the wasted AI cycles — it's what happens to the human. You notice the AI is stuck, so you start trying to break it out. You rephrase the prompt. You add context. You explain what the system _actually_ does. Twenty minutes later, you're debugging the AI's mental model instead of debugging your code. You went from warp speed to impulse to maneuvering thrusters, and the difference is mind-boggling — the same tool that wrote three features before lunch now can't fix a four-line function, and you're somehow making it worse by trying to help.
+
+The right move is to recognize the infinite loop early and then figure out how to break it — same as when a human is stuck and you need to get them unstuck. A few patterns that work:
+
+- **Surface the false belief** — Ask the AI "why do you think X works this way?" Sometimes it'll reveal the [heresy](#heresies) it's operating on, and you can correct it directly.
+- **Burn it down and restart** — Throw out the broken code, start a fresh session with clean context. The AI's context is poisoned; no amount of "no, actually..." will fix it. A new conversation with good priming is often faster than arguing with a confused one.
+- **Narrow the scope** — The AI is trying to solve too much at once and thrashing. Give it a smaller, more constrained problem. "Just fix this one function" instead of "fix the whole feature."
+- **Read the code yourself** — Sometimes the fastest way to break the loop is to actually understand what's happening. Read the code the AI wrote, find the wrong assumption, and tell it exactly what's true.
+- **Just do it manually** — Sometimes the right answer really is to take over. The hardest part is accepting the transition from 10x to "I'll write it myself" — it feels like defeat, but it's the fastest path forward when nothing else works.
+
+The teams that struggle most are the ones where nobody has permission to say "the AI is stuck, I'm changing approach."
+
+### Human In, On, and Out of the Loop
+
+Three modes of working with AI, borrowed from autonomous systems:
+
+- **Human in the loop** — The human approves every AI action before it takes effect. Every PR reviewed, every spec read, every generated test validated. This is where most teams start and it's the safest default.
+- **Human on the loop** — The AI acts autonomously, but the human monitors and can intervene. Think: AI-generated PRs that auto-merge if CI passes, but the EM watches dashboards and can halt the pipeline. The human isn't approving each action — they're supervising the system.
+- **Human out of the loop** — Fully autonomous. No human reviews the output.
+
+The EM question isn't "which mode should we be in?" — it's "are we actually in the mode we think we're in?" A team that claims human-in-the-loop but reviews 50 AI-generated PRs a day is kidding itself. That's rubber-stamping, which gives you the overhead of in-the-loop with the safety of out-of-the-loop — the worst of both worlds. And when the AI hits an [infinite loop](#infinite-loop) in on-the-loop mode, someone needs to notice before it burns hours on nothing.
 
 ## Appendix: Hot Takes
 

--- a/_includes/quote.html
+++ b/_includes/quote.html
@@ -1,0 +1,4 @@
+<!-- prettier-ignore -->
+<blockquote style="border-left: 4px solid #4a90d9; padding: 0.75em 1.25em; margin: 1.5em 0; background: rgba(74, 144, 217, 0.05); font-style: italic;">
+{{ include.text }}{% if include.author %} <span style="font-style: normal; font-size: 0.9em; color: #666; white-space: nowrap;">— {% if include.url %}<a href="{{ include.url }}">{{ include.author }}</a>{% else %}{{ include.author }}{% endif %}</span>{% endif %}
+</blockquote>

--- a/back-links.json
+++ b/back-links.json
@@ -973,7 +973,7 @@
         },
         "/ai-native-manager": {
             "description": "What does it mean to be an engineering manager when AI is rewriting every assumption you have about software, teams, and your own role? I don’t know yet. Nobody does. But I’m figuring it out in real time, and these are my notes from the chaos.\n\n",
-            "doc_size": 45000,
+            "doc_size": 52000,
             "file_path": "_site/ai-native-manager.html",
             "incoming_links": [
                 "/ai-feed",
@@ -983,7 +983,7 @@
                 "/manager-book",
                 "/pet-projects"
             ],
-            "last_modified": "2026-03-07T18:10:00.185005+00:00",
+            "last_modified": "2026-03-08T17:18:32.621571+00:00",
             "markdown_path": "_d/ai-native-manager.md",
             "outgoing_links": [
                 "/agency",


### PR DESCRIPTION
## Summary

- **Heresies**: New glossary term from Yegge's Gas Town article — false beliefs AI develops about your codebase that persist and spread even after correction
- **Infinite Loop**: When AI gets stuck cycling between broken solutions, and the warp-to-maneuvering-thrusters whiplash that follows
- **Human In/On/Out of the Loop**: The supervision spectrum, with the EM punchline: "are you actually in the mode you think you're in?"
- **`quote.html` include**: Reusable styled blockquote with inline author attribution and optional link

## Test plan

- [ ] Preview heresies section renders with styled quotes: `/ai-native-manager#heresies`
- [ ] Preview infinite loop section: `/ai-native-manager#infinite-loop`
- [ ] Preview human in/on/out section: `/ai-native-manager#human-in-on-and-out-of-the-loop`
- [ ] Quote include works with and without `url` param
- [ ] TOC links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three new appendix sections covering AI-related concepts: Heresies, Infinite Loop, and Human In, On, and Out of the Loop.
  * Each section includes definitions, illustrative quotes, and actionable patterns for AI governance and team dynamics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->