### PR TITLE
Add side quests page for tech explorations

### DIFF
--- a/_d/side-quests.md
+++ b/_d/side-quests.md
@@ -1,0 +1,48 @@
+---
+layout: post
+title: "Side Quests: Random Tech Explorations"
+ogtitle: "Side Quests: Random Tech Explorations"
+author: "Igor Dvorkin"
+inprogress: true
+comments: true
+permalink: /side-quests
+redirect_from:
+  - /side-quest
+  - /quests
+tags:
+  - how igor ticks
+  - tech-hobby
+---
+
+Tech is cheap, curiosity is free, and side quests are how I scratch the itch without derailing the main storyline. These are random explorations — little adventures where I poke at something interesting, learn just enough to be dangerous, and move on. No deadlines, no deliverables, just play.
+
+**The rule: don't overdo it.** Side quests are seasoning, not the meal. If I've got more than 3 active at once, something needs to ship or get shelved. The whole point is that they're lightweight — the moment they feel like obligations, they've failed.
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [Active Quests](#active-quests)
+  - [Apple Virtualization](#apple-virtualization)
+- [Completed Quests](#completed-quests)
+- [Shelved Quests](#shelved-quests)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+## Active Quests
+
+### Apple Virtualization
+
+_Started: 2026-03-14_
+
+Setting up Apple's Virtualization framework — running VMs natively on Apple Silicon without the overhead of traditional hypervisors. Exploring what's possible with lightweight Linux VMs on macOS.
+
+**Status:** Just getting started.
+
+## Completed Quests
+
+_Nothing here yet — ship something!_
+
+## Shelved Quests
+
+_Ideas that sounded fun but got deprioritized. No shame in the shelf._


### PR DESCRIPTION
## Summary

- New living document at `/side-quests` for tracking lightweight tech experiments
- Built-in 3-quest cap rule to avoid overcommitting
- Organized into Active / Completed / Shelved sections
- First quest: Apple Virtualization (just getting started)

## Test plan
- [ ] Verify page renders at `/side-quests`
- [ ] Check TOC links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new blog post documenting a lightweight project tracking system called "Side Quests" with sections for active, completed, and shelved exploratory initiatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->