### PR TITLE
Add 'Thoughts on Slowing the Fuck Down' to ai-feed

### DIFF
--- a/_d/ai-feed.md
+++ b/_d/ai-feed.md
@@ -21,6 +21,15 @@ It's [GTD](/gtd) capture meets AI triage. And unlike passive consumption, this p
 
 ## Feed
 
+### 2026-03-26
+
+- **[Thoughts on Slowing the Fuck Down](https://mariozechner.at/posts/2026-03-25-thoughts-on-slowing-the-fuck-down/)** — Mario Zechner on why unsupervised AI coding agents lead to compounding errors and unmaintainable codebases
+  - _Summary_: Agents lack learning mechanisms and create bottleneck-free code generation, allowing small errors to compound — "you don't even know that all the innocent booboos have formed a monster of a codebase." Advocates human-led development where agents handle scoped tasks while humans retain architectural control.
+  - _Why Randy thinks I'd like it_: Directly relevant to your AI-native manager thinking and CHOP work. You're building tools that keep humans in the loop — this validates that approach. Also connects to "cognitive debt" from the Mar 1 feed entry.
+  - _Cross-links_: [AI Native Manager](/ai-native-manager), [CHOP](/chop), [Explainers](/explainers)
+  - _Tags_: #ai-coding-agents #software-quality #craft #human-agency
+  - _Reaction_: TBD — queued for reading
+
 ### 2026-03-24
 
 - **[Training the Future with Mark Russinovich](https://www.fafo.fm/training-the-future-with-mark-russinovich/)** — FAFO podcast episode with Azure CTO Mark Russinovich on training the next generation of engineers in the AI era


### PR DESCRIPTION
## Summary
- Adds a new entry to the AI feed for 2026-03-26: Mario Zechner's "Thoughts on Slowing the Fuck Down" about why unsupervised AI coding agents lead to compounding errors
- Cross-linked to AI Native Manager, CHOP, and Explainers posts

## Test plan
- [ ] Verify the new entry renders correctly under the `### 2026-03-26` header
- [ ] Confirm cross-links resolve to valid blog posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new dated feed entry with a curated link, summary, personalized recommendations, cross-references, tags, and reading status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->