### PR TITLE
Fix Jekyll compatibility with Ruby 3.2+ and GCC 15

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,3 @@
 ---
 BUNDLE_PATH: "~/.bundle"
+BUNDLE_BUILD__COMMONMARKER: "--with-cflags=-std=gnu99 -Wno-error"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ source 'https://rubygems.org'
 gem 'github-pages'
 gem 'webrick'
 gem 'csv'
+gem 'bigdecimal'
+gem 'ostruct'
 
 group :jekyll_plugins do
   gem 'jekyll-algolia', '~> 1.0'

--- a/_ruby_compat.rb
+++ b/_ruby_compat.rb
@@ -1,0 +1,9 @@
+# Monkey-patch for Ruby 3.2+ compatibility with old github-pages gems
+# tainted?/taint/untaint were removed in Ruby 3.2
+unless Object.method_defined?(:tainted?)
+  class Object
+    def tainted?; false; end
+    def taint; self; end
+    def untaint; self; end
+  end
+end

--- a/justfile
+++ b/justfile
@@ -262,8 +262,12 @@ jekyll-serve port="4000" livereload_port="35729":
         BIND_HOST="127.0.0.1"
     fi
 
-    # Use rbenv to ensure correct Ruby version (3.3.x required for github-pages gem)
-    if [ "$(uname)" = "Darwin" ]; then
+    # Use rbenv to ensure correct Ruby version (3.2.x required for github-pages gem)
+    # Ruby 4.0+ and 3.3+ break old github-pages gems (tainted?, pathutil, etc.)
+    # _ruby_compat.rb monkey-patches tainted?/taint/untaint removed in Ruby 3.2
+    export RUBYOPT="-r$(pwd)/_ruby_compat.rb"
+    if command -v rbenv >/dev/null 2>&1; then
+        eval "$(rbenv init - sh)"
         rbenv exec bundle exec jekyll server --incremental --livereload --host $BIND_HOST --port {{port}} --livereload-port {{livereload_port}}
     else
         bundle exec jekyll server --incremental --livereload --host $BIND_HOST --port {{port}} --livereload-port {{livereload_port}}
@@ -287,7 +291,13 @@ jekyll-container port="4000":
     echo '{"branch": "'$(git branch --show-current)'"}' > _data/git.json
     # Update PR data for dev banner (non-fatal if no PR found)
     just update-pr-data || true
-    bundle exec jekyll server --incremental --livereload --host 0.0.0.0 --port {{port}}
+    export RUBYOPT="-r$(pwd)/_ruby_compat.rb"
+    if command -v rbenv >/dev/null 2>&1; then
+        eval "$(rbenv init - bash)"
+        rbenv exec bundle exec jekyll server --incremental --livereload --host 0.0.0.0 --port {{port}}
+    else
+        bundle exec jekyll server --incremental --livereload --host 0.0.0.0 --port {{port}}
+    fi
 
 jekyll-docker:
     #!/usr/bin/env sh


### PR DESCRIPTION
## Summary

- Add `_ruby_compat.rb` monkey-patch for `tainted?`/`taint`/`untaint` methods removed in Ruby 3.2
- Add `bigdecimal` and `ostruct` gems to Gemfile (removed from Ruby stdlib in 3.4+)
- Update justfile to use `rbenv` on all platforms (was Darwin-only) and load compat patch via `RUBYOPT`
- Add `.bundle/config` with commonmarker build flags for GCC 15 compatibility

## Context

The system Ruby upgraded to 4.0.1 (GCC 15, C23) which breaks the old `github-pages` gem chain:
- Liquid 4.0.3 uses `tainted?` (removed Ruby 3.2)
- pathutil 0.16.2 passes Hash as positional arg (breaks Ruby 3.2+)  
- bigdecimal/ostruct removed from default gems (Ruby 3.4+)
- GCC 15 C23 `bool` keyword breaks native extension compilation without `HAVE_STDBOOL_H`

Solution: pin Ruby 3.2.8 via rbenv + monkey-patches for the remaining incompatibilities.

## Test plan

- [x] `just jekyll-serve` starts successfully and serves on port 4000
- [ ] Verify `just jekyll-container` works in container environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Ruby compatibility layer to support Ruby 3.2+
  * Added required gem dependencies for improved compatibility
  * Refined build configuration and Ruby environment handling for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->