### PR TITLE
Add Magic Monitor card detection quest, graduate Context Grabber

### DIFF
--- a/_d/side-quests.md
+++ b/_d/side-quests.md
@@ -22,8 +22,9 @@ Tech is cheap, curiosity is free, and side quests are how I scratch the itch wit
 <!-- vim-markdown-toc-start -->
 
 - [Active Quests](#active-quests)
+  - [Magic Monitor Card Detection](#magic-monitor-card-detection)
+- [Completed / Graduated](#completed--graduated)
   - [Context Grabber](#context-grabber)
-- [Completed Quests](#completed-quests)
 - [Shelved Quests](#shelved-quests)
   - [Apple Virtualization](#apple-virtualization)
 
@@ -31,6 +32,23 @@ Tech is cheap, curiosity is free, and side quests are how I scratch the itch wit
 <!-- prettier-ignore-end -->
 
 ## Active Quests
+
+### Magic Monitor Card Detection
+
+_Started: 2026-03-15_ | [GitHub](https://github.com/idvorkin/magic-monitor)
+
+Magic Monitor is my webcam-based magic practice mirror — instant replay, hand tracking, the works. The next frontier: real-time playing card detection so it can "see" what card I'm holding. Imagine practice sessions where the app knows which card was produced and can verify the trick landed.
+
+**The idea:**
+
+- Train a YOLO model to recognize all 52 playing cards from webcam video
+- Run inference in the browser via ONNX Runtime Web — no server needed
+- Overlay detected cards with bounding boxes and confidence scores on the live feed
+- Eventually: trick verification ("you said Queen of Hearts, and I see... Queen of Hearts")
+
+**Status:** Model trained and exported — YOLO26n (9.7 MB ONNX) trained on [Augmented Startups dataset](https://universe.roboflow.com/augmented-startups/playing-cards-ow27d), 52 card classes, 416x416 input. Browser integration is half-working — detections show up but confidence is low (24% on a clearly visible King) and only catching 1 of 2 cards. HUD has a `[object Object]` bug. Next up: improve detection accuracy and build proper UI integration.
+
+## Completed / Graduated
 
 ### Context Grabber
 
@@ -45,11 +63,7 @@ My AI life coach would be way more helpful if it had access to context that's cu
 - Background location tracking with SQLite storage for "where was I" context
 - At-a-glance dashboard with summary banner and metric cards
 
-**Status:** Core app built — health metrics (steps, heart rate, sleep with bedtime/wake, weight, meditation), background location tracking, dashboard UI, OTA updates, 68 tests. [PR #1](https://github.com/idvorkin/context-grabber/pull/1).
-
-## Completed Quests
-
-_Nothing here yet — ship something!_
+**Status:** Graduated to side project. Core app built — health metrics (steps, heart rate, sleep with bedtime/wake, weight, meditation), background location tracking, dashboard UI, OTA updates, 68 tests. [PR #1](https://github.com/idvorkin/context-grabber/pull/1).
 
 ## Shelved Quests
 

--- a/back-links.json
+++ b/back-links.json
@@ -963,15 +963,15 @@
                 "/walking-with-god",
                 "/y25"
             ],
-            "last_modified": "2026-03-15T15:58:06.298241+00:00",
+            "last_modified": "2026-03-15T09:05:04-07:00",
             "markdown_path": "_d/ai-journal.md",
             "outgoing_links": [
                 "/ai-art",
                 "/ai-security",
-                "/ai-talk",
                 "/chop",
                 "/chow",
                 "/eulogy",
+                "/genai-talk",
                 "/gpt",
                 "/how-igor-chops",
                 "/hyper-personal",
@@ -994,7 +994,7 @@
                 "/manager-book",
                 "/pet-projects"
             ],
-            "last_modified": "2026-03-14T22:56:00.189040+00:00",
+            "last_modified": "2026-03-14T16:03:56-07:00",
             "markdown_path": "_d/ai-native-manager.md",
             "outgoing_links": [
                 "/agency",
@@ -1043,13 +1043,13 @@
         },
         "/ai-second-brain": {
             "description": "Your brain is for thinking, not storage. That was the promise of the “second brain” movement — offload everything to a trusted external system, free your mind for actual thought. Great idea. Most people failed at it, because the system demanded you become a librarian. AI changes that equation completely.\n\n",
-            "doc_size": 27000,
+            "doc_size": 30000,
             "file_path": "_site/ai-second-brain.html",
             "incoming_links": [
                 "/ai-native-manager",
                 "/hyper-personal"
             ],
-            "last_modified": "2026-03-14T22:56:00.189040+00:00",
+            "last_modified": "2026-03-14T16:03:56-07:00",
             "markdown_path": "_d/ai-second-brain.md",
             "outgoing_links": [
                 "/ai-cockpit",
@@ -1350,7 +1350,7 @@
         },
         "/balloon": {
             "description": "Want to plaster a huge smile on someone’s face with 10 cents of material and 20 seconds of work? Make them a balloon! In 2022, I discovered ballooning, and have used it in my joy-delivering arsenal ever since.\n\n",
-            "doc_size": 21000,
+            "doc_size": 22000,
             "file_path": "_site/balloon.html",
             "incoming_links": [
                 "/eulogy",
@@ -1384,7 +1384,7 @@
         },
         "/be-proactive": {
             "description": "I choose ‘.’ I am responsible for my own life ‘.’ My behavior is a function of my decisions, not my conditions ‘.’ I can subordinate feelings to values ‘.’ I have the initiative and the responsibility to make things happen. These are my insights from 7 habits Chapter 1.\n\n",
-            "doc_size": 22000,
+            "doc_size": 23000,
             "file_path": "_site/be-proactive.html",
             "incoming_links": [
                 "/7-habits",
@@ -1522,7 +1522,7 @@
         },
         "/books-that-defined-me": {
             "description": "Books allow great thoughts to enter our mind and mold us into who we want to become. These are the books that are molding me.\n\n",
-            "doc_size": 16000,
+            "doc_size": 17000,
             "file_path": "_site/books-that-defined-me.html",
             "incoming_links": [
                 "/being-a-great-manager",
@@ -2325,7 +2325,7 @@
         },
         "/debug": {
             "description": "Igor's Blog",
-            "doc_size": 23000,
+            "doc_size": 24000,
             "file_path": "_site/debug.html",
             "incoming_links": [],
             "last_modified": "2025-03-16T16:15:36+00:00",
@@ -2859,7 +2859,7 @@
         },
         "/first-things-first": {
             "description": "The key to effective management, is allocating energy through the lens of importance rather than urgency. E.g, ask yourself what one thing could you do that if you did on a regular basis, would make a tremendous positive difference in your life? Lemme guess, it’s important, but not urgent so you’re not doing it. These are my insights based on the 7 habits Chapter 3.\n\n",
-            "doc_size": 25000,
+            "doc_size": 26000,
             "file_path": "_site/first-things-first.html",
             "incoming_links": [
                 "/4dx",
@@ -3393,6 +3393,7 @@
                 "/ai-journal",
                 "/changelog",
                 "/chop",
+                "/pet-projects",
                 "/y25",
                 "/y26"
             ],
@@ -3467,7 +3468,7 @@
                 "/ai-second-brain",
                 "/how-igor-chops"
             ],
-            "last_modified": "2026-03-14T22:56:00.189040+00:00",
+            "last_modified": "2026-03-14T16:03:56-07:00",
             "markdown_path": "_d/hyper-personal.md",
             "outgoing_links": [
                 "/ai-second-brain"
@@ -3747,7 +3748,7 @@
                 "/structure",
                 "/y26"
             ],
-            "last_modified": "2026-03-15T20:00:09.378857+00:00",
+            "last_modified": "2026-03-15T13:01:45-07:00",
             "markdown_path": "_d/larry.md",
             "outgoing_links": [
                 "/affirmations",
@@ -4583,16 +4584,16 @@
                 "/how-igor-chops",
                 "/y25"
             ],
-            "last_modified": "2026-03-15T20:00:09.378857+00:00",
+            "last_modified": "2026-03-15T13:01:45-07:00",
             "markdown_path": "_d/pet-projects.md",
             "outgoing_links": [
                 "/ai-native-manager",
                 "/bike-tesla-identity",
                 "/explainers",
+                "/how-igor-chops",
                 "/larry",
                 "/process-journal",
-                "/static/pet-projects.html",
-                "/vibe"
+                "/static/pet-projects.html"
             ],
             "redirect_url": "",
             "title": "Pet Projects",
@@ -5293,12 +5294,12 @@
         },
         "/side-quests": {
             "description": "Tech is cheap, curiosity is free, and side quests are how I scratch the itch without derailing the main storyline. These are random explorations — little adventures where I poke at something interesting, learn just enough to be dangerous, and move on. No deadlines, no deliverables, just play.\n\n",
-            "doc_size": 17000,
+            "doc_size": 19000,
             "file_path": "_site/side-quests.html",
             "incoming_links": [
                 "/ai-second-brain"
             ],
-            "last_modified": "2026-03-15T03:38:10.562771+00:00",
+            "last_modified": "2026-03-15T05:47:34-07:00",
             "markdown_path": "_d/side-quests.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -5585,7 +5586,7 @@
                 "/gap-year-igor",
                 "/words-we-dont-have"
             ],
-            "last_modified": "2026-03-15T20:00:09.378857+00:00",
+            "last_modified": "2026-03-15T13:01:45-07:00",
             "markdown_path": "_d/structure.md",
             "outgoing_links": [
                 "/larry"
@@ -6994,7 +6995,7 @@
             "incoming_links": [
                 "/changelog"
             ],
-            "last_modified": "2026-03-15T20:00:09.378857+00:00",
+            "last_modified": "2026-03-15T13:01:45-07:00",
             "markdown_path": "_d/y2026.md",
             "outgoing_links": [
                 "/22",


### PR DESCRIPTION
## Summary
- Add **Magic Monitor Card Detection** as new active side quest — YOLO26n model trained (9.7 MB ONNX, 52 cards), browser integration in progress with low confidence/detection issues to fix
- Graduate **Context Grabber** from active quest to "Completed / Graduated" — now a full side project
- Rename "Completed Quests" → "Completed / Graduated" to reflect quests that level up

## Test plan
- [ ] Verify [/side-quests](https://idvorkin.github.io/side-quests) renders correctly
- [ ] Check TOC links work for new section names
- [ ] Confirm Magic Monitor quest appears under Active, Context Grabber under Completed / Graduated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new "Magic Monitor Card Detection" project to active quests with implementation details and current progress status.
  * Reorganized project sections with updated graduation status for existing projects.

* **Chores**
  * Updated navigation and internal metadata references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->