### PR TITLE
Expand ACT Made Simple post to deep reference

### DIFF
--- a/_d/act.md
+++ b/_d/act.md
@@ -20,7 +20,11 @@ ACT is a therapy tradition I've circled for years without ever sitting down with
 
 - [Part 1: Key Concepts & My Takeaways](#part-1-key-concepts--my-takeaways)
   - [Psychological Flexibility — the Goal](#psychological-flexibility--the-goal)
+  - [The Choice Point — Towards Moves and Away Moves](#the-choice-point--towards-moves-and-away-moves)
+  - [Workability — and Why I Stop Asking "Is This True?"](#workability--and-why-i-stop-asking-is-this-true)
   - [The Problem: Cognitive Fusion & Experiential Avoidance](#the-problem-cognitive-fusion--experiential-avoidance)
+  - [Creative Hopelessness — Inventorying What I've Tried](#creative-hopelessness--inventorying-what-ive-tried)
+  - [What "Mindfulness" Means in ACT](#what-mindfulness-means-in-act)
   - [The Hexaflex — Six Core Processes](#the-hexaflex--six-core-processes)
     - [1. Cognitive Defusion](#1-cognitive-defusion)
     - [2. Acceptance](#2-acceptance)
@@ -29,6 +33,8 @@ ACT is a therapy tradition I've circled for years without ever sitting down with
     - [5. Values](#5-values)
     - [6. Committed Action](#6-committed-action)
   - [When to Reach for Which Process](#when-to-reach-for-which-process)
+  - [Self-Compassion — The Six Building Blocks](#self-compassion--the-six-building-blocks)
+  - [Emotions as Allies — What Feelings Are For](#emotions-as-allies--what-feelings-are-for)
   - [Metaphors That Land](#metaphors-that-land)
   - [Practices I Want to Lift Into My Life](#practices-i-want-to-lift-into-my-life)
 - [Part 2: Book Chapters — Key Ideas](#part-2-book-chapters--key-ideas)
@@ -81,6 +87,46 @@ Harris chunks the six core processes into a simpler **triflex**: Be Present, Ope
 
 What I like most about ACT's north star is that it doesn't promise me happiness. It doesn't even promise me relief. It promises me a life where I can keep moving toward what matters even while feeling whatever I'm feeling. That's a much harder claim to make and a much more honest one.
 
+_Full chapters: [Ch 1 — Human Challenge](#chapter-1-the-human-challenge) · [Ch 32 — Therapist's Journey](#chapter-32-the-act-therapists-journey)_
+
+### The Choice Point — Towards Moves and Away Moves
+
+Harris's favorite diagnostic tool, introduced in the opening chapter and referenced throughout the book. It's a simple diagram he draws live with clients, usually halfway through the first session:
+
+- At the bottom: the difficult situations, thoughts, and feelings I'm dealing with
+- From the bottom, two arrows diverge
+- **Away moves** (one arrow) — things I do when hooked, what I want to stop or do less of
+- **Towards moves** (the other arrow) — things I do when unhooked, what I want to start or do more of
+- "Hooked" labels the away arrow, "unhooked" labels the towards arrow
+
+That's the whole thing. Harris claims almost every psychological problem he knows of — anxiety, depression, addiction, you name it — reduces to the same loop: hooked by difficult thoughts and feelings, then away moves. The work is noticing the hook and switching to a towards move instead.
+
+Three nuances that took me a minute to get:
+
+1. **"Behavior" includes covert stuff.** Anything a whole being does — thinking, remembering, focusing — is behavior. Rumination is a covert away move; defusing is a covert towards move. Harris's video-camera test: if a camera could record it, it's overt; if not, it's covert. Both kinds belong on the diagram.
+2. **Any activity can be either, depending on function.** Watching TV to escape the gym is an away move; watching a show I love as a conscious choice is a towards move. Never the form, always the function.
+3. **I define what's an away move, not someone else.** If the gambling addict initially calls gambling a towards move, Harris writes it on the towards arrow and doesn't debate. The choice point is a snapshot of my worldview, not the therapist's. The work surfaces the truth later.
+
+The towards/away vocabulary is the backbone of the whole ACT diagnostic. I use it now as a self-check: _was that a towards move or an away move?_ That's the cleanest single question I've found.
+
+_Full chapter: [Ch 1 — Human Challenge](#chapter-1-the-human-challenge)_
+
+### Workability — and Why I Stop Asking "Is This True?"
+
+The single thinking move that underpins every ACT intervention. **Workability is the replacement for asking if a thought is true.** In ACT, I never debate the content of thoughts. I ask:
+
+> If I let this thought guide my behavior, will that help me create a richer, fuller, more meaningful life?
+
+That's the whole therapy in one question. Harris has a transcript of a client insisting "I really am fat, look at me," and the therapist refusing to argue: "In this room, we're never going to debate whether your thoughts are true or false. What we're interested in is whether they're useful or helpful — whether they help you live a better life."
+
+The reason this works is that **the same thought functions differently in different contexts**. In a context of fusion, the thought "I'm not good enough" cancels my social plans. In a context of defusion, the same thought is noticed, acknowledged, and I go anyway. Nothing about the content changed. Only the grip changed. Harris's reformulation of Shakespeare lands hard: "Thinking does not make anything good or bad, but fusion with your thinking creates problems."
+
+This ties into the broader ACT philosophy Harris calls **functional contextualism**. Every behavior is judged by what it _does_ in context, not what it _looks like_. His example: two cuts on a forearm can have five different functions — self-punishment, tension release, body art, attention, getting out of numbness. Same form, radically different treatments. The form is a distraction; what matters is the function, and the function is always judged by workability.
+
+I'm trying to make this my default stance — when I notice a thought is bothering me, skip the true/false question entirely. Ask: "is living as if this were true taking me toward the person I want to be?" That's workability, and it's faster than arguing with my own mind.
+
+_Full chapters: [Ch 2 — Getting Hooked](#chapter-2-getting-hooked) · [Ch 4 — Get Your Geek On](#chapter-4-get-your-geek-on)_
+
 ### The Problem: Cognitive Fusion & Experiential Avoidance
 
 **Cognitive fusion** means my thoughts dominate my behavior in self-defeating ways. I'm not observing a thought — I'm wearing it. When my mind says "I'm not good enough" and I cancel on a friend, that's fusion. Harris's favorite client-friendly synonym is "getting hooked." The thought hooks me, reels me in, and jerks me around.
@@ -100,6 +146,54 @@ These overlap. A typical narrative weaves several together: "because bad things 
 
 These two processes are linked. I fuse with the thought "this feeling is unbearable," and fusion drives the avoidance. Harris's line is that **thoughts and feelings are not the problem**. Getting hooked by them is. The same anxious thought that derails one person's day leaves another person untouched — not because one has "worse" thoughts, but because the context of fusion is different.
 
+_Full chapters: [Ch 2 — Getting Hooked](#chapter-2-getting-hooked) · [Ch 8 — Creative Hopelessness](#chapter-8-creative-what)_
+
+### Creative Hopelessness — Inventorying What I've Tried
+
+Harris uses an awkward-sounding intervention called **creative hopelessness**. It's not hopelessness in life — it's hopelessness in the agenda of emotional control. The move is to take an honest inventory of everything I've tried to make unwanted feelings go away, and notice that none of it has worked in the long term. The point isn't to feel bad about myself. The point is to create room for a new approach.
+
+The inventory comes with an acronym: **DOTS**.
+
+- **D**istraction — TV, scrolling, food, games, anything that pulls my attention off the feeling
+- **O**pting out — avoiding people, places, events, or situations that might trigger the feeling
+- **T**hinking strategies — positive thinking, debating the thought, suppressing, self-criticism, rumination, problem-solving the feeling
+- **S**ubstances and other strategies — alcohol, drugs, medication, even exercise when it's used as escape
+
+Harris runs the DOTS through five questions, in order:
+
+1. What have you tried?
+2. How has it worked — in the long term?
+3. What has it cost you — time, energy, money, health, relationships, opportunities?
+4. What's showing up right now as we talk about this?
+5. Are you open to trying something new?
+
+The critical frame Harris hammers: **most of these strategies do work in the short term.** Distraction does distract. Alcohol does blunt anxiety. Avoiding the phone call does kill the guilt in the moment. The problem is none of it works long-term, and the costs compound.
+
+I did this exercise on myself while reading the chapter and it was uncomfortable. My DOTS: scrolling to avoid boredom, stalling on hard conversations, over-checking work to silence "not good enough," using exercise to burn off anxiety. None of it is bad in small doses. All of it becomes a problem when it's the go-to move instead of feeling the feeling and acting on values anyway.
+
+_Full chapter: [Ch 8 — Creative Hopelessness](#chapter-8-creative-what)_
+
+### What "Mindfulness" Means in ACT
+
+Harris devotes an entire chapter to the word "mindfulness" because it causes more problems than it solves. The word conjures monks, incense, chanting "Om," and long meditation sessions — which for a lot of people (including me, some days) is a hard sell. Harris strips the baggage and redefines it cleanly.
+
+**In ACT, mindfulness is not meditation.** Mindfulness is the combination of four specific skills:
+
+1. **Defusion** — stepping back from thinking instead of getting tangled in it
+2. **Acceptance** — opening up to and making room for unwanted feelings
+3. **Flexible attention** (contact with the present moment) — being able to narrow, broaden, sustain, or redirect my focus
+4. **Self-as-context** — the noticing self, the part of me aware of everything else
+
+Meditation is one of hundreds of ways to train these skills. Yoga is another. Tai chi, mindful walking, mindful dishwashing, Notice Your Hand — all of them work. If I want to meditate, great. If I don't, also great. **ACT does not require formal practice.**
+
+Harris's definition: **mindfulness is paying attention with openness, curiosity, kindness, and flexibility**. And the basic instruction at the core of every mindfulness exercise is three words: **notice X**. Where X is any present-moment experience — breath, feet on the floor, sounds in the room, the taste of coffee, the feeling of fear. That's it.
+
+Harris even recommends avoiding the word "mindfulness" with clients who have baggage around it. Use "unhooking skills," "dropping anchor," "flexible attention," or "being present" instead. The skills are the point, not the label.
+
+This is the reframe I needed. Every time I've bounced off meditation, it was because I believed mindfulness required sitting still with my eyes closed. It doesn't. It requires noticing X with openness and curiosity, and I can do that anywhere.
+
+_Full chapters: [Ch 3 — Dodgy Words](#chapter-3-mindfulness-and-other-dodgy-words) · [Ch 17 — Being Present](#chapter-17-being-present)_
+
 ### The Hexaflex — Six Core Processes
 
 ACT centers on six processes arranged in a hexagon Harris calls the hexaflex: defusion, acceptance, contact with the present moment, self-as-context, values, and committed action. They're not a sequence. He explicitly calls ACT "nonlinear" — I can work on any of the six at any moment, and when I get stuck on one, I move to another. The six are facets of the same diamond.
@@ -114,6 +208,8 @@ The single practice I want to keep: take a self-critical thought like "I'm a los
 
 Harris is clear that the point of defusion is never to make thoughts go away. That's just avoidance dressed up in mindfulness clothes. The point is to engage in what matters while the thought is still there. A thought I've defused from can still be around — I'm just not in its grip.
 
+_Full chapters: [Ch 11 — Notice That Thought](#chapter-11-notice-that-thought) · [Ch 12 — Deeper into Defusion](#chapter-12-deeper-into-defusion) · [Ch 13 — Defusion Smorgasbord](#chapter-13-the-defusion-smorgasbord) · [Ch 15 — Leaves on a Stream](#chapter-15-leaves-streams-clouds-and-sky)_
+
 #### 2. Acceptance
 
 Acceptance — Harris also calls it "willingness," "expansion," "opening up," "making room" — means opening up to unwanted inner experiences and letting them be. Not liking them. Not wanting them. Allowing them. Crucially, acceptance is never "passive acceptance of my life situation." I change the situation where I can and accept the pain that shows up as I do. The book is called Acceptance _and Commitment_ Therapy for a reason.
@@ -121,6 +217,8 @@ Acceptance — Harris also calls it "willingness," "expansion," "opening up," "m
 The signature metaphor is the **Struggle Switch**. Imagine a switch at the back of my mind. Switch on: I must get rid of any bad feeling. Now I have anxiety about my anxiety, anger about my anger — a feedback loop that amplifies whatever I started with. Switch off: the feeling is still unpleasant, but I'm not pouring fuel on it. Harris treats acceptance as a 0-to-10 scale, not all-or-nothing. I can move from 9 (full struggle) to 3 (mostly allowing it) and that's a big win.
 
 The practice is the three As: **Acknowledge** the feeling, **Allow** it to be there, **Accommodate** it — make real space for it, like an unwanted houseguest I decide to offer a chair. Harris is emphatic that acceptance isn't tolerance. Tolerance is gritted teeth. Acceptance is "I don't like this, and I'm letting it be here anyway."
+
+_Full chapters: [Ch 8 — Creative Hopelessness](#chapter-8-creative-what) · [Ch 9 — Drop the Struggle](#chapter-9-drop-the-struggle) · [Ch 22 — Fifty Shades of Acceptance](#chapter-22-fifty-shades-of-acceptance) · [Ch 23 — Emotions as Allies](#chapter-23-emotions-as-allies)_
 
 #### 3. Contact with the Present Moment
 
@@ -130,13 +228,19 @@ The antidotes: **engaging, savoring, focusing**. The signature practice is his *
 
 The universal instruction is just "notice X," where X is any present-moment experience — breath, feet on the floor, sounds in the room, the taste of coffee.
 
+_Full chapters: [Ch 10 — Dropping Anchor](#chapter-10-dropping-anchor) · [Ch 17 — Being Present](#chapter-17-being-present)_
+
 #### 4. Self-as-Context (the Observing Self)
 
-This is the trickiest process. Harris calls it the "noticing self" — the part of me that notices everything without being any of it. Thoughts change, feelings change, my body changes, my roles change. The part that's doing the noticing never changes. It was there when I was a child, and it's here now.
+Harris calls this the trickiest process in ACT and opens chapter 25 by warning he's about to try to make it simple and may fail. The one-line version: **the observing self is the part of me that does all the noticing** — a safe place inside me from which to open up to difficult thoughts and feelings, and a viewpoint from which to step back and watch them pass. I access it by bringing awareness to my own awareness.
 
-The best metaphor is the **Sky and Weather**. My noticing self is the sky. Thoughts and feelings are the weather. The worst storm cannot hurt the sky, and the sky always has room for the weather. The second metaphor is the **Stage Show** — life is a stage show of thoughts, feelings, sensations, and actions, and there's a part of me that can step back and watch the whole show.
+Harris piles up synonyms so one of them lands: noticing self, observer self, pure awareness, the continuous you, the "I" that notices. None of the words are the thing; technically it isn't a self at all, just the locus from which noticing happens. But the metaphor of a "self" works, so it stays.
 
-The practice: in any mindfulness exercise, slip in the instruction "and as you notice X, be aware that you're noticing. There's X, and there's a part of you noticing X." Harris's template is five repeating lines: notice X, there's a part of you noticing X, if you can notice X you cannot be X, X is a part of you but there's much more to you, X changes but the part noticing X does not.
+Three metaphors to hold it: the **Stage Show** (life is a show I can step back from and watch, able to zoom in on any detail or zoom out to the whole stage), **Sky and Weather** (I am the sky, thoughts and feelings are the weather, which cannot harm the sky and always passes), and the **Chessboard** (I am the board holding both the white pieces I like and the black pieces I don't — the board is the safe place, not either side).
+
+The critical move is that **no metaphor will give me the actual experience** — only experiential exercises will. Fortunately the observing self is already implicit in every mindfulness practice I do: "notice X" has a noticer doing the noticing. Building it is mostly about noticing that I'm noticing inside practices I'm already running. Harris calls this "planting seeds" and does it from session one, slipping lines like "and there's a part of you noticing everything" into dropping-anchor and Leaves-on-a-Stream exercises long before ever naming the concept. The full ladder of exercises from the 1-second seed up through the 15-minute Continuous You, plus the Good Self / Bad Self exercise for defusing from self-concept, is in [Chapter 25](#chapter-25-the-noticing-self).
+
+_Full chapters: [Ch 25 — Noticing Self](#chapter-25-the-noticing-self)_
 
 #### 5. Values
 
@@ -157,6 +261,8 @@ Harris also gives six quick rules about values:
 - **Values are freely chosen.** I'm not obligated to live by them. I choose to.
 - **Values include self and others.** If my value is kindness, I should treat both myself and others kindly.
 
+_Full chapters: [Ch 19 — Know What Matters](#chapter-19-know-what-matters) · [Ch 20 — What If Nothing Matters](#chapter-20-what-if-nothing-matters)_
+
 #### 6. Committed Action
 
 Committed action is translating values into ongoing patterns of effective behavior. Harris folds in all the standard behavioral tools — goal setting, action planning, skills training, exposure — but insists they ride on top of values, not fusion. Without values underneath, goal setting becomes another form of "should" and fails predictably.
@@ -174,6 +280,8 @@ Harris's best diagnostic for why I fail to follow through is the **HARD** acrony
 
 When I'm not doing the thing, I can usually name which of HARD is active in under a minute. The one I see in myself most often is D — I set goals that are too ambitious and then don't start.
 
+_Full chapters: [Ch 21 — Do What It Takes](#chapter-21-do-what-it-takes) · [Ch 24 — What's Stopping You](#chapter-24-whats-stopping-you)_
+
 ### When to Reach for Which Process
 
 Harris keeps reminding readers that ACT is nonlinear, but that's hard to act on without a crude decision tree. Here's mine, compressed from the book:
@@ -186,264 +294,1288 @@ Harris keeps reminding readers that ACT is nonlinear, but that's hard to act on 
 - **I have no direction, everything feels pointless** → values. Mistakenly-held funeral, or "ten years from now, looking back."
 - **I know what to do but can't get myself to do it** → committed action plus HARD diagnostic.
 
+_Full chapters: [Ch 31 — Getting Unstuck](#chapter-31-a-quick-guide-to-getting-unstuck) · [Ch 24 — What's Stopping You](#chapter-24-whats-stopping-you)_
+
+### Self-Compassion — The Six Building Blocks
+
+Harris defines compassion in six words: **acknowledge pain and respond with kindness**. Self-compassion is the same move turned on myself. It's not a mood or a feeling — it's a behavior I can practice whether I feel it or not.
+
+The opener is the **Two Friends** question: when I'm suffering, do I want the friend who says "stop whining, suck it up" or the friend who says "this is rough, I'm here for you, we're in this together"? Then the uncomfortable follow-up: which friend am I being to myself?
+
+Harris breaks self-compassion into six building blocks:
+
+1. **Acknowledge the wound** — notice the pain, name it, don't look away.
+2. **Be human** — this is what humans feel. The pain is normal, not proof that something is wrong with me.
+3. **Disarm the critic** — defuse from harsh self-judgment ("there's the 'I'm a failure' story again").
+4. **Hold yourself kindly** — in thoughts, words, and actions. Speak to myself the way I'd speak to a friend.
+5. **Make room for your pain** — accept it, don't fight it, don't push it away.
+6. **See yourself in others** — common humanity. I'm not the only one going through this.
+
+The concrete practice is **Kind Hand**: when a feeling has a physical location (tight chest, churning gut, lump in throat), place a hand on that spot and imagine warmth flowing from it. Not to dissolve the feeling. To hold it. Harris is emphatic that the goal is never to make the pain go away — that's avoidance dressed up as self-care. The goal is to loosen up around the pain.
+
+The line I want to hold in mind: **"acknowledge pain and respond with kindness."** Short enough to remember in the moment the bad feeling shows up, and it tells me exactly what to do — step 1, notice; step 2, be kind about it.
+
+_Full chapter: [Ch 18 — Hold Yourself Kindly](#chapter-18-hold-yourself-kindly)_
+
+### Emotions as Allies — What Feelings Are For
+
+Harris opens chapter 23 with a reframe that lands hard: **emotions are not the problem, they're messengers.** Every emotion I have evolved to do three things:
+
+1. **Communicate** — to me and to others ("I'm in danger" / "I'm suffering" / "I need help")
+2. **Motivate** — prepare my body to act in the situation ("fight" / "flee" / "rest" / "bond")
+3. **Illuminate** — show me what I care about. The size of the feeling is proportional to the size of the gap between what I want and what I have.
+
+Harris gives a specific function-per-emotion table:
+
+- **Fear** — communicates danger, motivates flight, illuminates safety and protection
+- **Anger** — communicates violation, motivates fighting, illuminates boundaries and defended territory
+- **Sadness** — communicates loss, motivates rest and withdrawal, illuminates what I cared about
+- **Guilt** — communicates "I've done wrong," motivates repair, illuminates how I want to treat others
+- **Love** — communicates appreciation, motivates caring, illuminates connection and bonding
+
+The slogan Harris uses throughout the book: **"Your pain is your ally."** Once an emotion has been accepted (not fought, not suppressed, not avoided), I can ask it questions: _What is this emotion reminding me to do? What does it tell me I care about? What does it reveal about what's missing or threatened?_
+
+This reframes the whole project. The work is not to eliminate difficult emotions. The work is to stop cutting the communication cable. When sadness shows up, it's telling me I loved something. When anger shows up, it's telling me something crossed a line I care about. When fear shows up, it's telling me something I value is at risk. Those are all _useful_ messages, and the feeling is the messenger.
+
+The practice move: when a hard emotion shows up and I've accepted it, ask **"what is this telling me about what matters to me?"** The answer is almost always obvious in hindsight, and I usually missed it because I was busy trying to make the feeling go away.
+
+_Full chapter: [Ch 23 — Emotions as Allies](#chapter-23-emotions-as-allies)_
+
 ### Metaphors That Land
 
-- **Hands as Thoughts and Feelings** — hands over my face = fusion, hands in my lap = defused. Same thoughts, radically different ability to engage.
-- **Pushing Away Paper** — pushing a sheet of paper away with both hands all day is exhausting and useless. Drop it in my lap and life resumes.
-- **Tug-of-War with a Monster** — pulling harder on the rope doesn't help. Drop the rope. The monster is still there, but I'm free.
-- **Struggling in Quicksand** — the natural instinct is to thrash. Thrashing kills you. Lying back and floating is counterintuitive and correct.
-- **The Struggle Switch** — a switch that amplifies any feeling into anxiety-about-anxiety. Turn it off and the feeling is just the feeling.
-- **Sky and Weather** — my observing self is the sky; thoughts and feelings are weather that can never harm the sky and always passes.
-- **Leaves on a Stream** — put each thought on a leaf and watch it come, stay, and go. The aim is not to wash thoughts away, just to watch.
-- **Two Kids in the Car** — goal-obsessed kid whines "are we there yet?", values-living kid plays I-spy. Same destination, different life.
-- **Dropping Anchor** — when an emotional storm hits, drop an anchor (ACE: Acknowledge inner experience, Come back into body, Engage with world). The anchor doesn't stop the storm. It holds me steady.
-- **The Two Friends** — when you're suffering, do you want the friend who says "stop whining, suck it up," or the one who says "this is rough, I'm here for you, we're in this together"? Then ask: which friend am I being to myself?
-- **The Polygraph** — imagine a mad scientist wires you to a lie detector so sensitive it catches any flicker of anxiety, and says he'll electrocute you if you feel anxious. You'd fry. Proof that I do not have direct control over my feelings, no matter how high the stakes.
-- **Caveman Mind** — my mind evolved as a "don't get harmed" machine, constantly scanning for danger, comparing me to the tribe, rehearsing threats. It's not broken. It's doing its job. I stop taking its output quite so seriously once I see that.
+- **[Hands as Thoughts and Feelings](#chapter-2-getting-hooked)** — hands over my face = fusion, hands in my lap = defused. Same thoughts, radically different ability to engage.
+- **[Pushing Away Paper](#chapter-9-drop-the-struggle)** — pushing a sheet of paper away with both hands all day is exhausting and useless. Drop it in my lap and life resumes.
+- **[Tug-of-War with a Monster](#chapter-9-drop-the-struggle)** — pulling harder on the rope doesn't help. Drop the rope. The monster is still there, but I'm free.
+- **[Struggling in Quicksand](#chapter-9-drop-the-struggle)** — the natural instinct is to thrash. Thrashing kills you. Lying back and floating is counterintuitive and correct.
+- **[The Struggle Switch](#chapter-22-fifty-shades-of-acceptance)** — a switch that amplifies any feeling into anxiety-about-anxiety. Turn it off and the feeling is just the feeling.
+- **[Sky and Weather](#chapter-25-the-noticing-self)** — my observing self is the sky; thoughts and feelings are weather that can never harm the sky and always passes.
+- **[Leaves on a Stream](#chapter-15-leaves-streams-clouds-and-sky)** — put each thought on a leaf and watch it come, stay, and go. The aim is not to wash thoughts away, just to watch.
+- **[Two Kids in the Car](#chapter-19-know-what-matters)** — goal-obsessed kid whines "are we there yet?", values-living kid plays I-spy. Same destination, different life.
+- **[Dropping Anchor](#chapter-10-dropping-anchor)** — when an emotional storm hits, drop an anchor (ACE: Acknowledge inner experience, Come back into body, Engage with world). The anchor doesn't stop the storm. It holds me steady.
+- **[The Two Friends](#chapter-18-hold-yourself-kindly)** — when you're suffering, do you want the friend who says "stop whining, suck it up," or the one who says "this is rough, I'm here for you, we're in this together"? Then ask: which friend am I being to myself?
+- **[The Polygraph](#chapter-8-creative-what)** — imagine a mad scientist wires you to a lie detector so sensitive it catches any flicker of anxiety, and says he'll electrocute you if you feel anxious. You'd fry. Proof that I do not have direct control over my feelings, no matter how high the stakes.
+- **[Caveman Mind](#chapter-11-notice-that-thought)** — my mind evolved as a "don't get harmed" machine, constantly scanning for danger, comparing me to the tribe, rehearsing threats. It's not broken. It's doing its job. I stop taking its output quite so seriously once I see that.
 
 ### Practices I Want to Lift Into My Life
 
-- **"I'm having the thought that..."** When I catch myself fused with a self-critical thought, prefix it with "I'm having the thought that" and then "I notice I'm having the thought that." Defuses almost instantly.
-- **Drop anchor with ACE.** When I'm hooked or overwhelmed, run the three steps: (A) Acknowledge what's going on inside, (C) Come back into my body — push feet into floor, straighten spine, stretch, (E) Engage with the world — name five things I see, three I hear.
-- **Name the emotion in third-person form.** Instead of "I am angry," say "I'm noticing anger" or "Here is a feeling of anger." Separates me from the emotion without dismissing it.
-- **Run the challenge formula on any stuck situation.** Leave, stay-and-live-values, or stay-and-give-up. Option 3 is always the default. Forcing the choice surfaces it.
-- **Every goal has to pass the live-person test.** If a corpse can do it better than me, rewrite it as "when X happens, I will Y."
-- **Ask the workability question.** Not "is this thought true?" but "if I let this thought run my life, does it take me toward the person I want to be?"
-- **The HARD diagnostic when I don't follow through.** Hooked, Avoiding discomfort, Remote from values, Doubtful goals. Pick the one that's real and respond with the matching skill.
-- **The Two Friends test for self-talk.** When something goes wrong, ask: am I talking to myself like the harsh friend or the kind friend? The test is almost always "harsh," and the correction is to rewrite the line.
-- **Notice Your Hand as a connection warm-up.** Before important conversations, do 60 seconds of curious-child attention on something physical. It resets my attention the way a breath can't.
-- **"Your pain is your ally."** When a hard emotion shows up, ask what it's telling me about what I care about. Emotions communicate, motivate, and illuminate.
-- **"Willing" instead of "wanting."** When I don't want to do the important thing, don't pretend I do. Ask instead: "am I willing to do it anyway?" The answer is almost always yes, and that's enough.
-- **Leaves on a Stream for rumination.** When I'm stuck in a thought loop, imagine a stream with leaves, put each thought on a leaf, and watch it come, stay, and go. Not to wash it away. Just to watch.
-- **Apply the Two Friends test.** When I'm talking to myself harshly, ask which friend I'm being — the one who says "shut up and suck it up" or the one who says "this is rough, I'm here for you." Almost always the first. Rewrite the line.
-- **Kind Hand for physical pain.** When a feeling has a strong physical location (tight chest, churning gut), place a hand on that spot and imagine warmth flowing from it. Not to dissolve the feeling. To hold it kindly.
-- **Before hard conversations, declare values silently.** "I want to be honest, calm, and kind here." Harris calls this pre-commitment. It pre-loads the posture before anxiety can hijack it.
-- **Track towards-moves and away-moves weekly.** Simple journal: what did I do this week that moved toward the life I want, and what moved away? No judgment, just data.
-- **"Act guided by values, not by feelings."** When I don't feel like doing the thing, I don't need to manufacture a feeling. I just need to ask: does doing this take me toward the person I want to be?
+- **[_"I'm having the thought that..."_](#chapter-12-deeper-into-defusion)** When I catch myself fused with a self-critical thought, prefix it with "I'm having the thought that" and then "I notice I'm having the thought that." Defuses almost instantly.
+- **[Drop anchor with ACE](#chapter-10-dropping-anchor).** When I'm hooked or overwhelmed, run the three steps: (A) Acknowledge what's going on inside, (C) Come back into my body — push feet into floor, straighten spine, stretch, (E) Engage with the world — name five things I see, three I hear.
+- **[Name the emotion in third-person form](#chapter-22-fifty-shades-of-acceptance).** Instead of "I am angry," say "I'm noticing anger" or "Here is a feeling of anger." Separates me from the emotion without dismissing it.
+- **[Run the challenge formula on any stuck situation](#chapter-21-do-what-it-takes).** Leave, stay-and-live-values, or stay-and-give-up. Option 3 is always the default. Forcing the choice surfaces it.
+- **[Every goal has to pass the live-person test](#chapter-21-do-what-it-takes).** If a corpse can do it better than me, rewrite it as "when X happens, I will Y."
+- **[Ask the workability question](#chapter-2-getting-hooked).** Not "is this thought true?" but "if I let this thought run my life, does it take me toward the person I want to be?"
+- **[The HARD diagnostic when I don't follow through](#chapter-24-whats-stopping-you).** Hooked, Avoiding discomfort, Remote from values, Doubtful goals. Pick the one that's real and respond with the matching skill.
+- **[The Two Friends test for self-talk](#chapter-18-hold-yourself-kindly).** When something goes wrong, ask: am I talking to myself like the harsh friend or the kind friend? The test is almost always "harsh," and the correction is to rewrite the line.
+- **[Notice Your Hand as a connection warm-up](#chapter-17-being-present).** Before important conversations, do 60 seconds of curious-child attention on something physical. It resets my attention the way a breath can't.
+- **[_"Your pain is your ally."_](#chapter-23-emotions-as-allies)** When a hard emotion shows up, ask what it's telling me about what I care about. Emotions communicate, motivate, and illuminate.
+- **[_"Willing" instead of "wanting."_](#chapter-20-what-if-nothing-matters)** When I don't want to do the important thing, don't pretend I do. Ask instead: "am I willing to do it anyway?" The answer is almost always yes, and that's enough.
+- **[Notice that I'm noticing](#chapter-25-the-noticing-self).** Inside any mindfulness practice I'm already doing — breath, feet on the floor, dropping anchor — slip in the line "and there's a part of me noticing this." One sentence, done inside what I was already doing. This is Harris's "planting seeds" move and it's the cheapest way to build the observing self.
+- **[Talking and Listening, 30 seconds](#chapter-25-the-noticing-self).** Close my eyes and silently listen to what my mind is saying. When thoughts stop, keep listening until they start again. The point is the distinction that falls out of it: there's a part that talks and a part that listens.
+- **[Brief stage-show step-back, a few times a day](#chapter-25-the-noticing-self).** 20 seconds to drop in, notice the whole stage show (thoughts, feelings, sensations, room, body), notice it's changed from the last check-in, notice the part watching it has not.
+- **[The full Continuous You once every week or two](#chapter-25-the-noticing-self).** The 15-minute version — five instructions applied to breath, thoughts, body, feelings, roles, ending with Sky and Weather. For when I need the heavy lift, not the daily maintenance dose. And then don't analyze it afterward.
+- **[Good Self / Bad Self when I'm hooked on self-concept](#chapter-25-the-noticing-self).** Write out the bad-self story on one side of a card, the good-self story on the other. Hold either side up to my face — notice it blocks everything. Drop it in my lap. The move isn't to argue with the stories; the move is to stop holding them up.
+- **[Leaves on a Stream for rumination](#chapter-15-leaves-streams-clouds-and-sky).** When I'm stuck in a thought loop, imagine a stream with leaves, put each thought on a leaf, and watch it come, stay, and go. Not to wash it away. Just to watch.
+- **[Kind Hand for physical pain](#chapter-18-hold-yourself-kindly).** When a feeling has a strong physical location (tight chest, churning gut), place a hand on that spot and imagine warmth flowing from it. Not to dissolve the feeling. To hold it kindly.
+- **[Before hard conversations, declare values silently](#chapter-19-know-what-matters).** "I want to be honest, calm, and kind here." Harris calls this pre-commitment. It pre-loads the posture before anxiety can hijack it.
+- **[Track towards-moves and away-moves weekly](#chapter-1-the-human-challenge).** Simple journal: what did I do this week that moved toward the life I want, and what moved away? No judgment, just data.
+- **[_"Act guided by values, not by feelings."_](#chapter-20-what-if-nothing-matters)** When I don't feel like doing the thing, I don't need to manufacture a feeling. I just need to ask: does doing this take me toward the person I want to be?
 
 ## Part 2: Book Chapters — Key Ideas
 
 ### Chapter 1: The Human Challenge
 
-Harris opens with the argument that life is hard by design — the normal human mind evolved to generate suffering, not happiness. He introduces the six core processes (the hexaflex), chunks them into the triflex (Be Present, Open Up, Do What Matters), and introduces his favorite tool, the **choice point**: a diagram where difficult thoughts and feelings sit at the bottom, "hooked" leads to away moves, and "unhooked" leads to towards moves.
+_Related: [Ch 2 — Getting Hooked](#chapter-2-getting-hooked) · [Ch 19 — Know What Matters](#chapter-19-know-what-matters) · [Ch 25 — Noticing Self](#chapter-25-the-noticing-self)_
+
+Harris opens with the argument that life is hard by design — not because anything is wrong with us, but because the normal human mind evolved in a way that naturally manufactures psychological suffering.
+
+**The core premise.** Life is both amazing and terrible. If we live long enough we will hit frustration, disappointment, rejection, loss, failure, illness, injury, aging, grief, and our own death. On top of that, many baseline emotions — fear, sadness, guilt, anger, shock, disgust — are inherently painful. And on top of _that_, the human mind can conjure pain any moment it likes: replay a memory, predict a disaster, compare me unfavorably to someone else, judge me. Harris's example is Susan at her own wedding, blissfully happy until the thought "I wish my father were here" drops her into grief over a suicide from decades ago. None of us are immune to that move.
+
+Harris summarizes the human challenge in three lines: (A) life is difficult, (B) a full human life comes with the full range of emotions — pleasant and painful, (C) a normal human mind naturally amplifies psychological suffering.
+
+**What ACT is.** Pronounced "act," not A-C-T, because at its core it's a behavioral therapy about _taking action_ — values-guided, mindful action. Its two jobs: clarify what matters (values) and teach mindfulness skills for handling difficult inner experiences so they don't derail that action. Harris notes that ACT grew out of behaviorism — specifically a branch called **functional contextualism** — which surprised him when he first found it, because he had assumed behaviorists treated humans as rats. ACT is a "third wave" behavioral therapy alongside DBT, MBCT, CFT, and FAP.
+
+**The hexaflex.** ACT has six core processes arranged in a hexagon:
+
+- **Contact with the present moment** — "be here now," flexibly paying attention
+- **Defusion** — stepping back from thinking instead of getting tangled in it
+- **Acceptance** — opening up and making room for unwanted inner experiences
+- **Self-as-context** — the "noticing self," the part of me that's aware of everything else
+- **Values** — desired qualities of ongoing action, the compass
+- **Committed action** — effective, values-guided behavior, including goal-setting, exposure, skills training
+
+Harris is emphatic that these are not a sequence. ACT is explicitly _nonlinear_: any process can be worked on at any moment, and if I get stuck on one I move to another. He calls them six facets of one diamond, and the diamond is **psychological flexibility** — "the ability to act mindfully, guided by our values." The greater my flexibility, the better my response to whatever life throws at me, and the more **vitality** I experience — which Harris is careful to distinguish from "feeling good." Vitality is "a sense of being fully alive and embracing the here and now, regardless of how we may be feeling in this moment." I can feel vital on my deathbed or in grief.
+
+**The triflex.** The six processes chunk into three functional units — what Harris calls the triflex: _Be Present_ (contact with the present moment + self-as-context), _Open Up_ (defusion + acceptance), _Do What Matters_ (values + committed action). Six words for the whole model.
+
+**The choice point.** Harris's favorite tool, co-created in 2013 with Ciarrochi and Bailey. It's a diagram he draws live with clients, usually halfway through session one. At the bottom: difficult situations, thoughts, and feelings. From the bottom, two arrows diverge — "away moves" (what I do when hooked; what I want to stop or do less of) and "towards moves" (what I do when unhooked; what I want to start or do more of). "Hooked" goes on the away arrow, "unhooked" on the towards arrow. Almost every psychological problem Harris knows of — anxiety, depression, addiction, you name it — reduces to the same loop: hooked by difficult thoughts and feelings, then away moves.
+
+Three nuances Harris flags up front about the choice point:
+
+1. **It includes overt and covert behavior.** "Behavior" in ACT is anything a whole being does — including thinking, remembering, focusing. Harris's video-camera test: if a video camera could record it, it's overt; if not, it's covert. Covert away moves like rumination and covert towards moves like defusing both belong on the diagram.
+2. **The client defines what is an away move.** If a gambling addict initially calls gambling a towards move, Harris does not debate it — he writes it on the towards arrow, because the choice point is a snapshot of the client's worldview, not the therapist's. He addresses it later once flexibility has built.
+3. **Any activity can be a towards or an away move depending on context.** Watching TV to avoid the gym is an away move; watching a show I love as a conscious choice is a towards move. It's never the form of the activity; it's the function.
+
+**The promise.** What I like most about ACT's north star is that it doesn't promise me happiness. It doesn't even promise me relief. It promises me a life where I can keep moving toward what matters while still feeling whatever I'm feeling. That's a much harder claim and a much more honest one.
 
 ### Chapter 2: Getting Hooked
 
-The chapter defines **cognitive fusion** and **experiential avoidance** — the two processes that do almost all the clinical damage in ACT's model. Harris introduces the Hands as Thoughts and Feelings metaphor and the **workability** frame: we never ask "is this thought true?", we ask "if you let this thought run your life, does it take you where you want to go?" He lists six categories of fusion: past, future, self-concept, reasons, rules, and judgments.
+_Related: [Ch 1 — Human Challenge](#chapter-1-the-human-challenge) · [Ch 11 — Notice That Thought](#chapter-11-notice-that-thought) · [Ch 22 — Acceptance](#chapter-22-fifty-shades-of-acceptance) · [Ch 8 — Creative Hopelessness](#chapter-8-creative-what)_
+
+The chapter defines the two processes ACT says do almost all the clinical damage — **cognitive fusion** and **experiential avoidance** — and introduces the concept of **workability** that replaces "is this thought true?" with "does living this thought get me where I want to go?"
+
+**What "mind" means in ACT.** Harris opens by listing the kind of things our minds say: "I can't do this," "I'm so dumb," "I'll never be good enough," plus the unfavorable comparisons, the grim future scenarios, the dredged-up painful memories. If your mind does this, Harris says, your mind is normal. In ACT, "mind" is a metaphor for human language — the whole system of symbols and cognitive processes, overt and covert. The mind is a double-edged sword: it builds maps, plans, and knowledge, _and_ it lies, compares, condemns, and conjures pain at will. The dark side is normal and universal, and it's where fusion and avoidance live.
+
+**Cognitive fusion.** Fusion means my cognitions _dominate_ my behavior in a self-defeating way. Harris is careful: ACT reserves the word "fusion" for when the resulting behavior is rigid, narrow, or ineffective. Daydreaming on a beach or rehearsing a speech isn't fusion — that's "absorption." Fusion shows up two ways: (1) my cognitions dominate my _actions_ (I think "no one likes me" and cancel the social event), or (2) my cognitions dominate my _awareness_ (I'm so caught up ruminating that I can't focus on the task in front of me). With clients Harris almost never says "fusion" — he says **"getting hooked."** The thoughts hook me, reel me in, jerk me around, pull me off track. "Hooked" is a broader word than "fused" — it covers fusion _and_ experiential avoidance — which is why Harris prefers it.
+
+**Hands as Thoughts and Feelings.** The signature metaphor. Harris literally has you do it: hold your hands in front of your face as if they were the pages of an open book, then slowly raise them until they cover your eyes. Look through the gaps. Notice how much of the world you lose, how limited you are, how hard it is to act. That's fusion. Then lower your hands toward your lap, slowly. As the distance increases, notice how much easier it is to see, connect, and act. That's defusion. Same thoughts and feelings, same room, radically different ability to engage. Harris flags two things: the purpose of defusion is _never_ to make unwanted thoughts go away (that's just avoidance dressed up), and the point is simply to engage in what matters while the thought is still present.
+
+**Workability — engrave it on your cortex.** This is the move that underpins every ACT intervention. We do not ask "is this thought true or false?" We ask: "is what you're doing working to give you the life you want, in the long term?" Harris is emphatic — we never debate the content of thoughts. He gives a transcript of a client insisting "I really am fat, look at me," and the therapist refusing to argue: "In this room, we're never going to debate whether your thoughts are true or false. What we're interested in is whether they're useful or helpful — whether they help you to live a better life." Workability is built into the choice point — away moves are unworkable behaviors, towards moves are workable. Harris's reformulation of Shakespeare lands hard: "Thinking does not make anything good or bad, but fusion with your thinking creates problems."
+
+> If you let this thought guide your behavior, will that help you create a richer, fuller, more meaningful life?
+
+That's the whole therapy in one question.
+
+**Thoughts and feelings are not the problem.** Harris wants this to land before anything else: in a context of fusion and excessive avoidance, thoughts and feelings become pathological. In a context of defusion, acceptance, flexible attention, or self-as-context, the _same_ thoughts and feelings function differently — still painful, maybe, but no longer running the show. That's why the therapist language is always "when you get _hooked by_ these thoughts and feelings..." — it lays the foundation that the problem isn't the content, it's the grip.
+
+**Six categories of fusion** to learn to spot:
+
+- **Fusion with the past** — rumination, regret, dwelling on pain, blame, resentment, idealizing
+- **Fusion with the future** — worry, catastrophizing, predicting the worst, hopelessness, anticipating rejection
+- **Fusion with self-concept** — "I'm broken," "I'm a loser," "I'm always right," over-identifying with a diagnostic label
+- **Fusion with reasons** — all the reasons I can't, won't, or shouldn't change ("I'm too X," "Z might happen," "it's pointless," "it's too hard")
+- **Fusion with rules** — should, must, have to, ought, right, wrong, fair, unfair; "I can't _until_," "I shouldn't _unless_"
+- **Fusion with judgments** — evaluations of self, others, past, future, body, behavior, life, anything
+
+These overlap and interweave into compound narratives: "because bad things happened to me (past), I am damaged (self-concept), so I can't do X (reason), which means I'll never have Y (future)." Learning to spot which category is loudest is what makes picking the right defusion move possible.
+
+**Experiential avoidance.** The second half of "hooked." Experiential avoidance is the ongoing attempt to avoid, escape, or get rid of unwanted private experiences — thoughts, feelings, memories, urges, sensations — and anything we do to make that happen. Harris explains it via the **Problem-Solving Machine metaphor**: the human mind evolved as a problem-solving machine, and problem solving works brilliantly in the physical world — cold? build a shelter. Wolf at the door? throw rocks. So the mind naturally tries the same move on the inner world, where it mostly doesn't work and often backfires. A glass of wine to kill the anxiety. Scrolling to drown the boredom. Skipping the hard conversation because I don't want to feel guilty. Harris is not a purist — small doses of avoidance can be fine. The problem is when avoidance becomes the life.
+
+**Tolerance is not acceptance.** Harris's line: gritting your teeth and putting up with a feeling while desperately hoping it will go away is still experiential avoidance. His test question cuts deep — would you want the people you love to _tolerate_ you, waiting for you to leave, or to _accept_ you as you are and be glad to have you around? Acceptance is a radically different posture from tolerance.
+
+**Anxiety about anxiety.** The deeper diagnostic move. The more I try to avoid a feeling, the more I develop anxiety _about_ that feeling, which amplifies it in a self-reinforcing loop — and that loop is the core of any anxiety disorder. Research Harris cites: suppressing a thought produces a rebound effect. Suppressing a mood intensifies it. High experiential avoidance correlates with anxiety disorders, depression, addictions, PTSD, long-term disability.
+
+**Mindfulness fascists.** Harris is careful here. ACT does _not_ insist people must always be present, defused, and accepting. Experiential avoidance is not inherently pathological — it's normal. ACT only targets it when it's excessive, rigid, or inappropriate to the point of blocking a rich life. Taking aspirin for a headache is avoidance, and it's fine. One glass of wine is probably fine. Two bottles a night is a different story. The judge is always workability.
+
+**Acceptance has two conditions.** ACT advocates acceptance (1) when avoidance is limited or impossible anyway, or (2) when avoidance is possible but the methods being used make life worse long-term. If avoidance is possible _and_ helps me live my values — go for it.
+
+**How fusion gives rise to avoidance.** Excessive avoidance is almost always driven by fusion with two categories: judgments ("this feeling is bad") and rules ("I have to get rid of it"). The sequence fires faster than conscious thought. So fusion is the overarching pathological process in ACT; avoidance is one of the main things fusion causes. If I'm ever wondering "is this fusion or avoidance?" the answer is usually _both_. Harris splits "hooked" into two modes: **automatic mode** (in fusion, I obey the thought or feeling — fuse with anger, act aggressively) and **avoidance mode** (in fusion, I do whatever I can to escape the thought or feeling — drink, scroll, cancel). Usually both at once.
+
+**The six pathological processes** (the dark mirror of the hexaflex): fusion, experiential avoidance, inflexible attention, remoteness from values, unworkable action, fusion with self-concept. Inflexible attention shows up as **the three Ds**: **distractibility** (can't sustain focus), **disengagement** (going through motions on autopilot), **disconnection** (lack of contact with my own thoughts and feelings). You see the three Ds across almost every disorder, not just depression.
+
+**Who is ACT suitable for?** Harris's reply when asked this: "Can you think of anyone it's _not_ suitable for?" Anyone who would benefit from being more present, more values-connected, more able to make room for pain, more able to defuse, more able to act effectively in the face of discomfort — which is essentially everyone. He lists the evidence base: anxiety, depression, OCD, social phobia, GAD, schizophrenia, borderline PD, workplace stress, chronic pain, drug use, cancer adjustment, epilepsy, weight, smoking, diabetes self-management. ACT positions itself as a model for the human condition, not a niche treatment.
 
 ### Chapter 3: "Mindfulness" and Other Dodgy Words
 
-Harris argues that "mindfulness" has become so loaded a word that it's often better to avoid it. He defines it as "paying attention with openness, curiosity, kindness, and flexibility" and insists mindfulness is not meditation — ACT is overwhelmingly non-meditative. The basic instruction at the core of every mindfulness exercise is the three words "notice X," where X is any present-moment experience. He recommends swapping in concrete terms like "unhooking," "dropping anchor," "engaging," or "expanding" to avoid triggering client resistance to the word "mindfulness." Also warns against confusing "practicing mindfulness" with "practicing mindfulness meditation" — totally different things.
+_Related: [Ch 10 — Dropping Anchor](#chapter-10-dropping-anchor) · [Ch 17 — Being Present](#chapter-17-being-present) · [Ch 16 — Technique Overload](#chapter-16-technique-overload-and-other-perils)_
+
+A short but important chapter. Harris argues that the word "mindfulness" has accumulated so many connotations it's often better to avoid it entirely and use concrete, skill-specific terms instead.
+
+**Where mindfulness comes from.** Harris is pedantic here — mindfulness is _not_ a Buddhist invention. Yogic, Taoist, and Judaic mindfulness traditions go back at least 4,000 years; Buddhism is 2,600 years old, and Buddhist scriptures say Buddha learned mindfulness from a Yogi. Most Western mindfulness-based approaches _are_ derived from Buddhism. ACT is a notable exception — it comes out of behaviorism.
+
+**The definition.** If you pool all the definitions in the literature, they reduce to:
+
+> Mindfulness is a set of psychological skills for effective living that involves paying attention with openness, curiosity, kindness, and flexibility.
+
+Five things fall out of this definition: (1) mindfulness is a set of _diverse_ skills, not one thing; (2) it's an _attention_ process, not a thinking process — you pay attention to experience, you don't think _about_ it; (3) the attitude is openness and curiosity — even toward difficult experience; (4) it requires _flexibility_ of attention (narrow, broaden, sustain, redirect); (5) the quality is _kindness_ — not the cold attention of a scientist dissecting a rat, but the warm attention of a loving parent to a child.
+
+In ACT specifically, "mindfulness" is an umbrella for any combination of the four mindfulness processes — **defusion, acceptance, contact with the present moment, and self-as-context** — and any technique used to instigate them.
+
+**"Notice X" — the universal instruction.** At the core of every single mindfulness exercise, from a ten-second ACT technique to a ten-day silent retreat, is one instruction: **notice X**. Common alternatives: observe, pay attention to, focus on, be aware of, bring awareness to. X can be anything present — a thought, a feeling, a sensation, a sound, the taste of coffee, the sensation of feet on the floor, the expression on a loved one's face. Harris calls this the single most flexible technique in all of ACT; every core process gets instigated by some form of "notice X."
+
+**Mindfulness is not meditation.** Harris is insistent on this. Mindfulness _sometimes_ involves formal meditation, but it also covers a huge array of quick, informal skills that bear no resemblance to sitting practice. And there are meditation traditions that aim to _clear_ the mind of thoughts — which is the opposite of mindfulness meditation, where you expect the thoughts and just watch them. Most ACT protocols deliberately de-emphasize formal meditation in favor of short skills that slot into everyday life. His analogy: if I want to get more people exercising, I don't tell them to go to the gym forty minutes a day — I tell them to take the stairs, walk at lunch, park a block away. Same pragmatic move with mindfulness.
+
+**"Mindfulness" has become a dodgy word.** When Harris wrote _The Happiness Trap_ in 2006, the word was so unknown he didn't mention it until halfway through. Twelve years later everyone knows it — and many of them have loaded it with wrong meanings. People conflate it with Buddhism, meditation, positive thinking, relaxation, distraction, or a technique for getting rid of unwanted thoughts and feelings. None of those are what ACT means. So Harris's advice is to just use other words: **"unhooking," "engaging," "dropping anchor," "task-focused attention," "expansion," "opening up," "making room," "refocusing," "being present."** Pick the concrete term that matches the skill the client is learning and link it explicitly to the client's issue.
+
+**Mindfulness vs. mindfulness _meditation_.** Harris's specific warning. There are zillions of ways to practice mindfulness in daily life without ever meditating, and most clients won't get into meditation in a big way — many will be turned off by the mere suggestion. If a client brings up a past bad experience with mindfulness, usually it turns out they tried formal meditation, which is hard and boring for many people, and then were disappointed it didn't relax them. The fix is to reassure them that's a very different approach and switch to talking about "unhooking skills" instead.
+
+The takeaway: "values," "commitment," "acceptance," and "self-compassion" are also dodgy words with some clients, and Harris promises to offer alternatives for each as they come up. The meta-rule is: don't stick to the script, adapt everything to the client, and if a word's going to backfire, change it.
 
 ### Chapter 4: Get Your Geek On
 
-The technical chapter on **functional contextualism** — ACT's underlying philosophy. The core move is that we care about the _function_ of a behavior (what effect it has in context), not its _form_. Two cuts on a forearm can have five different functions — self-punishment, tension release, body art, attention, getting out of numbness. Same form, different function, different treatment. Workability is always judged by consequences, not by how the behavior looks. Introduces antecedents (triggers) and reinforcing consequences (what keeps the behavior going).
+_Related: [Ch 2 — Getting Hooked](#chapter-2-getting-hooked) · [Ch 6 — What's the Problem](#chapter-6-whats-the-problem) · [Ch 21 — Do What It Takes](#chapter-21-do-what-it-takes)_
+
+Harris's technical chapter on **functional contextualism** — ACT's underlying philosophy of science — which he warns is the jargon-heaviest chapter in the book and begs you not to skip. It's short and the payoff is concrete, so I won't pad it.
+
+**Functional contextualism.** The name comes from two moves: we care about the _function_ of a behavior (what effect it has in context), not the _form_ of it. Harris's canonical example: five people in five situations each cut their forearm with a sharp knife. Same form. Five possible _functions_: getting attention, self-punishment, release of tension, distraction from painful emotion, creating body art, feeling something while totally numb, attempting suicide. Same behavior, radically different functions, radically different treatments. The reverse move is just as important: many different forms can have the same function — if I want my distracted friend's attention, I can wave, shout, pour water over his head, bang furniture, or politely ask. Different forms, same function.
+
+**Workability is judged by function, not form.** This is why ACT refuses to evaluate behavior as good/bad or right/wrong. Instead we ask: does this behavior function as a towards move or an away move _in this context_? Watching TV to procrastinate functions as an away move; watching TV as a values-guided lifestyle choice functions as a towards move. Same activity, different function, different verdict.
+
+**Behavior, in ACT, is anything a whole being does.** That includes overt behavior (actions, speech, movement — things a video camera could record) and covert behavior (thinking, focusing, defusing, accepting, remembering — things a camera couldn't). Both go on the choice point.
+
+**Context.** Every behavior happens in a context, where "context" means everything influencing the behavior: emotions, thoughts, attention, memory, other people present, relationship history, cultural and social events, the physical environment, genetics, physiological states (thirst, hunger, fatigue), drugs, health, status, learning history. The stream of influences is so vast we can never map all of it, so we focus on two broad categories: **antecedents** and **consequences**.
+
+**Antecedents and consequences.** _Antecedents_ are what trigger the behavior — situations, thoughts, feelings that immediately precede it. On the choice point, antecedents always go at the bottom. _Consequences_ are what happen after. Every behavior has payoffs (benefits) and costs (detriments). If the costs lead the behavior to reduce over time, they are **punishing consequences**. If the payoffs lead the behavior to maintain or increase over time, they are **reinforcing consequences**. Harris's example: a client cancels a social event, gets instant relief from dread, and starts cancelling more often — that relief is a reinforcing consequence, which is why the behavior sticks even though she hates the long-term effect.
+
+**Functional analysis, a.k.a. function spotting.** Mapping out the antecedents and reinforcing consequences of a behavior is what behaviorists call functional analysis — Harris plays it as "function spotting" with clients. Adding payoffs at the top of the choice point is how he helps a client understand why she keeps doing the thing she says she wants to stop. It also hands the therapist a concrete intervention map: thoughts at the bottom get defusion, feelings at the bottom get acceptance, and the triggering situations get values-guided problem-solving and skills training.
+
+The chapter's takeaway lands in two moves: first, we use mindfulness to raise awareness of antecedents (notice the thoughts, feelings, and situations that trigger the behavior) and to track the consequences (what this behavior actually produces, short- and long-term). Second, the goal of ACT is to change how I respond to the antecedents so that the _same_ situations, thoughts, and feelings that once triggered away moves now become antecedents for towards moves. That's the whole game in behavioral terms.
 
 ### Chapter 5: Setting Up for Success
 
-How to run the first session: establish rapport, obtain informed consent, take a history, establish behavioral goals. Harris introduces the **"rainbow vs. roadblock"** reframe — do I see this client as a unique work of nature, or an obstacle? He also introduces the **Press Pause** metaphor: the therapist's right to gently interrupt the session to notice what's happening and the **Guitar Metaphor** for explaining ACT to clients — learning ACT is like learning guitar, which takes practice, and reading about it without practicing does nothing.
+_Related: [Ch 6 — What's the Problem](#chapter-6-whats-the-problem) · [Ch 7 — Where Do I Start](#chapter-7-where-do-i-start) · [Ch 30 — I and Thou](#chapter-30-i-and-thou)_
+
+A practical chapter on how to run session one. Harris says roughly half the problems he encounters in supervision come from therapists launching into ACT without setting up their sessions properly. This chapter is the foundation work.
+
+**Session one aims.** Ideally we want to hit:
+
+- establish rapport
+- obtain informed consent
+- take a history
+- establish behavioral goals
+
+And if time allows: a brief experiential exercise and simple homework. High-functioning clients with a clear problem can often get all of that done in a single session. Low-functioning clients with complex trauma histories may need two or three sessions of history-taking and rapport-building before ACT even really starts — especially if there's a long history of betrayal in intimate relationships and trust issues are significant.
+
+**Rainbow or roadblock?** Harris's reframe for the therapeutic relationship. For any given client, ask yourself: _Do I see this person as a rainbow or a roadblock?_ A rainbow is a unique, beautiful work of nature — we don't look at it as an obstacle, we feel grateful to be in its presence. A roadblock is something in our way. Stuck clients — highly fused, highly avoidant — are the ones who most easily flip from rainbow to roadblock in the therapist's mind. When that happens, Harris says the fix is to apply ACT to _yourself_: unhook from the judgments and return to paying attention with openness, curiosity, and appreciation.
+
+**Radical equality — the Two Mountains metaphor.** ACT's stance is that therapists are not enlightened beings who have resolved all their issues. Harris's metaphor: you are climbing your mountain, I am climbing mine. From my mountain I can see things on yours you can't — an avalanche, an alternate path, an inefficient use of the pickaxe — but I have not reached the top of my mountain, I am still climbing, still making mistakes, still learning. We're all climbing until the day we die. The work is getting better at climbing and better at appreciating the journey. Many therapists share this on the first session.
+
+**Informed consent.** Harris likes to do this before the halfway mark of session one. His minimum list of points to cover:
+
+- ACT is an _active_ therapy — not just talking about problems and feelings
+- We work together as a team to build the life you want
+- One big piece is learning skills to _unhook_ from difficult thoughts and feelings
+- Another piece is clarifying values — what you want to stand for, how you want to treat yourself and others
+- Every session ends with an action plan — something practical to take away
+- I will sometimes ask you to try new things that pull you out of your comfort zone, but you are always free to say no
+
+**The "Press Pause" metaphor.** Harris introduces this right after informed consent. He asks the client for mutual permission to "press pause" during the session — either when the therapist notices the client doing something useful (so they can slow down and really notice it, with an eye to using it outside the room) or when the therapist notices something contributing to the problem (so they can address it in real time). And it goes both ways — the client can press pause on the therapist too. What Harris has actually done with this move is install a real-time mindfulness intervention into the therapeutic contract. He can interrupt an aggressive escalation in mid-sentence ("do you remember I could press pause? I think this is one of those times...just pause, take a breath, notice how you're speaking, your tone, the things you're saying...your fists are clenched...") and then transition into grounding, defusion, or assertiveness work. He can also use it to reinforce flexibility when it shows up: "a few minutes ago you were slouched and staring at the floor — do you notice how you're sitting differently now?" A practical tip Harris flags: helping a client notice a behavior is _usually_ a reinforcing consequence for that behavior, but if the client gets self-conscious and stops doing it, the noticing was actually _punishing_, and you should stop and try a different tack.
+
+**The Guitar Metaphor.** Harris's move for getting clients to buy into between-session practice: doing ACT is like learning guitar. You cannot learn guitar by thinking about it, reading about it, or talking about it — the only way is to pick it up and strum. In session you will learn skills with me, and that helps. But what makes the difference is how much you practice at home. The in-session work is not the work; the out-of-session practice is the work. This metaphor also applies to the therapist — Harris opens the Skilling Up section of every chapter with "you cannot learn ACT by reading about it" and hammers on the same point.
+
+**Defusion from doubt.** If a client says "I don't think this will work for me" in session one, Harris refuses to argue. He validates the thought as natural and reframes it as an opportunity. His punchline: "If you ever go see any health professional who guarantees you one hundred percent _this will work_, I recommend you don't go back — they're either lying or deluded." Then he predicts the thought will keep showing up ("your mind will keep saying _this won't work_ for at least the first couple of sessions") and frames each appearance as a choice point: we can give up because your mind says so, or we can let your mind say that and carry on anyway. The client agrees to the second option, and Harris has quietly installed both acceptance (the thought is allowed to be there) and defusion (the thought is present but doesn't control action) on the very first day of therapy, without ever naming either.
+
+**Agreeing on the number of sessions.** Harris refuses to be prescriptive — he's seen transformation in a single session and he's had clients for three or four years. As a default he contracts for six sessions initially (the US default in the literature is twelve) and lets the client judge whether they're making progress. He also frames therapy as a roller-coaster ride — sometimes a huge leap forward, sometimes a step back — so the client isn't surprised by the dip.
+
+**Reducing dropout risk.** If he suspects a client is likely to drop out, Harris names it up front: "sometimes you might feel an urge to drop out, and that's completely normal, especially if you're facing up to something important. If you ever feel that way, please share it with me so we can work with those feelings during the session. I'd hate for you to drop out when you're just about to make a breakthrough." Naming the urge in advance drastically reduces its power later.
+
+**How directive is ACT?** As directive or nondirective as the client needs. Low-functioning clients with skills deficits usually need a clear agenda each session and repeated steering back to it. High-functioning, self-motivated clients need very little direction. Harris titrates per client. But it's impossible to be _fully_ nondirective when teaching mindfulness skills — you do need to give instructions, suggestions, and feedback.
+
+The takeaway Harris repeats at the end: set your sessions up like laying a foundation for a house. Skimp on informed consent and the alliance and everything built on top is shaky. Rainbow, not roadblock.
 
 ### Chapter 6: What's the Problem?
 
-Taking a history through "ACT eyes." Harris reduces the entire diagnostic to two questions: (1) what valued direction does the client want to move in? and (2) what's getting in the way? He introduces the distinction between **emotional goals** ("I want to feel happy") and **behavioral goals** ("I will do X") and warns against **"dead person's goals"** — any goal a corpse can achieve better than a live person.
+_Related: [Ch 5 — Setting Up for Success](#chapter-5-setting-up-for-success) · [Ch 7 — Where Do I Start](#chapter-7-where-do-i-start) · [Ch 19 — Know What Matters](#chapter-19-know-what-matters) · [Ch 21 — Do What It Takes](#chapter-21-do-what-it-takes)_
+
+Taking a history through "ACT eyes." Harris reduces the entire diagnostic frame to two questions and the rest of the chapter is about how to get clean answers to them.
+
+**The two questions.**
+
+1. What valued direction does the client want to move in?
+2. What is getting in the client's way?
+
+Question 1 is the right-hand side of the choice point — values, towards moves, the life the client actually wants. Question 2 is the bottom and left side — the difficult situations, hooking thoughts and feelings, and away moves that are keeping them stuck. Clients find it far easier to describe question 2. Harris's job is to drag question 1 into the open anyway, because without it you can't do ACT.
+
+**Two intake worksheets Harris uses before session one.**
+
+- **Dissecting the Problem.** Four boxes: thoughts that hook you, feelings that hook you, life-draining actions you're doing, and situations you're avoiding. Breaks the suffering into fusion-with-thoughts, fusion-with-feelings, experiential avoidance, and unworkable action.
+- **The Bull's Eye.** Divides life into four domains (work/education, personal growth/health, relationships, leisure) and asks for values in each. The fastest values snapshot Harris knows.
+
+**Eight key areas of history to cover:** presenting complaint, initial values assessment, current life context, relevant past history, psychological rigidity (the six rigidity processes from chapter 2), motivational factors, psychological flexibility, and client resources. Harris is emphatic that you don't only listen for these — you watch for them as they show up live in session, because clients will enact their fusion and avoidance in front of you before they can describe it.
+
+**Three kinds of goals.** This is the move in the chapter.
+
+- **Behavioral goals** = what I want to _do_.
+- **Emotional goals** = how I want to _feel_.
+- **Outcome goals** = what I want to _get_ or _have_.
+
+Clients walk in with emotional goals ("I want to feel happy, confident, calm; I want to stop feeling depressed, anxious, angry"). Harris's line is that every emotional goal reduces to the same agenda: _get rid of my unwanted thoughts and feelings; I want to feel good_. If the therapist agrees to that agenda, ACT is over before it started — the whole model exists to undermine experiential avoidance, and you can't undermine it while having contracted to serve it. You also don't confront the emotional goal head-on (that's creative hopelessness, chapter 8). You _reframe_ it as a behavioral goal.
+
+**The reframe template.** "So a big part of our work here will be _learning new skills to handle these difficult thoughts and feelings more effectively_." Learning a new skill is itself a behavioral goal, and it's the one behavioral goal that any emotional goal can be converted into.
+
+Outcome goals (find a partner, get a job, cure this illness, get my kids to obey me) get a different reframe: "so part of our work here is to get you _saying and doing things_ that are likely to increase your chances of...". The move is to pivot from the uncontrollable outcome to the controllable behavior. Insight goals ("I want to understand why I'm like this") are a special case of outcome goals and lead directly to analysis paralysis — Harris's reframe is "you'll get a lot of insight as a side effect; what do you want to _do_ with it?"
+
+**Dead person's goals.** The single idea I'm taking forward from this chapter. A dead person's goal is any goal a corpse can achieve better than a live human — "stop using drugs," "stop procrastinating," "stop having panic attacks," "stop feeling depressed." The corpse wins every one of those. The fix is always: "if you weren't doing X, what would you be doing instead?" Any "I won't X" gets rewritten as "I will Y." Every goal has to pass the live-person test.
+
+**Two questions for flushing out live-person goals:**
+
+- **The magic wand question.** "Suppose I wave this wand and all these thoughts and feelings are no longer a problem for you — like water off a duck's back. What would you do differently? What would you start? What would you do more of?" Note the phrasing: _no longer a problem_, not _disappeared_. That's load-bearing.
+- **The seven-day documentary question.** "Suppose we followed you with a camera for a week and edited it into a documentary. And then we did it again after we're done working together. What would be different on the new video? What would we see you doing, hear you saying, notice about how you treat other people?"
+
+**Covert behavioral goals matter too.** Sometimes a client's overt life is fine and the problem is they can't _be present_ in it — the chemotherapy patient still sees friends and goes to work but is consumed by worry the whole time. Her behavioral goal isn't "do different things," it's "focus better, engage more, appreciate what's here." Harris reframes "stop worrying" (dead person's goal) as "unhook from anxious thoughts and refocus attention on what you're doing" (live person's goal). Same reframe works for rumination, dwelling on the past, revenge fantasies, obsessing.
+
+**Two insights to seed from session one:**
+
+1. Your thoughts and feelings are not the main problem — getting hooked by them is.
+2. Your thoughts and feelings don't have to control your behavior. They _influence_ it; they don't _control_ it.
+
+Harris notes the second insight surprises most therapists, not just clients.
 
 ### Chapter 7: Where Do I Start?
 
-ACT is nonlinear, so there's no fixed starting process. Harris gives a default sequence: rapport, history, informed consent, brief experiential exercise, simple homework. His default first exercises are **dropping anchor** or **"I'm having the thought that..."**. The key tool for homework is noticing towards and away moves throughout the week. Because ACT is process-based not technique-based, any core process can be worked on at any time — if you get stuck on one, move to another and come back.
+_Related: [Ch 5 — Setting Up for Success](#chapter-5-setting-up-for-success) · [Ch 10 — Dropping Anchor](#chapter-10-dropping-anchor) · [Ch 16 — Technique Overload](#chapter-16-technique-overload-and-other-perils) · [Ch 8 — Creative Hopelessness](#chapter-8-creative-what)_
+
+ACT is nonlinear, so there's no fixed opening sequence. Harris's honest answer to "where do I start?" is "it depends," then he gives a default anyway.
+
+**The default first session (or two).**
+
+1. Establish rapport.
+2. Take a history.
+3. Obtain informed consent.
+4. Establish behavioral goals.
+5. Brief experiential exercise (if time).
+6. Simple homework.
+
+His default first exercises are **dropping anchor** (chapter 10) or **"I'm having the thought that..."** (chapter 12). Both are short, both work almost universally, both can be debriefed quickly. Harris warns: only introduce an exercise if you have time to _also_ debrief it, otherwise the client leaves confused about the point.
+
+**Default first homework: noticing towards and away moves.** Between sessions, notice your towards moves — when and where they happen, what difference they make, really appreciate them as you're doing them. And notice your away moves — when and where, and especially the thoughts and feelings that hook you and pull you into them. Harris avoids the word "homework" because clients dislike it; he uses "play around with this," "try it out," "experiment with it." This same noticing-towards-and-away assignment is the default homework for almost any first session.
+
+**After session one: two paths.** Harris says ACT protocols after the first session tend to flow down one of two paths, matched to the two history questions:
+
+- **Path A: "What valued direction?"** Values clarification → goal setting → action planning → problem solving → skills training → exposure. Focus is on building towards moves.
+- **Path B: "What's getting in the way?"** Target inflexible attention with present-moment work, fusion with defusion, experiential avoidance with acceptance, self-criticism with self-compassion. Focus is on unhooking skills matched to specific away moves.
+
+Whichever path you start on eventually crosses into the other. The six processes are interconnected.
+
+**Matching the starting process to the client.** Harris's decision tree for where to begin:
+
+- **Overwhelmed, dissociated, extremely fused, emotionally dysregulated, impulsive** → dropping anchor.
+- **Major grief or loss** → self-compassion and/or dropping anchor.
+- **Poorly motivated or fused with hopelessness** → values work and defusion from hopelessness.
+- **Fixated on feeling good and getting rid of pain** → creative hopelessness.
+
+**The triflex as a session map.** Be Present, Open Up, Do What Matters. In any session, ask which of the three the client needs right now:
+
+- Overwhelmed or fused → Be Present (grounding, drop anchor).
+- Deeply stuck, paralyzed by fusion and avoidance → Open Up (defusion, acceptance).
+- Ready to move → Do What Matters (values, committed action).
+- Hit a wall on either side → come back to center (Be Present).
+- Successfully doing what matters → return to Be Present to help them engage fully and savor it.
+
+**A rough sequence for teaching unhooking skills.** Harris explicitly says no sequence is required, but shares the one he uses in his own Happiness Trap online program: (1) dropping anchor, (2) simple defusion like noticing and naming, (3) meditative defusion like Leaves on a Stream, (4) attention training and focusing, (5) engaging and savoring, (6) self-compassion, (7) acceptance of pain, (8) the noticing self.
+
+**Generic session structure:** brief mindfulness exercise, review previous session, set agenda, main interventions, homework. Hold loosely. Harris's line on being flexible is that you should be willing to drop everything you had planned in response to what's actually happening in session — you can come back to the plan later.
+
+The through-line I'm taking from this chapter: ACT isn't a recipe, it's a set of moves you deploy based on what's in front of you. Any core process can be worked on at any time. When stuck on one, move to another and come back. This is the same thing Harris will say about self-talk and exposure and everything else — the model is nonlinear because humans are.
 
 ### Chapter 8: Creative What?!
 
-**Creative hopelessness** is Harris's name for the intervention where the client examines, without judgment, everything they've tried to avoid or kill unwanted feelings and notices that none of it worked long-term. The goal is hopelessness _in the agenda of emotional control_, not in life. He runs it through the **DOTS** acronym:
+_Related: [Ch 9 — Drop the Struggle](#chapter-9-drop-the-struggle) · [Ch 22 — Acceptance](#chapter-22-fifty-shades-of-acceptance) · [Ch 2 — Getting Hooked](#chapter-2-getting-hooked)_
 
-- **D**istraction (TV, scrolling, games, food)
-- **O**pting out (avoiding people, places, activities that trigger the feeling)
-- **T**hinking strategies (positive thinking, debating, suppressing, self-criticism)
-- **S**ubstances and other strategies (alcohol, drugs, medication, exercise-as-escape)
+**Creative hopelessness** is Harris's name for the intervention where the client examines, without judgment, everything they've tried to kill their unwanted feelings and notices that none of it is working long-term. The hopelessness is _in the agenda of emotional control_ — not in the client's future, self, or life. The "creative" part is what opens up once that agenda collapses: the space for a radically different response (acceptance) to show up.
 
-The five questions: What have you tried? How has it worked? What has it cost? What's showing up? Are you open to something new? The key frame: most of these strategies do work in the short term. The problem is they don't work in the long term and the costs compound.
+**When to use it.** Only when the client is clinging tightly to the agenda of emotional control: _I have to get rid of these feelings; I just want to feel good_. If the client is already motivated and open, skip it. If they're already familiar with mindfulness, skip it. But if they walk in with pure emotional goals and resist every attempt to reframe as behavioral goals, creative hopelessness is non-optional — you cannot do ACT with that client without it.
+
+**It's not a one-shot.** Harris warns this is rarely a single intervention. You come back to it session after session, each time quicker. Length ranges from a few minutes to an entire session, titrated to how attached the client is to the agenda.
+
+**Emotional control strategies (ECS).** Anything the client does primarily to get rid of unwanted thoughts and feelings. Crucially, the label depends on _intention_, not the activity. Exercise motivated by self-care isn't an ECS. Exercise motivated by "I need to burn off this anxiety" is. Same activity, different function. Harris is explicit that ACT is not anti-control — he calls out that ACT therapists are "not mindfulness fascists." If an ECS is working to build a life the client wants, keep doing it. The intervention targets _excessive_ reliance on ECS, not their existence.
+
+**The DOTS acronym** for prompting the client's memory about what they've tried:
+
+- **D**istraction — TV, music, getting busy, computer games, scrolling, reading, smoking weed.
+- **O**pting out — procrastinating, quitting, withdrawing, avoiding people, places, situations, activities, events that trigger the feeling.
+- **T**hinking strategies — positive thinking, challenging thoughts, debating with yourself, pushing thoughts out of your head, minimizing, self-criticism, telling yourself to _snap out of it_.
+- **S**ubstances and other strategies — drugs, alcohol, prescription meds, caffeine, nicotine, food; also self-harm, suicide attempts, doctor-shopping, self-help books, yoga, meditation-as-escape, prayer-as-escape, keeping busy, beating yourself up.
+
+**The five questions** (this is the spine of the whole intervention):
+
+1. **What have you tried?** (Walk through DOTS. Prompt generously — most clients can't list what they've tried without help.)
+2. **How has it worked?** Specifically: in the long term, did these feelings permanently go away, or do they keep coming back? The answer is always _they keep coming back_ — otherwise the client wouldn't be in your office.
+3. **What has it cost?** Time, money, health, relationships, missed opportunities, narrowed life. Walk through the costs of each DOTS category separately.
+4. **What's showing up?** Pause and ask what the client is feeling right now, after the first three questions have landed. Often sadness, anger, anxiety, guilt — sometimes relief. If self-criticism shows up ("I'm such a loser"), segue into quick defusion before continuing.
+5. **Are you open to something new?** Once the futility of the emotional control agenda has been contacted, ask if they're willing to try a radically different response. Not a pitch, an invitation.
+
+**The key frame:** Most of these strategies _do_ work in the short term. That's why people use them. The problem is they don't work in the long term and the costs compound. Harris returns to this framing constantly because coming in judgmentally ("your coping strategies are bad") invalidates the client and kills the intervention. The stance has to be: you've worked incredibly hard, you're not lazy, you're not stupid, everyone does these things, they _do_ give short-term relief, AND in the long term they're not giving you the life you want.
+
+**Closing question 3 (the validation spiel).** Harris's actual words are worth keeping close:
+
+> You've really worked hard at this. You have tried and tried and tried for a long, long time to get rid of these painful thoughts and feelings. No one can call you lazy. You've put a lot of effort into this. And no one can call you stupid, either, because everyone does these things... And of course, these things do work in the short term: they give you those sweet moments of relief. But in the long term, those feelings keep returning, right? And what I'm wondering is, are these strategies really giving you the life you want, and helping you to be the sort of person you want to be?
+
+**Practical tools.** Harris has a **Join the DOTS worksheet** you fill in with the client (or on a whiteboard) recording each strategy, whether it worked short-term, whether it worked long-term, and what it cost. He recommends practicing creative hopelessness on yourself first before trying it on a client. That's good advice for any of these moves.
+
+**What next?** If the client has truly contacted the unworkability of the emotional control agenda, segue into dropping the struggle (chapter 9). If not, stay with CH longer. Harris emphasizes this is a judgment call the therapist has to make — you can't rush someone out of creative hopelessness before it's landed.
+
+The move I want to lift from this chapter is running the five questions on myself, honestly, whenever I notice I'm stuck in an emotional control loop. What have I tried? How has it worked? What has it cost? What's showing up? Am I open to something new? That's a 5-minute self-audit I can do anywhere.
 
 ### Chapter 9: Drop the Struggle
 
-Once creative hopelessness has landed, the next step is dropping the struggle with difficult feelings. Harris introduces his signature **Pushing Away Paper** exercise alongside **Tug-of-War with a Monster** and **Struggling in Quicksand**. The point of all three: struggle against unwanted thoughts and feelings is the problem, not the thoughts and feelings themselves.
+_Related: [Ch 8 — Creative Hopelessness](#chapter-8-creative-what) · [Ch 22 — Acceptance](#chapter-22-fifty-shades-of-acceptance) · [Ch 23 — Emotions as Allies](#chapter-23-emotions-as-allies)_
+
+Once creative hopelessness has landed, the immediate next step is _dropping the struggle_ with difficult feelings. Harris is explicit that this is the bridge between creative hopelessness and formal acceptance work — clients need to feel the struggle collapse before they can be introduced to willingness as the alternative.
+
+**A terminology note.** Most ACT textbooks call this "Control is the problem, not the solution." Harris dislikes that framing because ACT _does_ help people exert control — over their behavior, their actions, what they say and do. What's not in our control is the vast majority of our thoughts, feelings, and sensations. So Harris prefers **"struggle is the problem, not the solution"** — the struggle being the fight with, and flight from, difficult thoughts and feelings.
+
+**Two interventions in this phase:**
+
+A. Naming struggle as the problem (via metaphor).
+B. Shattering the illusion of emotional control (via short experiential demonstrations).
+
+**Metaphors for struggle as the problem:**
+
+- **Pushing Away Paper** (Harris's favorite). Therapist and client sit side by side, each holding a sheet of paper. Imagine the whole room in front of you contains everything that matters to you, all your loved ones, all your problems, all the tasks that make your life work. Write your difficult thoughts and feelings on the paper. Now grip it tightly and push it as far away from you as possible, arms fully extended. Hold it there. Notice three things: how exhausting this is after less than a minute, how distracting it is — how hard it is to focus on anything in the room — and how hard it is to take any action while holding this posture. Then drop the paper into your lap. Feel the relief. Notice the thoughts and feelings haven't disappeared — they're still right there — but now you can see, move, connect, act. The close of the exercise is important: Harris never dismisses the feelings. If there's something useful in them, you can use them; if not, they can just sit there.
+- **Struggling in Quicksand.** In old movies, the bad guy falls into quicksand and the more he thrashes, the faster it sucks him under. The way to survive is to lie back, spread your arms and legs, and float. Every instinct screams to struggle. The instinct kills you. Lying back is psychologically hard but physically much easier than thrashing.
+- **Tug-of-War with a Monster.** I'm in a tug-of-war with a huge anxiety monster, bottomless pit between us, and the monster keeps pulling me closer to the pit. Pulling harder is instinct; pulling harder doesn't work. The move is to _drop the rope_. The monster is still there. I'm no longer tied up fighting it, and now I can do something useful.
+
+The shared teaching across all three: the instinctive response (push, thrash, pull) is the problem. The counterintuitive move (drop, float, release) is the solution. Harris adds that you can use any metaphor of this shape — slamming on the brakes during a skid, swimming against a rip tide, digging your way out of a hole, scratching an itchy rash, leaning back on skis when you're going too fast.
+
+**Shattering the illusion of emotional control.** A handful of tiny experiential exercises that prove, in seconds, that the client doesn't have direct control over their thoughts and feelings no matter how much they want it:
+
+- **Delete a memory.** "Remember how you got here today. Done? Now delete that memory. Just get rid of it."
+- **Numb your leg.** "Make your left leg go completely numb. So numb I could cut it off with a hacksaw."
+- **Don't think about ice cream.** "For the next exercise, you must not think about what I say. Not even for a microsecond. Don't think about ice cream. Don't think about your favorite flavor. Don't think about how it melts in your mouth on a hot summer's day."
+- **The Polygraph.** A mad scientist wires you to a lie detector so sensitive it catches any flicker of anxiety, says he'll electrocute you if you feel anxious. You'd fry. Your life depends on it, and you still can't stop the anxiety.
+- **Falling in love.** A billion dollars if you can fall head-over-heels in love with the next person who walks in — and it's a sexist, racist, unwashed stranger. You could put on an act (that's behavior, which you _do_ control); you cannot manufacture the feeling.
+
+Each one lands the same point: behavior is controllable, inner experience mostly isn't, and the whole emotional control agenda is therefore built on a premise that isn't true.
+
+**Homework after this session.** A simple struggle-noticing journal: when and where does the struggle happen, what triggers it, what are the consequences, when (if ever) do I drop the struggle, and what difference does that make? If Pushing Away Paper was the metaphor used, the language is "notice when you're pushing hard and notice when you stop pushing." If Tug of War was used, "notice when you're tugging on the rope."
+
+The point of all three metaphors and all five shattering-control exercises: **struggle against unwanted thoughts and feelings is the problem, not the thoughts and feelings themselves.** Once that's landed, the next move — acceptance — has room to be introduced.
 
 ### Chapter 10: Dropping Anchor
 
-Dropping anchor is Harris's favorite first mindfulness skill because it works for almost everyone, including clients in acute distress or dissociation. The structure is **ACE**:
+_Related: [Ch 17 — Being Present](#chapter-17-being-present) · [Ch 25 — Noticing Self](#chapter-25-the-noticing-self) · [Ch 15 — Leaves on a Stream](#chapter-15-leaves-streams-clouds-and-sky)_
 
-- **(A) Acknowledge** inner experience: notice and name the thoughts, feelings, sensations present. "Here's anxiety. Here's a painful memory."
-- **(C) Come back** into the body: regain control over your physical actions. Push feet into the floor, straighten your spine, stretch, change posture, alter your breathing.
-- **(E) Engage** with the world: expand awareness. Notice what you can see, hear, touch, smell. Name five things you can see, three you can hear.
+Dropping anchor is Harris's favorite first mindfulness skill, and he recommends it as the opening move for almost any client — dysregulation, dissociation, panic, flashbacks, extreme fusion, impulsive or compulsive behavior, or just "interested in mindfulness." He likes it because it's simple, it works fast, and it lays foundations for every other core ACT process in one exercise.
 
-The framing metaphor is the **Emotional Storm** — when a storm hits, drop an anchor. The anchor doesn't stop the weather; it holds you steady. In the WHO refugee camp protocol, Harris swapped the metaphor for "grounding" — climbing down out of a tree in a windstorm — because boats and harbors weren't culturally relevant.
+**The framing metaphor — Emotional Storm.** Thoughts spin around your head, feelings churn in your body, and you're being swept away by the weather. When a boat hits harbor in a storm, the first thing you do is tie it up or drop an anchor. Anchors don't control the weather; they hold you steady until the storm passes. Harris notes you pitch this as a boat already in or approaching harbor — a boat out at sea would ride the waves, not drop anchor. When he wrote the WHO refugee camp protocol for Syria and Uganda, he swapped boats for the **grounding** metaphor: you're high in a tree when a storm hits, and your job is to climb down so you can actually do something useful — like comfort a child at the base of the tree.
+
+**The ACE structure.** Every dropping-anchor exercise cycles the same three steps:
+
+- **A — Acknowledge your inner experience.** Notice and silently name whatever thoughts, feelings, memories, urges, or sensations are present. "Here's sadness." "Here's a painful memory." "I'm having a feeling of anger."
+- **C — Come back into your body.** Regain a sense of self-control through the one thing you reliably control when you're flooded: your physical actions. Push feet into the floor, straighten your spine, stretch, sit forward, press fingertips together, move your elbows and shoulders, alter your breathing.
+- **E — Engage with the world.** Expand awareness outward. Notice what you can see (name five things), hear (three or four sounds), touch, taste, smell. Notice the room, notice the therapist, notice the two of you "working here together, as a team."
+
+The therapist cycles A → C → E repeatedly until the client is grounded, and models every action — pushing feet down while asking the client to push feet down — so the client isn't self-conscious and feels the "we're in this together" rapport.
+
+**The move that makes it mindfulness and not distraction.** Harris is emphatic: if you skip the acknowledge step, you have a distraction technique, not a mindfulness technique. He bolds every "notice the painful thoughts and feelings" line in his script for a reason. Grounding exercises in other therapy traditions usually aim to reduce distress; in ACT that's explicitly _not_ the aim. Harris's debrief questions never ask "do you feel better?" They ask: are you less hooked, less swept away, more able to engage, more in control of your arms and legs? If a client answers "it relaxed me," Harris gently redirects — relaxation is a bonus, not the point, and he'll rerun the Pushing Away Paper exercise to reset the frame.
+
+**ACE maps onto the triflex.** Acknowledge → Open Up. Come back → Do What Matters. Engage → Be Present. One simple exercise is laying foundations for every core process.
+
+**Dropping anchor when the weather is fine.** Harris prescribes practicing it throughout the day — stuck in traffic, running late, kids taking forever, someone said something annoying. A ten-second version when you catch yourself drifting off. If you don't practice it when the weather is mild, you won't be able to do it when the storm hits. And after you've anchored, the move is: ask _am I doing a towards move right now?_ If no, stop and do one. If yes, give it your full attention.
+
+Harris has taken some clients through fifteen-minute versions when they were severely dissociating, and ten-second versions when they'd just drifted off slightly. Don't stick to the script — if a client has chronic pain, don't tell him to push his feet into the floor. Improvise from the ACE skeleton.
 
 ### Chapter 11: Notice That Thought
 
-The introduction to defusion. Harris's framework is five steps:
+_Related: [Ch 12 — Deeper into Defusion](#chapter-12-deeper-into-defusion) · [Ch 13 — Defusion Smorgasbord](#chapter-13-the-defusion-smorgasbord) · [Ch 14 — Barriers to Defusion](#chapter-14-barriers-to-defusion) · [Ch 15 — Leaves on a Stream](#chapter-15-leaves-streams-clouds-and-sky)_
 
-1. Find out **what's hooking you** — identify the thoughts the client is fusing with.
-2. **Make the link** — show how fusion leads to specific problematic behaviors (away moves).
-3. **Offer a new skill** — frame defusion as the antidote to those specific problems.
-4. **Normalize and validate** the thoughts (his "caveman mind" metaphor — your mind evolved to generate threats).
-5. **Introduce a defusion metaphor** like Hands as Thoughts and Feelings.
+This is Harris's introduction to defusion, and it opens with the claim that _cognitive fusion is the overarching clinical problem in ACT_ — not experiential avoidance, which is often but not always part of the picture. Fusion means your cognitions dominate your behavior (overt or covert). Defusion means responding to them flexibly so they _can influence but don't dominate_ what you do.
 
-The "make the link" step is the one most commonly skipped. Without it, defusion feels like a random exercise. With it, the client sees exactly why they need this.
+**What defusion is and isn't.** The aim is to see thoughts as nothing more or less than constructions of words and pictures, and respond to them in terms of workability rather than literality — not whether a thought is true or false or positive or negative, but whether letting it guide you helps you build the life you want. Defusion is learning to: step out of content, stop fighting thoughts, stop obeying thoughts, stop clinging to thoughts, and stop giving all your attention to thoughts. And "thought" in ACT means any cognition — beliefs, schemas, memories, images, desires, and the cognitive component of every emotion.
+
+**The five-step lead-in.** Harris structures this as a repeatable sequence:
+
+1. **Find out what's hooking you.** Identify the specific cognitions the client is fusing with. Harris's go-to question: _"If I could listen in to your mind when it's beating you up, telling you all the things that aren't good enough about you or your life, what are the meanest, nastiest, most judgmental things I would hear it saying?"_ Variants for anxiety, depression, anger. The phrasing itself — "listening in," "what it is saying," "the mind" as an entity — plants defusion seeds from session one.
+2. **Make the link.** This is the step everyone skips, and if you skip it, defusion feels random and the client has no reason to care. The move is to connect fusion with _the specific problematic behaviors that follow from it_. Harris's favorite questions: _"When you get hooked by those thoughts, what happens next? What do you do or stop doing? If a film crew were following you 24/7, what would I see you doing?"_ Covert behavior changes are harder to spot, so ask leading questions: _"Who do you cut off from? What's hard to focus on? Who's hard to be present with?"_ These map straight onto the choice point — fusion at the bottom, hooked arrow up, away moves on one side.
+3. **Offer a new skill.** Don't sell mindfulness or defusion. _Offer_ it. Harris's rule: first reframe the client's issues into an ACT formulation, then offer a skill the client can clearly see is directly relevant. No selling required. In the transcript, the therapist summarizes the content of fusion, identifies the away moves that result, and asks whether the client would be interested in learning how to unhook — without ever using the word "mindfulness."
+4. **Normalize and validate.** This runs in the background from session one and facilitates both defusion and acceptance. Harris's favorite move is the disarmingly personal **"Your mind is a lot like mine"** — _your mind says those things to me too._ He backs this with **Caveman Mind metaphors**: your mind evolved as a "don't get harmed" machine, constantly scanning for danger, comparing you to every member of the tribe to make sure you won't be kicked out. That's why we all carry some version of the "I'm not good enough" story, usually from childhood on. Harris calls it the best-kept secret on the planet. The message: your mind isn't dysfunctional, it's just doing its job.
+5. **Introduce a defusion metaphor.** Harris's favorite is the extended **Hands as Thoughts and Feelings** exercise. He sits side by side with the client, both facing the room. Out there is everything that matters to you — the people, the problems you need to deal with, the tasks that make life work. Now treat your hands as your thoughts and feelings. Slowly raise them until they cover your eyes. Notice three things: how much you're missing out on, how hard it is to focus on anything important, how hard it is to _do_ the things that make life work. Now slowly lower the hands into your lap. Notice how much easier it is to engage and act. Then the critical point: the hands haven't disappeared. The thoughts and feelings are still there. If they have useful information, you can use them; if not, you let them sit.
+
+Harris prefers to start with dropping anchor before formal defusion work because it's easier for most clients. And he warns explicitly against skipping "make the link" — without it, clients get confused, uncertain, or actively resistant.
 
 ### Chapter 12: Deeper into Defusion
 
-A tour of defusion techniques the client can use immediately. The standout is **"I'm having the thought that..."** — prefix a self-critical thought with that phrase, then "I notice I'm having the thought that...". Harris also covers the Silly Voice technique (sing the thought to "Happy Birthday") and warns that playful techniques can backfire with shame and trauma.
+_Related: [Ch 11 — Notice That Thought](#chapter-11-notice-that-thought) · [Ch 13 — Defusion Smorgasbord](#chapter-13-the-defusion-smorgasbord) · [Ch 14 — Barriers to Defusion](#chapter-14-barriers-to-defusion) · [Ch 27 — Cognitive Flexibility](#chapter-27-cognitive-flexibility)_
+
+This is the chapter where Harris walks you through running defusion exercises on yourself. He tells you to grab a scrap of paper and write down two or three negative self-judgments — then work the techniques on your own worst thought. The opening warning matters: playful defusion techniques done carelessly feel invalidating, trivializing, or demeaning. Always join compassionately first.
+
+**The signature technique — "I'm having the thought that..."** This is the first defusion move Harris formally teaches after the lead-in from chapter 11, and it works for almost everyone. The ladder:
+
+1. Put your self-judgment into the form "I am X" — _I'm a loser_, _I'm not smart enough_.
+2. Fuse with it for ten seconds — believe it as hard as you can.
+3. Replay it prefixed with _"I'm having the thought that..."_ — _I'm having the thought that I'm a loser._
+4. Replay once more with _"I notice I'm having the thought that..."_
+
+Most people feel an immediate sense of separation. The client often gestures — "the thought sort of moved out here" — stretching arms out in front. Harris then asks clients to adopt this phrasing in session: _could you say "I'm having the thought that this is all too hard" instead of just "this is all too hard"?_ Once the convention is established, it becomes a reusable brief intervention. The "I'm having..." / "I'm noticing..." prefix also works for feelings, urges, memories, and sensations.
+
+**Singing and Silly Voices.** Sing the thought inside your head to "Happy Birthday." Or hear it in the voice of a cartoon character or sports commentator. Or say it in exaggerated slow motion. Harris warns explicitly: _you wouldn't ask a client with terminal cancer to sing her thoughts about dying to "Happy Birthday."_ In the right context these techniques are powerful; in the wrong context they're invalidating.
+
+**Computer Screen.** For visual clients: imagine the thought written as plain black text on a screen. Play with the formatting — space the words out, run them together vertically. Play with color and font. Animate the words Sesame Street style — jumping, wriggling, spinning. Add a karaoke bouncing ball. Put it back as plain text. Can be done for real on a tablet, in PowerPoint, or on paper with colored pens.
+
+**"But it's true!"** Clients will protest. Harris doesn't debate truth — he shifts to workability. The transcript with the "I am a bad mother" client is the template: _one thing I never intend to do here is debate what's true and false. What we're interested in is, when you get all caught up in this thought, does it help you be the mother you want to be?_ Sometimes yes; mostly no; either way, the question isn't accuracy, it's what the thought does to your behavior.
+
+**Fusion isn't the same as believability.** You can fuse with a thought you don't believe (a revenge fantasy you'd never act on) and defuse from a thought you do believe. Harris illustrates with Naomi, a workshop attendee with an incurable brain tumor who kept getting hooked by thoughts about her impending death. Harris helped her name it "the scary death story." By the second day she had defused significantly — the thoughts hadn't altered in believability one bit because they were 100% true, but she could let them come and go without getting caught up in them.
+
+**The misconception Harris drills against.** Clients (and new therapists) assume the aim of defusion is to feel better or get rid of unwanted thoughts. Harris is explicit: that's wrong. The aim is to reduce the problematic dominance of cognitions over behavior, period. If defusion also makes you feel better or the thought disappears, that's a bonus — enjoy it, but don't expect it, and don't use defusion as an emotional control technique or it stops being mindfulness. If a client says "that was great, the thought went away," Harris gently resets the frame on the spot. Similarly, defusion isn't _dismissing_ — even the most difficult thoughts often have useful information (anxious thoughts point at important issues; self-judgments often point at neglected values).
+
+**When defusion backfires.** Occasionally a client becomes _more_ fused after a technique. Harris's move: apply ACT to yourself first (drop anchor, unhook from the "I'm a lousy therapist" story), then apologize to the client and turn it into a teaching moment — _notice how you're even more caught up in that thought than before. This is what we mean by hooked._
 
 ### Chapter 13: The Defusion Smorgasbord
 
-A long catalog of defusion techniques built around the **Three Ns of Defusion**:
+_Related: [Ch 11 — Notice That Thought](#chapter-11-notice-that-thought) · [Ch 12 — Deeper into Defusion](#chapter-12-deeper-into-defusion) · [Ch 14 — Barriers to Defusion](#chapter-14-barriers-to-defusion) · [Ch 16 — Technique Overload](#chapter-16-technique-overload-and-other-perils)_
 
-- **Notice** the thought (just observe that it's there)
-- **Name** the thought (e.g., "there's my 'I'm a loser' story" or "here's the not-good-enough story")
-- **Neutralize** it (any technique that lets you hold it lightly — silly voices, writing it down, "I'm having the thought that...")
+Harris opens by admitting there are literally hundreds of defusion techniques in the ACT literature, which is why newbies get overwhelmed. This chapter is his attempt to make the landscape simple.
 
-Harris shows a full therapy transcript and emphasizes keeping defusion simple and tightly tied to the client's real goals. He warns against "metaphor abuse" — throwing technique after technique at clients hoping one sticks.
+**The Three Ns of Defusion.** Every defusion intervention starts with noticing a cognition; most add naming; many add neutralizing. This is Harris's own training shorthand — "neutralize" isn't an official ACT term, but he finds it useful.
+
+- **Notice.** The basic first step — notice what cognitions are present. _Notice what you're thinking. What's your mind saying? What's hooking you? What's your mind doing?_
+- **Name.** Give the cognition or process a label. Can be simple ("thinking," "worrying," "self-judgment"), playful ("the not-good-enough story," "radio doom and gloom," "the inner critic mouthing off again"), self-referential ("I'm having the thought that..."), or recurrence-acknowledging ("Aha! Here it is again. I know this one.").
+- **Neutralize.** Put the cognition in a new context that disarms its influence. Simplest version: ask about workability — _if you let this thought dictate your choices, will it take you toward or away from the life you want?_ Beyond workability, Harris lists six neutralizing moves:
+  - **Observe the thought as an object** — its size, location, movement, speed, direction.
+  - **Describe the thought** — "hot thoughts," "heavy thoughts," "sticky thoughts," "hooky thoughts."
+  - **Play with its properties** — visual (shape, color, brightness), auditory (volume, voice, tone, sing it, add music), kinesthetic (position, direction, speed).
+  - **Depict it** — write it, draw it, paint it, sculpt it, dance it, text it.
+  - **Transpose it** — imagine it on leaves on a stream, suitcases on a conveyor belt, subtitles on a TV, text messages on a phone.
+  - **Give the cognitive process a character** — "the inner critic," "radio doom and gloom."
+
+**The therapy transcript — Jane.** The rest of the chapter walks through a four-part session with "Jane," a twenty-four-year-old chiropractor fused with "I'm useless / waste of space / I'm f\*\*\*ed / there is no future." Harris uses the transcript to show how much defusion is happening _before_ he ever names a technique:
+
+- **Normalizing and allowing.** Client says "I don't think you can help me." Therapist: _"that's a perfectly natural thought to have."_
+- **Treating the mind as an entity.** "Your mind likes to swear." "Your mind is beating you up."
+- **Listening to the mind.** "If I could plug in and listen, what would I hear?"
+- **Writing thoughts down.** Therapist pulls out a white index card and jots the exact self-judgments on it, reads them back prefaced with "I am."
+- **Describing thoughts as stories.** "Any really dark or scary stories about the future?"
+- **Making the link.** Therapist pivots from listing thoughts to: "When you get hooked by these thoughts, what kind of away moves do you do?"
+
+Then the therapist runs Hands as Thoughts and Feelings — but uses _the index card_ instead of hands. The client holds the card in front of her face (fusion), lowers it to her lap (defusion). The card sits on her lap for the rest of the session as an ongoing physical metaphor. Whenever her eyes drift down to read it, the therapist gently says "Hooked?" and she looks back up.
+
+**Naming the Story — the session's closing move.** Harris asks Jane to imagine bundling all the related thoughts, feelings, and memories into an autobiography or documentary, and to give it a title. Jane picks _the "useless Jane" story_. Harris writes on the back of the index card: _"Aha! Here it is again! The 'useless Jane' story! I know this one."_ Then: read the front (get hooked), flip the card over, read the back, drop anchor. Jane grins and reports she can _see it as a story_. The homework: carry the folded card in her purse for the next month, pull it out three or four times a day, read the front, flip, read the back, fold it back up. The card reminds her she can carry the thoughts around _and_ keep living her life.
+
+**Keeping defusion simple.** Harris lists his favorite low-effort interventions:
+
+- _"Notice what your mind is telling you right now"_ — or just _"notice that thought."_ Almost instantly defusing.
+- **Notice the form** — is it words, sounds, or pictures? Your voice or someone else's? Where is it in space?
+- _"That's an interesting thought"_ — Harris's fallback when a client says something that throws him. Pause, then respond.
+- **Thank your mind** — _Oh, thanks mind! Thanks for sharing._ Only with playfulness and good rapport.
+- **Short phrases** — "Nice one!" "Lovely!" "Very creative!" "Ouch!" In response to a harsh self-judgment, delivered with warmth.
+
+**The warning — don't forget about the client.** Harris is blunt: when he was new to ACT, he got so caught up playing with techniques that he forgot about the human in front of him. We do techniques _with_ clients, not _on_ clients. He also warns against "metaphor abuse" (covered more fully in chapter 14) — flinging technique after technique hoping one sticks. Start with quick and easy techniques before longer meditative ones. Err on the side of caution. Remember: defusion is a _process_, not a technique.
 
 ### Chapter 14: Barriers to Defusion
 
-What to do when defusion doesn't land. Harris covers therapist barriers (fusion with self-doubt, "talking about ACT instead of doing ACT") and client barriers (hopelessness, reason-giving).
+_Related: [Ch 11 — Notice That Thought](#chapter-11-notice-that-thought) · [Ch 13 — Defusion Smorgasbord](#chapter-13-the-defusion-smorgasbord) · [Ch 16 — Technique Overload](#chapter-16-technique-overload-and-other-perils) · [Ch 31 — Getting Unstuck](#chapter-31-a-quick-guide-to-getting-unstuck)_
 
-His seven strategies for hopelessness and reason-giving:
+Harris's framing: anything that can go wrong, will. Even your favorite techniques will eventually fail or backfire. This chapter is about what to do when they do, and it splits cleanly into three sections — invalidation, therapist barriers, and client barriers.
 
-1. Notice and name the pattern
-2. Validate and normalize ("everyone's mind does this")
-3. Declare "no guarantees" (this might not work, but the alternative is keep doing what's not working)
-4. Write the thoughts down
-5. Refuse to convince
-6. The "three choices" — give up entirely, keep doing what you're doing, or try something new
-7. Acknowledge recurring thoughts (instead of fighting them, just see them as old visitors)
+**First dance in the dark, then lead to the light.** This is Harris's headline principle for highly fused clients. When a client is stumbling around in dense fusion, the impulse is to flick on the high beams of defusion and light up a path out. But if you rush into technique without first empathizing, seeing from the client's perspective, and validating the pain, you'll invalidate the client and ramp fusion _up_. Dancing in the dark means: listen with openness and curiosity, see things from the client's perspective, empathize and normalize and validate. Then gently lead to the light — toward any of the six core processes. Harris is clear this usually takes just a few minutes; if you're spending most of the session in supportive counseling mode you've drifted away from ACT.
+
+**Common invalidation traps.**
+
+- **Using "story" flippantly.** The word is powerful with most clients but dismissive if used carelessly. If a client reacts ("it's not a story!"), apologize immediately.
+- **Playful techniques in the wrong context.** Don't ask a bereaved client to sing her thoughts to Happy Birthday. Don't ask a trauma client to thank her mind for memories of childhood abuse. When it goes wrong: own it, apologize, repair.
+- **Lack of empathy.** Harris flags _"it's just a thought"_ as almost always invalidating. It may be _just a thought_ to you; it isn't to the client in that moment. (When clients spontaneously say "it's just a thought" about their own cognition, that usually _is_ defusion.)
+- **Neglecting feelings.** If painful emotions arise mid-defusion, put defusion on hold and work with the emotions.
+- **Lack of clarity.** Skipping "make the link" or failing to clarify defusion's purpose leaves the client confused. Often the reason for this is the therapist's own fusion.
+
+**Therapist barriers — fusion with self-doubt.** Harris says almost every ACT newbie gets hooked by _I can't do this, I'll screw it up, it won't work, it'll upset the client_. These thoughts aren't wrong — they're the caveman mind trying to help — but fusing with them means you stay in your comfort zone and avoid the experiential work.
+
+**Talking about ACT instead of actually doing ACT.** Harris calls this the single most common newbie mistake, and admits he's made it many times himself. When supervisees say "we discussed defusion" or "we did the Hands as Thoughts and Feelings metaphor," he knows they're talking _about_ ACT instead of practicing the skill. Talking is easy — there are so many cool metaphors. Doing is hard.
+
+**Metaphor abuse.** The image: therapist gets stuck in "talking about" mode, walks over to her bookcase, pulls down a huge can of metaphors, and flings them at the client by the handful hoping one sticks. At the end of the session the client walks out "dripping with metaphors." Metaphors are useful — they compress information, clients accept them as truisms, clients remember them — but they get overused when you don't fully understand their purpose or when you're avoiding experiential work. Harris's take-home: unhook, less talk, more action.
+
+**Client barriers.**
+
+- **"I have to get rid of these thoughts!"** Client sees thoughts as bad, dangerous, or abnormal and believes that changing behavior requires getting rid of them first. This is fusion with judgments ("these thoughts are bad") plus fusion with rules ("I can't live a good life until they're gone"). It leads to **pseudo-defusion** — misusing a defusion technique as an emotional control strategy. You'll know because the client reports "it's not working." Fix: revisit creative hopelessness (chapter 8). Rerun the Hands as Thoughts and Feelings metaphor with emphasis on the ending — hands still there, resting in the lap.
+- **"But I have real problems!"** The client thinks you're saying it's all in his head. Nearly always because the therapist failed to validate the real problems or failed to clarify how fusion makes problems worse. Fix: the _extended_ Hands as Thoughts and Feelings metaphor, because it explicitly names the client's real problems out there in the room, separates the problems from the thoughts _about_ the problems, and shows how defusion makes the real problems easier to tackle. If the client still protests, apologize immediately and offer to pivot to problem solving and committed action; come back to defusion later when fusion shows up as a barrier.
+- **"I'm not fully unhooked."** Clients (and therapists) get the idea that you have to be 100% defused before you can do towards moves. Not true. A little unhooking is usually enough to get started, and as you engage with values-guided action you'll progressively unhook further. Related misconception: that defusion means you no longer believe the thought or are no longer upset by it. Neither is required. Reduced believability and reduced distress are _bonuses_.
+
+**The Seven Strategies for Hopelessness and Reason-Giving.** Harris's toolkit for the depressed or cynical client who shows up fused with _therapy won't work, I've tried before, I'm a hopeless case, I can't do anything difficult when I feel this bad_. These can all be introduced on the very first session during history-taking. Any combination, any order:
+
+1. **Notice and Name.** _"I can see there's a bunch of thoughts showing up for you right now about why this won't work for you."_ Nonjudgmental, no challenge to content.
+2. **Validate and Normalize.** _"Those are very common thoughts. Many of my clients have similar thoughts when we first start working. Your mind is just trying to protect you — that's its job."_ Plants caveman-mind seeds.
+3. **Declare "No Guarantees."** _"Part of me really wants to reassure you this will work. But I can't guarantee that. Anyone who does is lying or deluded. What I can guarantee is I'll do my best, and I can guarantee that if we give up because your mind has doubts, we won't get anywhere. So even though your mind will keep saying this can't work — can we go ahead anyway?"_
+4. **Write Thoughts Down.** Ask permission, then jot every objection on paper. "So you have real and valid concerns — is it okay if I jot them all down so we can make sure we address them?" The paper becomes the physical referent for the rest of the session.
+5. **Refuse to Convince.** _"I don't think I'll be able to persuade you. In fact, my guess is, the harder I try to convince you, the more those thoughts are going to show up. What do you think?"_ The client usually smiles — that hint of amusement is often the first sign of defusion.
+6. **The "Three Choices" Strategy.** Harris points at the thoughts written on the paper. _Choice one: we give up, your mind says "this won't work" and we pack it in. Choice two: we debate, I try to convince your mind it's wrong, and your mind wins. Choice three: we let your mind say all this stuff and we just carry on working together as a team._ Then: _"which of those would you prefer?"_ If the client picks option three, that _is_ defusion — the thoughts are present but no longer dominating. Harris notes he's only ever twice had a client pick option one, and both times he talked them into finishing the current session.
+7. **Acknowledge Recurring Thoughts.** Hand the paper and a pen to the client and ask her to mark each thought as it recurs. Each time: _"keeps showing up. So do we give up, waste time debating, or acknowledge it just popped up again and carry on?"_ Keep the paper for the next session and open with it: _"any of these showing up right now? Most of them? Cool. Can we let them be there and carry on?"_
+
+All seven strategies are combinations of the Three Ns — notice, name, neutralize — with workability as the neutralizing move. Harris's reframe at the end of the chapter is the one that matters most: fusion with hopelessness and reason-giving isn't a barrier to therapy, it's _a golden opportunity to actively do therapy_. It gives you the chance to build defusion skills in session instead of just talking about them.
+
+**The four take-home messages.** Practice defusion on yourself before anything else. Model ACT in session — live the values of compassion, respect, and openness, and see clients as rainbows, not roadblocks. Dance in the dark before leading to the light. And validate, validate, validate — when in doubt about an intervention, don't do it; when you accidentally invalidate someone, apologize and clarify your intent immediately.
 
 ### Chapter 15: Leaves, Streams, Clouds, and Sky
 
-Meditative defusion. The signature exercise is **Leaves on a Stream**: visualize a stream with leaves, place each thought on a leaf, and let it come, stay, and go. Harris is emphatic that the aim is not to make thoughts go away — if you speed up the stream trying to wash them off, you've turned defusion into avoidance. He also plants "seeds for self-as-context" here with "there's a part of you noticing everything."
+_Related: [Ch 11 — Notice That Thought](#chapter-11-notice-that-thought) · [Ch 13 — Defusion Smorgasbord](#chapter-13-the-defusion-smorgasbord) · [Ch 25 — Noticing Self](#chapter-25-the-noticing-self) · [Ch 10 — Dropping Anchor](#chapter-10-dropping-anchor)_
+
+Meditative defusion — the "heavy lifting" end of the unhooking gym, where instead of a quick technique I sit with my thoughts for several minutes and watch them come and stay and go. Harris opens by pointing out that "meditation" is a loaded word — it lights up associations with chanting and incense and boredom — so he reframes the whole thing as unhooking skills. Formal meditation is just one of hundreds of ways to build defusion, acceptance, flexible attention, and self-as-context.
+
+**Why bother with the long version.** The brief techniques from earlier chapters are the light weights; meditative defusion is the heavy lifting. Harris pitches it to clients as an antidote to worrying, ruminating, and obsessing: instead of getting instantly hooked by a thought, I learn to step back and watch it float by while I keep giving my attention to the people and tasks in front of me.
+
+**Planting seeds for self-as-context.** This is where Harris starts slipping in the one-line SAC upgrade — "so there's a part of you that notices everything" — as a throwaway comment inside dropping anchor and Leaves on a Stream. No big deal made of it in chapter 15; the seeds germinate later in chapter 25. Generic seed phrases:
+
+- "As you notice X, be aware you're noticing."
+- "There's X and there's a part of you noticing X."
+
+**The Leaves on a Stream exercise.** The signature meditative defusion practice. Visualize a gently flowing stream with leaves on the surface, place each thought on a leaf, and let it come and stay and go in its own good time. Before running it, Harris layers on several setup notes:
+
+- **Offer a nonvisual option.** About one in ten people can't visualize (Harris himself is one); offer "the black space behind your eyelids" instead, or swap in the Hearing Your Thoughts exercise.
+- **Let it come _and stay_ and go.** "Let it go" gets misheard as "make it go away." Defusion doesn't mean the thought disappears; it means the thought isn't dominating me. If I speed up the stream to wash thoughts away, I've turned defusion into experiential avoidance. Harris explicitly coaches clients: "It's okay if the leaves hang around and pile up, or the river stops flowing; just keep watching."
+- **Include positive and negative.** Put happy thoughts on leaves too. If I refuse to let the nice ones float away, I'm not learning the skill.
+- **Invite creativity.** Clients modify the exercise endlessly — suitcases on a conveyor belt, clouds in the sky, platters on a sushi train, carriages on a train, letters floating up the _Star Wars_ opening crawl, tree trunks for clients whose thoughts come too fast for leaves.
+- **Don't do this in a business meeting.** Meditative exercises are practice, not in-the-moment tools. For live situations, rapidly unhook, ground, and refocus.
+- **Top and tail with dropping anchor.** Start with a minute of grounding and curious-child noticing, end with another round of dropping anchor. Optional but recommended.
+
+The exercise itself, roughly:
+
+1. Comfortable position, eyes closed or fixed on a spot.
+2. Imagine sitting beside a gently flowing stream with leaves on the surface. Imagine it however you like.
+3. As each thought pops up, place it on a leaf and let it come and stay and go in its own good time. Don't make it float away — just watch.
+4. If thoughts stop, watch the stream. They'll start again.
+5. Don't speed up the stream. You're not washing leaves away.
+6. If the mind says _this is stupid_ or _I can't do it_, place those thoughts on a leaf.
+7. If a leaf gets stuck, let it hang around.
+8. Optional acceptance add-in: if a difficult feeling shows up, say "here's boredom" or "here's impatience" and put the words on a leaf.
+9. You will get hooked and pulled out of the exercise repeatedly. This is normal. Notice, acknowledge, start again.
+
+After instruction 9, keep running for several minutes, periodically reminding the client "again and again, your thoughts will hook you. This is normal. As soon as you realize it, start up the exercise again." End with dropping anchor or a simple "open your eyes, look around, welcome back." Always debrief: what kinds of thoughts hooked you? Did you try to speed up the stream? Can you see how this is the opposite of rumination?
+
+**Watch Your Thinking** is Harris's shorter alternative. After a minute of grounding, ask where the thoughts are located in space (above, behind, to one side), what form they take (pictures, words, sounds), whether they're moving or still, what speed and direction. Then just observe them come and go like a curious child. Same debrief as Leaves on a Stream.
+
+**Creativity with metaphors.** Any meditative exercise can swap the leaves for something else the client connects with — passing cars driving by outside, clouds drifting across the sky, people walking on the other side of the street, waves washing onto the beach, birds flying across the sky, trains pulling in and out of the station.
+
+**Length.** All these exercises can run 2–3 minutes or 20–30 minutes. If I don't know how the client will cope, I start at 4–5 minutes as a test and adjust from there. And if visualization fails entirely, switch to Hearing Your Thoughts — notice them as if listening to a voice, attending to volume, pitch, tone, and emotionality.
 
 ### Chapter 16: "Technique Overload" and Other Perils
 
-How to avoid drowning in ACT techniques. Harris recommends picking three core techniques for each of the six processes — a personal 18-technique toolkit — and using them until they're second nature. He covers practical tips for experiential work: go slow, check in, record exercises, ensure clarity, debrief thoroughly, and handle the "it's not working" complaint by returning to creative hopelessness.
+_Related: [Ch 14 — Barriers to Defusion](#chapter-14-barriers-to-defusion) · [Ch 31 — Getting Unstuck](#chapter-31-a-quick-guide-to-getting-unstuck) · [Ch 32 — Therapist's Journey](#chapter-32-the-act-therapists-journey)_
+
+The practical-wisdom chapter on how to avoid drowning in ACT techniques and how to handle the messy moments when experiential work goes sideways. Harris opens with a confession: in session, it's easy to feel a googazillion techniques swirling in your head, pick none of them well, and end up thinking _I'm a lousy therapist_ until you fall back into supportive counseling.
+
+**The 18-technique toolkit.** Harris credits Kirk Strosahl with the core move: for each of the six core processes, pick three main techniques — tools, worksheets, exercises, metaphors, questions — and use them over and over until they're second nature. That's eighteen interventions, mix-and-matchable, adaptable to most issues. Harris gives his own personal toolkit as an example (not as "the right one"):
+
+- **Defusion:** Naming the Story, Hands as Thoughts and Feelings, "I'm having the thought that..."
+- **Acceptance:** Pushing Away Paper, Observe/Breathe/Expand/Allow, Compassionate Hand
+- **Contacting the present moment:** Notice X, Mindfulness of the Hand, Dropping Anchor
+- **Self-as-context:** Stage Show of Life, Sky and Weather, Notice That You Are Noticing
+- **Values:** Flavoring & Savoring, The Bull's Eye, Values Cards
+- **Committed action:** SMART Goals, The Choice Point, Towards Moves
+
+Harris recommends building my own version of this table on a computer (because I'll change my mind), playing with those eighteen interventions until they're fluid, then adding new techniques one at a time.
+
+**Practical tips for experiential exercises.** Harris dumps his field notes here instead of spreading them across every chapter:
+
+- **Check in.** On longer exercises, periodically ask "how are you doing with this? Is your mind on board? Are we okay to keep going?"
+- **Go slow.** It's almost impossible to go too slow. Ask "am I going too fast or too slow?"
+- **Play, adapt, create.** Change the words, imagery, objects. Harris ditched Man in the Hole and Passengers on the Bus early on because they felt too long, and built his own versions. He wants me to do the same.
+- **Improvise.** Never read scripts word for word — stilted and artificial. Use them as reference, put everything in my own words.
+- **Mix and match.** Add SAC seeds to dropping anchor. End long mindfulness with a bit of grounding or values.
+- **Record your exercises.** Clients connect more deeply to my voice than a stranger's. Record on a phone and send by text or email.
+- **Ensure clarity.** Harris's most repeated drumbeat: before any unusual exercise, link it explicitly to the client's issues and therapy goals. If I can't answer "how will this help?" clearly, I have homework to do before using the technique.
+- **Watch for "metaphor abuse."** Throwing metaphor after metaphor hoping one sticks rarely works. Use them sparingly and precisely.
+- **Debrief every exercise.** What happened? What feelings showed up? Did you get hooked? What did your mind do? How might this help with ABC? That last question is critical — if the client can't answer, I haven't made it clear enough.
+- **Use the language of experiments.** "I'm asking you to try this because I think it'll help with ABC, but there's no way to know for sure — it's always an experiment. Can we try it and see?" This opens up curiosity and defuses both of us in advance.
+- **Don't say "homework."** Use "practice," "try it out," "experiment," "give it a go."
+
+**When it's not working.** When a client says the exercise isn't working, they almost always mean _the thoughts/feelings aren't going away_. Harris's move is to apologize for not being clear about the purpose, then recap: this is not a way to get rid of unwanted thoughts and feelings. His go-to recap tools are Hands as Thoughts and Feelings (for defusion/attention), Pushing Away Paper (for acceptance), and the Struggle Switch metaphor (coming in chapter 22). If the client still pushes back, it's time to return to creative hopelessness.
+
+**When things go horribly wrong.** Sooner or later an intervention will backfire. Harris's protocol when it does:
+
+1. **Act calm even if you don't feel calm.** Use ACT on myself: defuse from _I'm screwing this up_, make room for the anxiety, drop anchor. Model calm through voice, words, posture.
+2. **Help the client drop anchor.** Ground them before exploring.
+3. **Name it as an experiment that didn't go as hoped.** "Well, that experiment didn't go the way I'd hoped. I'm sorry."
+4. **Explore with openness and curiosity.** What happened? What thoughts and feelings showed up? What hooked you?
+5. **Apologize if warranted.** Quick and genuine.
+6. **Reframe as learning.** How minds hook us, how easily we get pulled into struggle, how minds interfere with anything we try to do.
+
+Harris includes a transcript with Mark, an army veteran with PTSD, who called dropping anchor "pretty fucking stupid" and "irritating." The therapist links the reaction to Mark's already-named self-critical "dictator," draws an analogy to focusing through gunfire on active duty, and turns the backfire into a useful moment about the dictator vs. the caring part. The lesson: if I can defuse, accept, ground, and stay curious, almost any misfire can become a learning moment.
+
+**Technique vs. process.** Harris pushes back gently on trainers who warn about "relying on technique" versus "working with process." You can only work with process _through_ techniques. The real question is flexibility with technique: can I pick the right one for this client at this moment? Can I adapt it on the fly? Can I switch if it isn't working? The "notice X" technique is maximally flexible — it can be bent toward all six core processes — so Harris recommends making sure my toolkit has a few of those flexible workhorses in it.
 
 ### Chapter 17: Being Present
 
-Flexible attention. Harris identifies three costs of inflexible attention:
+_Related: [Ch 10 — Dropping Anchor](#chapter-10-dropping-anchor) · [Ch 25 — Noticing Self](#chapter-25-the-noticing-self) · [Ch 3 — Dodgy Words](#chapter-3-mindfulness-and-other-dodgy-words) · [Ch 22 — Acceptance](#chapter-22-fifty-shades-of-acceptance)_
 
-- **Cutting off** — from the person in front of me, going through the motions but not really there
-- **Missing out** — on enjoyable, pleasurable, satisfying aspects of experience
-- **Doing things poorly** — losing focus on the task at hand because attention is elsewhere
+Contacting the present moment, also called flexible attention. Harris opens with Tolstoy — "There is only one time that is important — NOW" — and the observation that past and future only exist as thoughts happening in the present. Flexible attention is the ability to notice my here-and-now experience and to narrow, broaden, sustain, or redirect my focus at will. It's the starting point of defusion, acceptance, and self-as-context; all three require noticing something first.
 
-The antidotes are **engaging, savoring, and focusing**. His signature exercise is **Notice Your Hand** — five minutes of curious-child attention on your own hand, which almost always leads to the insight "what if I paid this kind of attention to the people I love?" Harris is creative with present-moment exercises: mindful bubble wrap popping, mindful book exploration, mindful walking — anything that lets a client notice X with curiosity.
+**Three costs of inflexible attention.** Harris wants clients to see the concrete price of being lost in their heads:
+
+- **Cutting off** — I'm talking and listening to the person in front of me, but I'm not really there. No connection, just going through the motions.
+- **Missing out** — I fail to savor or appreciate enjoyable parts of my experience. Harris's images: watching my favorite movie in dark sunglasses, getting a massage in a wetsuit, eating delicious food with a numb tongue.
+- **Doing things poorly** — from playing guitar to driving to making love to cooking, the more distracted I am, the worse I do it.
+
+Harris's key reframe: when clients say "my thoughts and feelings are the problem," he gently changes it to "when you are _hooked by_ your thoughts and feelings, you can't engage." The enemy is fusion, not the content.
+
+**The three antidotes: engaging, savoring, focusing.**
+
+- **Engaging skills** aim at full engagement and deep connection with whatever or whoever I'm with.
+- **Savoring skills** aim at enjoyment and appreciation of pleasurable activities — drinking tea, eating a snack, listening to music, smelling flowers. Savoring only applies when there's something actually pleasant to savor.
+- **Focusing skills** aim at focusing on the most important aspects of an activity, narrowing, broadening, sustaining, or redirecting as needed. Focusing works even in stressful or painful situations where there's nothing to savor.
+
+The categories overlap heavily; most exercises foster at least two.
+
+**The Notice Your Hand exercise.** Harris's signature engaging exercise, inspired by watching his ten-month-old son stare at his own wiggling fingers. For about five minutes, the client holds a hand palm-up and observes it like a curious child who has never seen one before: trace the outline, notice the shapes of the gaps between fingers, notice the color (not one color but many tones and shades), slowly stretch the fingers and watch the color change and return, notice the lines on the palm and how smaller lines feed into bigger ones, notice the fingerprint spiral and trace it down into the palm, curl the hand slowly and watch the flesh scrunch, switch to the karate-chop position and notice where palm skin meets back-of-hand skin, turn the hand over slowly and notice scars, sunspots, veins, knuckles, nails, cuticles, tendons moving under the skin like pistons.
+
+Almost every client comes out of this amazed — at how fast five minutes went, and at how fascinating their own hand turned out to be. The debrief has four lines:
+
+1. What did you discover about your hand that was new or interesting?
+2. Did your attitude toward your hand change in any positive way?
+3. Did you get hooked by any negative judgments about your hand?
+4. **How is this exercise relevant to your relationships with other people?**
+
+Question 4 is the whole point. Clients almost always land on: we take the people we love for granted, lose interest, stop paying attention, get hooked by judgments of them — and when we actually pay curious-child attention to someone, the connection comes back. The homework writes itself: "next time you're with a loved one, pay attention to them the way you just paid attention to your hand — what happens?"
+
+Harris's **practical tip**: name curiosity explicitly. "Observe it like a curious child." "Observe it like a curious scientist." "Observe it as if you've never seen something like this before."
+
+**Noticing feelings as groundwork for acceptance.** Harris doesn't hit acceptance head-on until chapter 22, but he plants seeds here through brief "notice X" interventions — "what's happening in your body right now?", "where is the feeling most intense?", "what's the shape and size of it?" Repeated across many sessions, this quietly builds the capacity to turn toward feelings with openness instead of avoidance. Clients who can't notice feelings are usually high in experiential avoidance or dissociating; clients who notice but can't name them have alexithymia and need the naming skill taught explicitly.
+
+**Narrow vs. broad focus.** For worriers and ruminators, encourage narrow focus — engage in a valued activity and keep bringing attention back to it. For chronic pain, encourage broad focus — acknowledge the pain, then widen awareness to the five senses, the environment, the current activity, so pain becomes one performer among many on the stage rather than the spotlight act.
+
+**Keeping clients present.** When a client drifts off, Harris gently interrupts with the Press Pause metaphor: "Can I press pause here? You've told me about this several times now — is there anything helpful in going over it again?" Then "can you notice how your mind keeps hooking you here, pulling you back into the past?" The move is to validate the pain and redirect to unhooking rather than letting the client marinate in fused rumination.
+
+**Creativity with exercises.** Harris has done in-session mindfulness of: massaging hand cream, popping bubble wrap, exploring a book (sound of flipping pages, smell of paper, textures of cover and pages), listening to a lawn mower or air conditioner, smelling flowers, listening to favorite music and tracking individual instruments, walking outside the building, stretching. The prompt he gives himself: "what do I have in this room that could become an X to notice?"
 
 ### Chapter 18: Hold Yourself Kindly
 
-Self-compassion. Harris defines compassion in six words: **"acknowledge pain and respond with kindness."** The opener is the **Two Friends** metaphor: when you're suffering, what kind of friend do you want by your side?
+_Related: [Ch 24 — What's Stopping You](#chapter-24-whats-stopping-you) · [Ch 28 — Problem Emotions](#chapter-28-shame-anger-and-other-problem-emotions) · [Ch 22 — Acceptance](#chapter-22-fifty-shades-of-acceptance)_
 
-He lists six building blocks of self-compassion:
+Self-compassion. Life is hard — if I live long enough, I'm going to experience a lot of pain — and most of us have terrible defaults for handling it: fight it, avoid it, let it dominate us, deny it, or blame and criticize ourselves for it. Self-compassion is none of those. Harris boils compassion down to six words:
 
-1. Acknowledge the wound (notice the pain)
-2. Be human (validate the pain — this is what humans feel)
-3. Disarm the critic (defuse from harsh self-criticism)
-4. Hold yourself kindly (in thoughts, words, and actions)
-5. Make room for your pain (accept it)
-6. See yourself in others (common humanity)
+> Acknowledge pain and respond with kindness.
 
-The **Kind Hand** exercise — placing a hand on the hurting part of your body and imagining warmth flowing from it — is his core practice. Not to dissolve the pain, but to loosen up around it.
+Self-compassion is just that aimed inward. Harris is emphatic that it's a lot more than "being kind to yourself" — it's often a huge act of courage, because turning toward the pain is the hard part.
+
+**The Two Friends metaphor.** Harris often avoids the term "self-compassion" entirely at first, because it trips clients into reactions about flower power, hippy bullshit, weakness, or religion. Instead he opens with this: suppose you're going through a really rough patch in your life. Just about everything that can go wrong has gone wrong. What kind of friend do you want by your side? The friend who says "shut up, stop whining, there are people worse off, suck it up"? Or the friend who says "this is really rough, anyone would be struggling, I'm here for you, I've got your back"? Clients always pick the second. Then: "So what kind of friend are you being to yourself, as you go through this?"
+
+The metaphor segues directly into self-compassion without ever using the term. From there Harris explores which category the client's actual self-talk and self-treatment falls into. For most clients there's almost nothing in the "kind and supportive" column.
+
+**The six building blocks of self-compassion.** Harris expands Kristin Neff's triad (mindfulness, kindness, common humanity) into six blocks. Any given session might use one block or stack several — no fixed sequence.
+
+1. **Acknowledge the wound.** Notice and name the difficult thoughts, feelings, and triggering situations. Don't default to distracting, numbing, or escaping. (Flexible attention.)
+2. **Be human.** Validate the pain as a natural and normal part of being human. Painful thoughts and feelings are not weakness or defect — they're reminders that I am a living, caring human being.
+3. **Disarm the critic.** When I fail, get rejected, or screw up, my mind pulls out a big stick and beats me down. Use defusion to pull the power out of the harsh self-criticism.
+4. **Hold yourself kindly.** In thoughts, words, and actions. Talk to myself kindly. Take care of myself with gestures and deeds that honor my health and well-being.
+5. **Make room for your pain.** Accept it rather than fighting it. This frees up the time and energy I'd otherwise burn on the struggle, and it's itself an act of kindness.
+6. **See yourself in others.** Recognize common humanity. Everywhere I look, people are struggling in ways similar to mine. I'm not alone — this is what it is to be human.
+
+**The Kind Hand exercise.** Harris's all-time favorite self-compassion practice. The client brings to mind a problem they're struggling with, notices where the pain lives in the body, picks one hand, turns it palm up, and connects with times they've used that hand in kind ways — holding a loved one's hand, rubbing someone's back, cuddling a crying baby, helping a friend with a hard task. Fill the hand with that same sense of caring, support, and kindness — imagine it filling with warm, kind energy. Then slowly place the hand on whichever part of the body hurts the most (or the numbest, or over the heart). Feel the warmth flowing from the palm into the body, spreading in all directions. Let the body soften around the discomfort — loosen, make space. Hold the pain as gently as I'd hold a crying baby, a whimpering puppy, or a priceless fragile work of art. Infuse the gesture with caring and warmth. Optionally add the second hand — one on the chest, one on the stomach. Sit in that space as long as wanted — five seconds or five minutes; the spirit of kindness matters, not the duration.
+
+Harris adapts the exercise for clients who don't want to touch their body (because of disgust, trauma, or fused self-judgment): rest the hands in the lap or hover them above the body and imagine warm kind energy radiating from the palms into the heart. If the exercise lands, read it again and notice that it quietly folds in all six building blocks.
+
+**Briefer self-compassion moves.** Exercises don't have to be long meditations. Harris offers a ladder of short interventions that can be combined at will:
+
+- **Kindly acknowledge pain.** "This is really painful." "This hurts." "I'm noticing sadness." "This is a moment of suffering." Then a kindness phrase: "go easy on yourself," "be kind to yourself," or just "gentle."
+- **Add a kind gesture.** Hand on the pain. Hand on the chest, abdomen, or forehead. Gentle massage on the neck or shoulders.
+- **Add acceptance.** Breathe into and around the pain. Drop anchor and expand awareness.
+- **Add defusion.** "Here's my mind beating me up again — and even so, I'm going to be kind to myself." "Aha, there's the not-good-enough story."
+- **Add kind imagery.** Warm healing light into the hurting parts. A figure who is a source of love (friend, parent, Gandhi, Mandela, religious figure) reaching out with compassionate words. Inner-child imagery.
+- **Add common humanity.** "Everybody hurts sometimes." "We all screw up and make mistakes." "All humans feel pain when life is tough."
+
+**Barriers.** Clients resist self-compassion for three main reasons. Negative reactions to the term — handled by dropping the word and using Two Friends. Lack of clarity about how it helps — handled by linking it to their concrete therapy goals using the choice point. And the stubborn belief that being hard on oneself is good motivation — handled by the **Donkeys, Carrots, and Sticks** metaphor: you can motivate your donkey with a stick or with carrots, both work, but one gives you a miserable beaten donkey. Humans have something even better than carrots — values. The metaphor segues straight into values and committed action. Beyond that, self-compassion work often triggers fusion (harsh self-judgment, "I don't deserve kindness") and experiential avoidance (because turning toward pain brings up anxiety, sadness, guilt, or shame); the antidotes are dropping anchor and defusion.
 
 ### Chapter 19: Know What Matters
 
-Values — the bedrock of ACT. Values are "desired global qualities of ongoing action," not goals. Harris hammers the values-vs-goals distinction with examples like "being loving" (value) vs "getting married" (goal). He gives six key points: values are here and now; they never need justification; they often need prioritizing; they're best held lightly; they're freely chosen; they include self and others. The signature exercise is **The Video of Your Mistakenly Held Funeral**.
+_Related: [Ch 20 — What If Nothing Matters](#chapter-20-what-if-nothing-matters) · [Ch 21 — Do What It Takes](#chapter-21-do-what-it-takes) · [Ch 6 — What's the Problem](#chapter-6-whats-the-problem)_
+
+Values — the bedrock of ACT. The entire model exists to build the capacity for mindful, values-guided action ("psychological flexibility"), and everything else — defusion, acceptance, present moment, self-as-context, committed action — is in service of living a richer, fuller, more meaningful life. Harris opens by noting some ACT protocols save values for later (after the mindfulness skills are built); others open with values to get clients motivated for the hard work. Both approaches have tradeoffs. This chapter covers the values-first machinery.
+
+**Definition.** Values are "desired global qualities of ongoing action" (Hayes et al.). Harris unpacks that in three pieces:
+
+- **Ongoing action** — how I want to behave, overtly and covertly, on an ongoing basis. Not a one-off.
+- **Global qualities** — qualities that unite many different patterns of action. Playing baseball is an ongoing action but not a _quality_. Playing baseball skillfully, enthusiastically, passionately, half-heartedly — those are qualities. Being supportive to teammates is a global quality because it shows up across many actions. Critically, global qualities stay available even if the specific activity is gone — even if I'm paralyzed from the waist down and can never play baseball again, I can still be focused, competitive, respectful, cooperative, fair.
+- **Desired** — statements about how I _want_ to behave, not what I _should_. Many textbooks use "chosen" to underline that these are consciously chosen, not imposed.
+
+**Values vs. goals — the core distinction.** Most clients fuse the two. Harris hammers the difference with the classic example: "getting married" is a goal (something that can be completed, crossed off, achieved), and "being loving" is a value (how I want to behave on an ongoing basis). I can achieve the goal of marriage while completely neglecting the value of being loving. (The marriage probably won't last.) Another: "getting a good job" is a goal; "being helpful, reliable, and honest" are values — and those values are available right now, even if I hate my current job or don't have one. Values are always available in this moment; goals never are.
+
+**Six key points about values.** Harris's framing bullets:
+
+1. **Values are here and now; goals are in the future.** In any moment I can act on a value or neglect it. Goals are always "out there." A goal-focused life tends to breed chronic lack and frustration — I'm always reaching for the next thing under the illusion it'll bring lasting happiness. A values-focused life brings fulfillment because the values are always accessible.
+2. **Values never need to be justified.** They're like taste in ice cream — I don't have to justify why I like chocolate. I may need to justify specific _actions_ (moving my family to the countryside), but not the underlying value (connectedness with nature).
+3. **Values often need to be prioritized.** Harris's metaphor: values are like continents on a spinning globe; you can never see them all at once. Throughout the day and across different roles and situations, some values come to the foreground while others recede. I may value being loving toward my parents, but if they're abusive, values of self-protection take the front of the globe in that relationship. The loving value hasn't disappeared — it's just around the back.
+4. **Values are best held lightly.** Pursue values vigorously but hold them lightly. If I fuse with a value, it turns into a rigid rule — _should_, _must_, _have to_, _the right way_, _do it perfectly or not at all_ — and becomes oppressive. The compass metaphor: I don't clutch the compass the whole journey; I pull it out of the backpack when I need direction, then put it away.
+5. **Values are freely chosen.** I don't have to act this way; I choose to because it matters to me.
+6. **Values include self and others.** If my value is kindness, I explore what kindness toward myself looks like _and_ what kindness toward others looks like. Same for honesty, fairness, being loving.
+
+**The Two Kids in the Car metaphor.** Harris's favorite illustration of point 1. Mom's driving two kids to Disneyland — three hours away. One kid is pure goal-focus: "are we there yet? are we there yet?" — a journey of sheer frustration. The other has the same goal but is also in touch with values of playfulness, curiosity, and exploring — she's looking out the window, waving at cars, spotting farm animals, singing along, playing I-spy. Both kids reach Disneyland at the same time and both have a great time when they arrive. But the second kid also had a rewarding journey, because she wasn't just chasing the goal — she was living her values. On the way home the first kid is already asking "are we home yet?" while the other is still enjoying the ride.
+
+**Exercises for connecting with values.** Harris gives three favorites:
+
+- **Ten Years from Now, Looking Back.** Imagine you're ten years in the future looking back on life as it is today. Complete three sentences: _I spent too much time worrying about..._, _I did not spend enough time doing things such as..._, _If I could go back in time, what I'd do differently is..._
+- **The Video of Your Mistakenly Held Funeral.** The signature exercise. Imagine I'm like Tom Hanks in _Cast Away_ — my plane crashes in the ocean, I survive unharmed but get stranded on a deserted island. Back home, everyone thinks I'm dead, and they hold a funeral. Weeks later I get rescued, fly home to a happy reunion, and some time later get to watch the video of that funeral. Someone I love very much — parent, partner, child, best friend — walks up to the microphone and starts talking about me. What would I love to hear them say about the sort of person I was, my greatest strengths and qualities, and the way I treated them?
+- **One Year from Now.** Imagine looking back one year from now at the difficulty I'm facing today, and I've handled it in the best possible way — like the person I really want to be. What qualities or strengths did I live by? How did I treat myself? How did I treat others I care about?
+
+**Working with values — the Values Smorgasbord.** Harris includes a diagram of the "pentazillion" ways to get at values; this chapter covers several, Extra Bits covers many more. The common tools include:
+
+- **The Bull's Eye** worksheet (from chapter 6).
+- **The Checklist of Common Values** — a long list clients can scan and mark as V (very important), Q (quite important), or N (not so important). Useful when the client has no idea what their values are despite Harris's best efforts. Sample entries: acceptance, adventure, assertiveness, authenticity, caring, compassion, connection, contribution, cooperation, courage, creativity, curiosity, fairness, fitness, flexibility, forgiveness, freedom, friendliness, fun and humor, gratitude, honesty, industry, intimacy, kindness, love, mindfulness, order, persistence, respect, responsibility, safety, sensuality, sexuality, skillfulness, supportiveness, trust.
+- **Conversational elicitation.** Harris includes a long transcript with a mother whose adult son has a heroin addiction and keeps demanding money. She says "sometimes I think it'd be easier if he would just die" and immediately calls herself a monster. Harris normalizes the thought (the mind is a problem-solving machine cranking out solutions), notices the guilt in her body, and then uses the guilt as the doorway: "what does this feeling tell you about your son, about what he means to you?" — "I just want him to be happy." Then the question "what sort of mom do you want to be?" unearths loving, kind, supportive. The session turns from self-attack into values-clarity to action (saying no to the money, making room for the shakiness that comes with it). Harris calls this kind of fluid movement between defusion, acceptance, and values "dancing around the hexaflex."
+
+**Shifting from goals to values — useful questions.** When a client gives me a goal (get a partner, get a job, be happy, have more self-confidence, stop using heroin, stop having panic attacks), I can fish out the underlying value by asking:
+
+- Suppose you achieve this — how would you treat yourself, others, and the world differently?
+- How would you behave differently in your relationships, work, social life, family life?
+- What personal qualities or strengths would achieving this let you demonstrate?
+- If loved ones found out, what qualities would you want it to inspire in them?
+- What would achieving this show you stand for?
+
+Harris's **practical tip**: if a client says what they _don't_ want ("I want to stop fighting with my mom"), ask "what do you want to do instead? How would you like to treat her?"
+
+**Practical tip on terminology.** Some clients bristle at the word "values." Harris keeps backup terms in his pocket: being yourself, being true to yourself, living life your way, your heart's deepest desires for how you want to behave, personal qualities and strengths you want to live by, qualities you want to model for others.
+
+**Flavoring and savoring** is Harris's favorite homework. Each morning before getting out of bed, pick one or two values to bring into play that day — say, "loving" and "kindness." Throughout the day, look for opportunities to sprinkle those values into whatever I'm saying and doing, giving my behavior that flavor. Then savor the effect — notice what difference it makes. New values each day or the same ones every day, my choice.
+
+**One more case Harris flags.** A client who is already doing all the right things — going to work, looking after kids, keeping fit — but feels deeply unfulfilled. Almost always the reason is that they're acting on their values without being psychologically present: lost in the to-do list, fused with perfectionism, running an internal not-good-enough commentary, stuck in worry or rumination. For these clients, the work isn't more values clarification — it's chapter 17, engaging and savoring and focusing.
 
 ### Chapter 20: What If Nothing Matters?
 
-Barriers to values work. When clients say "nothing matters" or "I don't know," the function is almost always experiential avoidance — values questions are painful, and "I don't know" is an escape hatch. Harris gives a long transcript showing how to press pause, validate, and return to the question. He also covers fusion with "should/must/have to" and the **willing vs. wanting** distinction: "You don't want to do it and you don't have to. Are you willing to do it anyway, because it matters?"
+_Related: [Ch 19 — Know What Matters](#chapter-19-know-what-matters) · [Ch 21 — Do What It Takes](#chapter-21-do-what-it-takes) · [Ch 31 — Getting Unstuck](#chapter-31-a-quick-guide-to-getting-unstuck)_
+
+Barriers to values work. When values questions land, clients often go cold — "I don't know," "Nothing matters," "I have no values," "What's the point" — and Harris's read is that the function is almost always experiential avoidance. Values questions hurt, and "I don't know" is the cheapest escape hatch. The chapter is a catalog of those barriers and how to detour around them.
+
+**The transcript move.** Harris spends several pages on a long therapist-client transcript that models the response to "I don't know / I don't have any values." The therapist presses pause, names what's happening ("we're both getting a bit stuck"), validates that this is the hardest part of therapy, runs a brief mindful check-in to surface the underlying anxiety, and reframes the "I don't know" as the mind's problem-solving move to escape the discomfort. Then a workability question: what's it cost you so far, going through life without an inner compass? And finally, a choice — give up on values work and keep getting what you've been getting, or persist as an experiment. Harris notes that throughout this single transcript you can spot defusion, acceptance, flexible attention, committed action, workability, and willingness — ACT processes braid together even when the ostensible work is "just" values.
+
+**Fusion as a barrier.** When fusion (not pure avoidance) is blocking values work, Harris lists the four fusions to watch for: fusion with reasons ("I can't until I get a job / feel better / win them back"), fusion with judgments ("this is bullshit"), fusion with self-concept ("I'm a bad person, I don't deserve this"), and fusion with past or future ("I've tried this before, it won't work"). The move is to dance across the hexaflex from values to defusion, do a few unhooking reps, then come back.
+
+**"Nothing matters."** Harris's first reply is a curiosity move: "On the one hand I hear you saying nothing matters, and on the other hand I see you sitting here in front of me. So what matters enough that you came to therapy?" Whatever answer the client gives — partner, kids, "I'm sick of feeling depressed," "my doctor made me" — gets reframed into a value: caring for others, self-caring, caring about your health. Even the most reluctant answer becomes the seed of a value.
+
+**"I don't know."** Sometimes this is literal — the client has no idea what "values" even means and needs psychoeducation plus a values card sort or the Checklist of Common Values. Sometimes it's a request for help. And sometimes the move is just to ask the client to "sit with the question": close your eyes for a minute or two, don't say anything, let the mind keep going. Often answers surface. But Harris is honest that most of the time "I don't know" is experiential avoidance and the response is the transcript above.
+
+**"Should" and "must" and "have to."** Fusion with rigid rules — should, must, ought, right, wrong, perfect, don't screw up — disconnects me from values. Watch for the somatic tells: heaviness, burden, perfectionism, resentment, compliance rather than commitment. The move is defusion plus the **willing vs. wanting** distinction: "Your mind says you have to do this. We both know you don't have to. The question is, are you _willing_ to do it, even though it's uncomfortable?" Harris hammers this distinction: I don't have to want to do the hard thing, and I don't have to pretend I want to. I just have to be willing.
+
+**Desire for approval.** For clients fused with parental or cultural rules, Harris's magic-wand question: imagine I wave a wand and from now on everyone whose opinion matters to you automatically loves and approves of whatever you do — saint or serial killer, billionaire or homeless. From now on, you never have to impress anyone again. _Then_ what would you do with your life?
+
+**"Are these my real values?"** Harris refuses to get pulled into a long intellectual discussion. His answer is the proof-of-the-pudding move: we'll never know by talking about it. Go live by them and notice — do you get vitality, meaning, a sense of being more like the person you want to be? If so, those are real values. Stop analyzing and start eating.
 
 ### Chapter 21: Do What It Takes
 
-Committed action. Harris covers problem solving, goal setting, and action planning. The key tool is the **Challenge Formula**: for any difficult situation, you have three options — leave, stay and live your values (change what you can, make room for the pain), or stay and give up acting effectively. He introduces **SMART goals** (Specific, Motivated by values, Adaptive, Realistic, Time-framed) and the **dead person's goal** test.
+_Related: [Ch 19 — Know What Matters](#chapter-19-know-what-matters) · [Ch 24 — What's Stopping You](#chapter-24-whats-stopping-you) · [Ch 22 — Acceptance](#chapter-22-fifty-shades-of-acceptance)_
+
+Committed action — translating values into ongoing patterns of effective behavior. Harris folds in all the standard behavioral tools (problem solving, goal setting, action planning, role-play, exposure, behavioral activation) but insists they ride on top of values, not "shoulds." Without values underneath, goal setting becomes another stick to beat yourself with and fails predictably.
+
+**Mindful, values-based problem solving.** The actual steps (define the problem, brainstorm, evaluate, plan, implement, observe, modify) are the same as in any other model. The ACT difference is what comes _before_ them: drop anchor, unhook from unhelpful thoughts, accept any difficult feelings, and connect to values — _then_ problem-solve. Harris notes that most "problem-solving gone haywire" — rumination, worrying, obsessing, suicidal ideation — is the cognitive engine running without those upstream steps.
+
+**The Challenge Formula.** Harris's signature tool for any difficult situation. Three options, always:
+
+1. **Leave.**
+2. **Stay and live by your values** — change whatever you can to improve the situation, and make room for the pain that comes with it.
+3. **Stay and give up acting effectively** — do things that make no difference or make it worse.
+
+Option 1 isn't always available (prison, refugee camp, chronic illness), but if it _is_ available, take it seriously. Option 3 is the default — it's what we slide into when we get hooked. Option 2 is the work. Harris co-wrote a WHO protocol for refugee camps built around this formula: even a refugee can choose how to treat his neighbors, whether to join community activities, whether to be caring or withdrawn inside the tent. The little choices add up. The "make room for the pain" half of option 2 is dropping anchor, defusion, acceptance, and self-compassion.
+
+**SMART goals.** Harris's version of the acronym is specific to ACT:
+
+- **S** = Specific. Name the actual physical or psychological action. Not "I'll be more loving" but "I'll give my partner a long hug when I get home."
+- **M** = Motivated by values. Double-check the goal is aligned with the values you actually care about, not someone else's shoulds.
+- **A** = Adaptive. Wise. Is this likely to actually improve your life?
+- **R** = Realistic. Match the goal to the resources you have. If the resources are missing, the new goal might be to find the resources first.
+- **T** = Time-framed. A specific day, date, and time — as concrete as you can get.
+
+Harris is honest that formal SMART goal setting is a lot of work, and for most things informal goal setting ("notice your towards moves," "practice this skill once this week") is fine. Reach for SMART when you're trying to do something specific and difficult and you keep failing.
+
+**The dead person's goal test.** A "dead person's goal" is anything a corpse can do better than you. "I won't yell at the kids" — a corpse never yells, perfectly, every time. "I'll stop smoking" — a corpse never smokes. Any "I won't X" or "I'll stop Y" is a dead person's goal. The fix is always to specify what you _will_ do instead: "When the kids push my buttons, I'll drop anchor, breathe into my anger, connect to my value of patience, and speak to them calmly." That's a live person's goal — something I can do better than a corpse can.
+
+**The 7-out-of-10 rule.** For any goal, big or small, ask the client: on a 0-10 scale where 10 is "I'll definitely do this no matter what" and 0 is "I'll never do this," how realistic is it? If it's under 7, shrink the goal until it scores 7+. Harris credits this to Kirk Strosahl. It's the fastest way to surface whether you're committing to fantasy or to something you'll actually do.
+
+**Plan B and external obstacles.** Anticipate what could go wrong and pre-commit a fallback. "If you can't do X, what's another move that lives the same value?" Harris is firm that the fantasy of "I'll figure it out when I get there" is a setup for the next session's "I didn't do it because…"
+
+**The Gun at Your Head metaphor.** To make the control distinction concrete: if I held a gun to your head and demanded you have no fear or anxiety, could you? No. But if I held a gun to your head and demanded you dance like a penguin and sing Happy Birthday, could you? Of course. We have far more control over our physical actions — what we do with our arms, legs, voice, and face — than we do over our thoughts and feelings. Stop trying to control the inner stuff and pour the energy into the outer stuff.
+
+**When the goal is to change others.** Convert outcome goals ("I want my partner to be more affectionate") into behavioral goals about what I will do (more bids for connection, clearer requests, more reinforcement of the behavior I want). I can never control another person — only influence them. Harris teaches the standard interpersonal skills (assertiveness, clear requests, boundaries, perspective-taking) and the **5:1 magic ratio** — at least five times as much reinforcement of the behavior you want to increase as punishment of the behavior you want to decrease.
+
+**When the goal is impossible.** Harris's case study of Alex, a former football player with chronic pain who kept saying he wanted to play football again. The move is not to argue with the goal but to validate the pain of the **reality gap** ("when there's a huge gap between what you want and what you've got, that hurts"), accept and defuse from the grief, then dig _underneath_ the goal to find the values it was serving — being active, contributing, being competitive, being sociable. Then build new realistic goals on those values. Alex ended up volunteering at an old folks' home, making tea and playing chess with residents. A million miles from football, and still living the same values. The four-step recipe:
+
+1. Validate the pain of the reality gap.
+2. Respond with acceptance, defusion, self-compassion.
+3. Find the values _underneath_ the impossible goal.
+4. Set new goals based on those values, realistic for current life.
+
+**Action planning and the tiniest step.** Harris's go-to question when a client knows the goal but is stuck: _"What's the smallest, tiniest, simplest, easiest step you can take in the next twenty-four hours that will take you a little bit further in that direction?"_ And the warning that comes with it: don't get fused with the long-term goal. Living values is a journey that ends only at the final breath, and every tiny step counts. He quotes the Tao Te Ching ("the journey of a thousand miles begins with one step") and Aesop ("little by little does the trick").
+
+The chapter closes with a setup for the next one: committed action almost always brings discomfort. If I'm not willing to make room for that discomfort, I won't do what it takes to grow. Which is why Chapter 22 is acceptance.
 
 ### Chapter 22: Fifty Shades of Acceptance
 
-The long chapter on acceptance. Harris offers the **three As** — acknowledge, allow, accommodate — and a 13-step **Acceptance of Emotions** exercise. The exercise stitches together techniques: link to values, observe like a curious child, name the feeling, breathe into it, expand around it, allow it, physicalize it (what shape/color/temperature would it have as an object?), normalize it, be self-compassionate (Kind Hand), and expand awareness back to the whole stage show. He introduces the **Struggle Switch** metaphor and treats acceptance as a 0-to-10 scale rather than all-or-nothing. A client going from 9 (total struggle) to 3 (mostly allowing) is a massive win, even if the feeling itself hasn't changed at all.
+_Related: [Ch 8 — Creative Hopelessness](#chapter-8-creative-what) · [Ch 9 — Drop the Struggle](#chapter-9-drop-the-struggle) · [Ch 23 — Emotions as Allies](#chapter-23-emotions-as-allies) · [Ch 26 — Flexible Exposure](#chapter-26-flexible-exposure)_
+
+The long chapter on acceptance, which Harris also calls willingness, expansion, opening up, or making room. Critically, acceptance is _experiential_ acceptance — opening up to thoughts, feelings, memories, urges, and sensations. It is **never** passive acceptance of the life situation. The book is _Acceptance_ AND _Commitment_ Therapy for a reason: I open up to the inner pain so I can take action on the outer situation.
+
+**The language of acceptance.** Clients hear "acceptance" and assume it means resignation, tolerance, or approval. Harris avoids the word early in therapy. His preferred alternatives: allow it, open up and make room, expand around it, sit with it, drop the struggle, let it be, breathe into it, hold it gently, lean into it. "Willingness" is another good substitute. Pick the language the client doesn't recoil from.
+
+**Routes in.** Harris notes there's no fixed sequence. You can come at acceptance from defusion ("we've looked at how to unhook from thoughts — what about feelings?"), from values ("as you talk about these values, what feelings show up?"), from committed action ("what feelings will you need to make room for in order to do this?"), or from self-as-context ("using the part of you that notices, let's take a look at these feelings"). The most experientially avoidant clients need the slowest, gentlest route — usually with extra creative-hopelessness work first.
+
+**The three As.** Harris's framework for acceptance — three overlapping phases, not discrete stages:
+
+- **Acknowledge.** Notice the inner experience with curiosity and name it nonjudgmentally. This overlaps with the first step of defusion and dropping anchor.
+- **Allow.** Give it permission to stay. The internal script: _"I don't like this feeling, but I'll allow it."_
+- **Accommodate.** Actively make room. Harris's metaphor: an unwanted but harmless relative shows up at your door. You acknowledge him on the doorstep, allow him inside, and then go further — offer him a seat and a cup of coffee. "Accommodate" carries three meanings: provide space for, fit in with, and adapt to. All three apply.
+
+**The Acceptance of Emotions exercise — 13 techniques in one.** The chapter's centerpiece is a long mindfulness exercise built from thirteen techniques strung together. Harris is up front that it's too much for many early-therapy clients and that it's really a tool kit; you can pick any one or two of the techniques and run a much shorter version. The full sequence:
+
+1. **Link to values and goals.** Before starting: remind me why we're doing this. What values are you living? What will this enable you to do differently? Without this link, clients resist.
+2. **Observe like a curious child.** Sit upright, eyes closed or fixed. Tap into curiosity — notice your posture, feet, hands, what you can hear, smell, taste, think, feel.
+3. **The part that notices.** Plant the self-as-context seed: there's a part of you that notices everything, always there, always noticing. Use that part to step back and observe the difficult feelings.
+4. **Radio mind.** Let the mind chatter like a radio in the background. When thoughts hook you, acknowledge, unhook, refocus.
+5. **Notice.** Where does the feeling start and stop? What shape is it, 2D or 3D, on the surface or inside? Where is it most intense, where weakest? Sensations within sensations, layers within layers.
+6. **Name.** Silently: _"I'm noticing a feeling of X."_ Not "I am anxious" — "I'm noticing anxiety." The grammar separates me from the feeling.
+7. **Breathe.** Breathe into and around the feeling. (Skip if breath focus distresses the client — a small minority dislike it.)
+8. **Expand.** Open up around the feeling. Make space for it. _"It's as if, in some magical way, all this space opens up inside you."_
+9. **Allow.** Let the feeling be there. Don't try to change or remove it. Changing it isn't the goal — allowing it is. If it changes by itself, fine. If it doesn't, fine.
+10. **Physicalize.** Imagine the feeling as a physical object. Shape, color, temperature, texture, transparency. Notice you are bigger than the object — no matter how big it gets, it can never get bigger than you. (Harris is firm: do _not_ try to dissolve or shrink it with white light or any other trick. That's emotional control dressed up as mindfulness.)
+11. **Normalize.** This feeling tells you you're a normal human being with a heart, that you care, that there are things in life that matter to you. Humans feel this way when there's a gap between what we want and what we've got. The bigger the gap, the bigger the feeling.
+12. **Be self-compassionate** (the **Kind Hand** move). Place a hand on the part of the body where the feeling is strongest. Imagine it's a healing hand — the hand of a loving friend, parent, or nurse. Feel the warmth flowing in. Not to get rid of the feeling, but to make room for it. Hold it gently, as if it were a crying baby or a frightened puppy.
+13. **Expand awareness.** Bring up the lights on the rest of the **stage show**. Notice your arms and legs, the room, sounds, the therapist. The feeling is still on stage — but it's now one element in a much bigger scene. Move your limbs, stretch, open your eyes, look around.
+
+For each technique Harris also gives a **ten-second version** so you can drop in any single move conversationally without running the full exercise. Examples: "Notice that feeling. Notice where it's most intense." / "Use that noticing part of you to really observe this." / "Notice it and gently breathe into it." / "Just open up and give it some space." / "I know you don't want this — see if you can let it sit there for a moment." / "If this feeling were an object, what would it look like?" / "It's completely natural and normal that you'd feel this way." / "Place a hand where you feel it most, and see if you can hold it gently." / "Notice the feeling, and your body, and the room, and you and me here together — there's a lot going on."
+
+**Harris is emphatic about two things after the exercise lands.** Either the feeling will change or it won't, and it doesn't matter either way. If it reduces or vanishes, that's a bonus, not the goal. If clients start using acceptance techniques to make feelings go away, they're doing **pseudo-acceptance** — avoidance dressed up in mindfulness clothes — and they'll be back next session saying "it's not working."
+
+**The Struggle Switch metaphor.** Harris's signature acceptance metaphor (and the one I lean on most). Imagine a switch at the back of the mind. Switch _on_: I must get rid of any unpleasant feeling that shows up. So when anxiety arrives, I get anxious about my anxiety, then angry about being anxious, then depressed about being angry — the switch is an emotional amplifier and the secondary feelings are useless drains on energy. Switch _off_: anxiety arrives, it's still unpleasant, but I'm not pouring fuel on it. The natural feeling is free to rise and fall as the situation dictates. I put my energy into doing things that matter, instead of into the struggle.
+
+**Acceptance as a 0–10 scale.** Harris pushes back on the textbook claim that acceptance is all-or-nothing. He treats it as a scale and uses the **struggle scale** as the practical measurement (clients find struggle easier to rate than acceptance):
+
+- **10** = full struggle, "I have to get rid of this no matter what" (maximal avoidance)
+- **5** = tolerance, gritted-teeth putting up with it
+- **0** = no struggle, "I don't like it but I'm not fighting it" (maximal acceptance)
+
+A client moving from 9 to 3 on the struggle scale is a massive win, even if the underlying feeling is unchanged. The transcript Harris uses: client rates the struggle at 9, runs through several acceptance moves, comes back at 3, mentions the anxiety has also dropped. Harris's response: enjoy that, but our aim is the struggle, not the anxiety. Want to keep going and bring it down another notch?
+
+**Acceptance is not tolerance.** Harris is firm on this. Tolerance is gritted teeth — sitting at the 5 mark on the struggle scale, hating the feeling but enduring it. Acceptance is something different: "I don't like this, and I'm letting it be here anyway." The difference is the dropping of the fight, not the gritting of the teeth.
+
+**Common pitfalls Harris flags.** Too much talk and not enough experiential work (analysis paralysis). Reinforcing avoidance by getting excited when the feeling reduces. Insensitivity (rushing in with techniques without validation). Failing to link acceptance to values. Being too pushy with experiential exercises before the client is ready. Each pitfall predictably backfires, and most "ACT isn't working" sessions trace back to one of them.
 
 ### Chapter 23: Emotions as Allies
 
-Psychoeducation about what emotions are for. Harris argues emotions serve three purposes: **communicate** (to others), **motivate** (prepare us to act), and **illuminate** (what matters).
+_Related: [Ch 22 — Acceptance](#chapter-22-fifty-shades-of-acceptance) · [Ch 28 — Problem Emotions](#chapter-28-shame-anger-and-other-problem-emotions) · [Ch 19 — Know What Matters](#chapter-19-know-what-matters)_
 
-- Fear: communicates danger, motivates flight, illuminates safety and protection.
-- Anger: communicates violation, motivates fighting, illuminates boundaries and defended territory.
-- Sadness: communicates loss, motivates rest and withdrawal, illuminates what I cared about.
-- Guilt: communicates "I've done wrong," motivates repair, illuminates how I want to treat others.
-- Love: communicates appreciation, motivates caring, illuminates connection and bonding.
+Psychoeducation about what emotions are for, and a refutation of the "ACT is too cognitive, it doesn't deal with feelings" complaint. The move in this chapter is _past_ acceptance: once I've stopped fighting an emotion, I can tune into it and use it.
 
-The ACT slogan from this chapter: **"Your pain is your ally."** Emotions are messengers carrying gifts. Once an emotion is accepted, I can ask what it's telling me about what matters, what I need to do differently, or how I want to treat myself.
+**Emotions vs. physical actions.** Harris's foundational distinction. At the core of any emotion is a complex of neurological, hormonal, cardiovascular, and musculoskeletal changes that prepare the body to act. We notice these as sensations and as **action tendencies** — the inclination to cry, hide, shout, run. But "tendency" is the key word. A tendency is not a command. Anxiety about being late gives me the tendency to speed; it doesn't force me to. Anger gives me the urge to yell; I can still choose to talk calmly. We can _separate physical actions from emotions_ — control the voice, face, posture, and behavior even when we can't control the inner state. Most of the work in ACT runs on this distinction. A client with anger problems learns to feel the fury and act calmly. A client with anxiety learns to feel the fear and act courageously. Harris insists this is _not_ "fake it till you make it" — the aim is to honestly acknowledge what I'm feeling and also behave like the person I want to be. No faking.
+
+**The three purposes of emotions: communicate, motivate, illuminate.** Harris's compressed model.
+
+- **Communicate.** Emotions (technically, the physical actions that express them — facial expression, posture, voice, tears) signal to others what's going on inside us. Done appropriately with the right people, this elicits the support we need. Harris is careful that this only works when (a) we're willing to actually express the emotion rather than mask it, and (b) we're expressing it to people likely to respond with care.
+- **Motivate.** The words emotion, motivate, motion, and move all share the Latin root _movere_, "to move." Emotions evolved to prepare the body for action — fight, flight, repair, withdraw, connect.
+- **Illuminate.** Emotions shine a light on what matters. They show me what I care about, what I need to attend to, what's at stake.
+
+**The table of five emotions.** Harris runs all five through the three purposes:
+
+- **Fear** — communicates "watch out, danger" or "I find you threatening"; motivates running and hiding; illuminates the importance of safety and protection.
+- **Anger** — communicates "this isn't fair" or "you're trespassing on my territory"; motivates standing ground and fighting; illuminates the importance of defending boundaries and what's mine.
+- **Sadness** — communicates "I've lost something important"; motivates slowing down, withdrawing, resting; illuminates the importance of recovery after a loss and the value of what was lost.
+- **Guilt** — communicates "I've done something wrong and want to put it right"; motivates making amends and repairing social damage; illuminates how I want to treat others.
+- **Love** — communicates "I appreciate you, I want you close"; motivates loving, caring, and nurturing; illuminates the importance of connection, intimacy, and bonding.
+
+Harris's framing: emotions are messengers carrying gifts. The more I cut off from them, the more of the message I miss.
+
+**How to gain the wisdom of emotions.** The classic ACT slogan from this chapter:
+
+> Your pain is your ally.
+
+Once an emotion has been accepted, Harris suggests asking it questions:
+
+- What does this emotion remind you to do in terms of caring for yourself or others?
+- If this emotion could give you words of advice, what would it say? Will following that advice take you toward or away from your values?
+- What does it tell you about what matters, what you want, what you need to address, what you need to do differently?
+- If you expressed it appropriately to someone caring, what might that signal — and how might they help?
+
+Out of these explorations almost always come values, needs, and small concrete towards moves.
+
+**Harnessing the energy of emotions.** Some emotions — especially fear and anger — are massively energizing. Once I've defused and made room for them, I can channel that energy into action. Harris's example is performance anxiety: actors and musicians universally feel it, and they reframe it as being "amped" or "revved up" rather than trying to suppress it. Same physiology, different relationship.
+
+**Dissociation.** Some clients are so cut off they "don't feel anything" — Harris notes this is technically dissociation and correlates with high experiential avoidance. They _do_ feel something: numbness, emptiness, hollowness, deadness. The acceptance moves work the same way on numbness as on any other sensation: find where it's most intense, observe it, name it, breathe into it, make room. Often when numbness is accepted, buried feelings surface.
 
 ### Chapter 24: What's Stopping You?
 
-Why clients (and I) fail to follow through on commitments. The acronym is **HARD**:
+_Related: [Ch 21 — Do What It Takes](#chapter-21-do-what-it-takes) · [Ch 31 — Getting Unstuck](#chapter-31-a-quick-guide-to-getting-unstuck) · [Ch 18 — Hold Yourself Kindly](#chapter-18-hold-yourself-kindly)_
 
-- **H**ooked by unhelpful thoughts → defusion
-- **A**voiding discomfort → acceptance
-- **R**emoteness from values → reconnect to why this matters
-- **D**oubtful goals (unrealistic) → shrink the goal until it's actually doable
+The chapter on broken commitments — why clients (and I) leave a session fired up and come back having done none of it. Harris opens by normalizing it hard: when a client comes back without having done the homework, his first move is _"You are so like me!"_ followed by some self-disclosure about his own broken commitments. This unhooks the client from the "not good enough" story before any diagnosis happens. Then: "Can we figure out what got in the way last time, because whatever it was is going to get in the way next time too?"
 
-Harris distinguishes two commitment patterns: pattern 1 is "make a commitment, break a commitment, give up." Pattern 2 is "make, break, lick wounds, pick yourself up, learn, get back on track." Pattern 2 is the only one that grows. He also makes the case for "live person's goals" — if a corpse can do it better than me ("I won't yell"), it isn't a real goal.
+**HARD — the four common barriers.** Harris's diagnostic acronym, replacing the more complex FEAR-to-DARE worksheet from the first edition. For any commitment I'm not following through on, one of these four is almost always live, and naming it tells me which ACT skill to reach for:
+
+- **H = Hooked.** What reasons does my mind give for why I can't, shouldn't, or shouldn't even have to take action? What bad things does it predict? If I'm hooked by these thoughts, I won't act. _Antidote: defusion._ I can't stop my mind from saying these things, but I can unhook from them.
+- **A = Avoiding discomfort.** Personal growth and meaningful change always involve stepping out of the comfort zone, which always brings discomfort. If I'm not willing to make room for it, I won't do the thing. _Antidote: acceptance and expansion._ Think ahead — what discomfort is likely to show up, and am I willing to make room for it?
+- **R = Remoteness from values.** Why am I bothering to do this challenging stuff if it's not actually important? If it _is_ important, I've forgotten why. _Antidote: reconnect with values._ What values will I be living with every step?
+- **D = Doubtful goals.** On a 0–10 scale, how realistic does the goal seem? If it's under 7, follow-through is doubtful. The goal is too big, too ambitious, too perfect, or asking for resources I don't have. _Antidote: shrink the goal._ Make it smaller, simpler, easier, more matched to current resources, until it scores at least a 7.
+
+The chapter has a printable **What's Stopping You?** worksheet that walks the client through each letter for either a specific life domain or as a general overview.
+
+**Workability and willingness.** Harris's other lever for motivation is the choice point and the language of payoffs and costs. For an unworkable behavior (e.g. the case study of a 19-year-old who self-harms to escape numbness), the move is to **validate the payoffs first** — it does work in the short term, it does make her feel more alive, and it's not surprising she has mixed feelings about stopping — and _then_ compassionately surface the costs (scarring, shame, hiding, distance from her self-care value). Harris is firm that you cannot skip the payoff validation. If you go straight to the costs, you're moralizing and the client feels lectured. Then the flip: identify the new behavior the client wants to do instead (here, massaging skin cream and the **Kind Hand** self-compassion exercise), highlight the payoffs of that behavior, and validate the costs that come with it. The willingness question that captures the whole move:
+
+> Are you willing to make room for all this difficult stuff, in order to go ahead with these towards moves?
+
+**The two commitment patterns.** Harris's framing for the inevitability of breaking commitments:
+
+- **Pattern 1:** Make a commitment, break a commitment, give up.
+- **Pattern 2:** Make a commitment, break a commitment, lick your wounds, pick yourself up, learn from it, get back on track, make another commitment.
+
+Pattern 1 leads to getting stuck. Pattern 2 is the only one that grows. The job is to ask the client which pattern they're in, and if it's Pattern 1, look at it honestly through the lens of workability. Harris also notes that beating yourself up doesn't help — _"if beating yourself up were a good way to change behavior, wouldn't you be perfect by now?"_ — and the response to a broken commitment is self-compassion first, reconnect to values, get moving again.
+
+**If all else fails.** Harris's three-step fallback when nothing's working: (A) acknowledge that right now nothing is helping — that's the current reality, and it may change later but for now it's where we are; (B) acknowledge the difficult thoughts and feelings and practice self-compassion; (C) recognize that life is bigger than this one stuck issue and shift focus to other domains where the client _can_ live their values and make towards moves. Don't let one stuck area swallow the whole life.
 
 ### Chapter 25: The Noticing Self
 
-Self-as-context. Harris warns this is the trickiest concept in ACT and introduces it via metaphors: the **Stage Show** and the **Sky and the Weather**. The experiential exercise is the **Continuous You** — five repeating instructions:
+_Related: [Ch 10 — Dropping Anchor](#chapter-10-dropping-anchor) · [Ch 15 — Leaves on a Stream](#chapter-15-leaves-streams-clouds-and-sky) · [Ch 17 — Being Present](#chapter-17-being-present) · [Ch 27 — Cognitive Flexibility](#chapter-27-cognitive-flexibility)_
 
-1. Notice X (breath, thoughts, body, feelings, roles).
-2. There's X — and there's a part of you noticing X.
-3. If you can notice X, you cannot be X.
-4. X is a part of you; there's so much more to you than X.
-5. X changes; the part of you noticing X does not change.
+Self-as-context, the trickiest concept in ACT. Harris opens the chapter by warning he's about to try to make it simple and may fail, then spends the longest chapter in the book on it. This is also the chapter I most want to lift into my own practice, so the summary is long.
 
-He also introduces the **Good Self/Bad Self** exercise to defuse from self-concept: write all your "I'm good" thoughts on one side of a piece of paper and all your "I'm bad" thoughts on the other. Hold either side up to your face and notice you can't see the room. Drop the paper in your lap and notice you can. Both kinds of self-concept are equally hooking — high self-esteem and low self-esteem are both fusion.
+**Definition.** The observing self is the _locus or perspective from which all noticing happens_ — metaphorically a "safe place" inside me and a "viewpoint" from which to step back and watch thoughts and feelings pass. I access it by actively noticing that I'm noticing — bringing awareness to my own awareness. Harris's synonyms: self-as-perspective, observing self, noticing self, observer self, silent self, transcendent self, pure awareness, the continuous you, the "I" that notices. Harris openly admits the observing self isn't a "self" or a "part" at all; technically it's a repertoire of covert behavior. Calling it a self is a metaphor, but the metaphor works, so it stays.
+
+**The five aims** for working with it explicitly:
+
+1. **Defusion from the conceptualized self.** If I can _notice_ the thought "I'm broken," I can't _be_ it.
+2. **Acceptance of feared feelings.** The noticing self is a safe vantage point from which to open up. From the sky, no storm can hurt me.
+3. **Flexible present-moment contact.** The same part of me that notices a thought also notices my feet on the floor.
+4. **A stable sense of self when life is chaotic.** My body, roles, and feelings change; the noticer doesn't. That constancy is a thing to stand on when everything else is moving.
+5. **A transcendent sense of self** — the felt sense that there's more to me than my body and my mind. The full Continuous You exercise often lands as a spiritual experience.
+
+Harris structures the chapter around three overlapping classes of intervention: metaphors, experiential "notice your noticing" exercises, and exercises to defuse from self-concept.
+
+**Metaphors:**
+
+- **The Stage Show.** Life is a huge stage show. On it are my thoughts, feelings, and everything I see, hear, touch, taste, smell, and do. The show changes moment to moment. There's a part of me that can step back and watch it — always there, always watching, able to zoom in on any detail or zoom out to the whole show. When I get hooked, a performer has grabbed me and pulled me up onto the stage.
+- **Sky and Weather.** My noticing self is the sky. Thoughts and feelings are weather. No storm can harm the sky, and the sky always has room for the weather. Sometimes clouds obscure the sky, but rise high enough — even above the darkest thunderclouds — and I reach clear sky, stretching in every direction. Harris notes this metaphor shows up in Hindu, Buddhist, and Taoist traditions; ACT didn't invent it.
+- **The Chessboard** (from the Extra Bits). Thoughts and feelings are the pieces — white ones I like, black ones I don't. The board is the part of me that holds them all. I've spent my whole life picking sides in a game where the board itself is the safe place.
+
+Harris is emphatic that **no metaphor will give me the actual experience** — for that I need experiential exercises. The good news is the observing self is already implicit in every mindfulness practice I do, so building it is mostly about noticing that I'm noticing inside practices I'm already running. Harris calls this "planting seeds" and starts doing it in chapter 10 (dropping anchor) and chapter 15 (Leaves on a Stream) — long before chapter 25 ever names self-as-context — by slipping lines like "and there's a part of you that notices everything" into those earlier exercises.
+
+**Experiential exercises — the ladder from short to long:**
+
+1. **The one-line upgrade (the seed).** Inside any mindfulness practice I'm already doing, slip in: _"and as I notice X, be aware I'm noticing. There's X, and there's a part of me noticing X."_ Harris inserts this sentence into dropping-anchor, Leaves on a Stream, and acceptance exercises — any practice with "notice" in it. One sentence; does half the work.
+2. **Talking and Listening (30 seconds).** For 30 seconds, silently listen to what my mind is saying. If the thoughts stop, keep listening until they start again. Harris's payoff line: _there's a part of my mind that talks — the thinking part — and a part of my mind that listens — the noticing part._ First-contact exercise; works almost immediately.
+3. **There Go Your Thoughts (2–3 minutes).** Ask: where are my thoughts located in space — above me, behind me, to one side? What form — pictures, words, or sounds? Moving or still? If moving, what direction and speed? Notice two separate processes: thinking (my mind throwing up words and pictures) and noticing (a part of me watching the throwing). My mind will whir, debate, and try to intellectualize — fine, just watch it doing that too.
+4. **The Continuous You (10–15 minutes, the heavy lift).** The classic exercise from Hayes et al., built on five repeating instructions applied in turn to my breath, my thoughts, my body, my feelings, and my roles:
+   1. Notice X.
+   2. There is X — and there's a part of you noticing X.
+   3. If you can notice X, you cannot be X.
+   4. X is a part of you; there's so much more to you than X.
+   5. X changes; the part of you noticing X does not change.
+
+   For each X, Harris adds a childhood anchor: _when you were a child, X was different — but the you who could notice X as a child is the same you noticing it now._ That's the move that makes the unchanging noticer tangible. Longer versions of the exercise walk the client back through memories from several periods of life and point out that the noticing self was present when every one of those memories was recorded. End with the Sky and Weather metaphor. Do not analyze it afterward — Harris warns explicitly that intellectualizing it flattens it.
+
+5. **Brief stage-show step-backs, two or three times a day (the homework).** After the Continuous You lands, Harris prescribes this as the ongoing practice: 20–30 seconds to drop in, notice the stage show, notice it has changed since the last check-in, notice that the part watching the show has not. This is the rep count that builds the muscle.
+
+**Defusing from self-concept — the Good Self / Bad Self exercise.** Write all "I'm good" thoughts on one side of a piece of paper (kind, smart, hardworking, generous) and all "I'm bad" thoughts on the other (loser, selfish, fraud, lazy). Hold either side up in front of my face — I can't see the room, can't engage with anyone, can't act on what matters. Turn it over and hold the "good" side in front of my face — same result. Drop the paper in my lap — the thoughts are all still there, but I'm free to engage. The punch line: **both high and low self-esteem are fusion**. The problem isn't that I'm thinking bad things about myself; the problem is that I'm holding the paper up in the first place. The fix isn't better self-talk, it's dropping the paper.
+
+**"Who am I, then?"** Harris's one-liner when clients ask this and he doesn't want to get sucked into philosophy: in everyday language we talk about two selves — the physical self (body) and the thinking self (mind). There's a third we rarely name — the noticing self — which notices both the other two. I am all three at once, one whole human being. There are no actual separate bits of me.
+
+**Is making self-as-context explicit necessary?** Harris's honest disclaimer is no. Many ACT therapists never name self-as-context and let it grow as a side effect of the rest of the mindfulness work. Explicit SAC work is _essential_ only for aim 5 (transcendent sense of self); for aims 1–4 it just accelerates what dropping-anchor, defusion, and acceptance are already building.
 
 ### Chapter 26: Flexible Exposure
 
-Exposure in ACT is different from classical exposure — it's not about habituation or distress reduction. Harris's definition: "organized contact with repertoire-narrowing stimuli for the purpose of increasing response flexibility." Success is measured by whether behavior becomes more flexible, not whether anxiety drops. A client can finish exposure with unchanged anxiety but radically expanded behavior and still have succeeded. This is aligned with the newer inhibitory learning theory of exposure, which found no correlation between anxiety reduction during exposure and long-term behavioral change.
+_Related: [Ch 22 — Acceptance](#chapter-22-fifty-shades-of-acceptance) · [Ch 27 — Cognitive Flexibility](#chapter-27-cognitive-flexibility) · [Ch 28 — Problem Emotions](#chapter-28-shame-anger-and-other-problem-emotions)_
+
+ACT is an exposure-based model all the way down, but the exposure looks nothing like what I learned exposure was. Harris spends the chapter rewriting the definition and the success criterion.
+
+**Old-school exposure.** The standard definition Harris grew up with: "organized contact with fear-evoking stimuli for the purpose of habituation." Build a hierarchy (spiders: talk about them, imagine them, look at drawings, photos, videos, dead ones in jars, live ones in jars, on the floor, crawling), expose the client, measure **SUDS** (Subjective Units of Distress Scale, 0–10), and declare success when SUDS drops by about half. The entire scoreboard is distress reduction.
+
+**What the research actually shows.** Harris points to the **inhibitory learning theory** work (Craske et al.) which found _no correlation_ between SUDS drops during exposure and long-term behavioral change. Clients can finish with unchanged distress and big behavior change. Clients can finish with big distress drops and zero behavior change. The habituation scoreboard is measuring the wrong thing.
+
+**New-school exposure — Harris's ACT definition.** "Organized contact with _repertoire-narrowing_ stimuli for the purpose of _increasing response flexibility_." Two key shifts:
+
+- **Repertoire-narrowing** replaces **fear-evoking.** It's not just fear that collapses my behavior into a narrow rut — shame, anger, guilt, loneliness, pain, disgust, envy, lust, and greed all do it too. Any stimulus that shrinks my range of responses is fair game for exposure.
+- **Response flexibility** replaces **habituation.** Success is measured by whether behavior becomes more flexible — emotionally, cognitively, behaviorally — not whether distress drops. Anxiety might still be a 9 and the exposure can still be a home run.
+
+**Acceptance is exposure.** Any time I consciously turn toward a difficult thought, feeling, memory, or sensation with openness, curiosity, and flexibility instead of my usual narrow rigid response, that's exposure. This means Harris considers almost every ACT intervention in the book to be informal exposure — it's happening continuously, not just in the formal protocols.
+
+**Two types.** _Informal_ exposure happens spontaneously in every session. _Formal_ exposure is planned and structured, targeting specific repertoire-narrowing stimuli (traumatic memories in PTSD, obsessions in OCD, physical sensations in panic, social situations in social anxiety, painful emotions).
+
+**Goodbye SUDS.** Instead of measuring distress, Harris uses 0–10 scales for response flexibility: degree of acceptance vs. avoidance, fusion vs. defusion, presence/engagement, control over physical actions, connection with values. But he's honest that what he actually watches for as a clinician isn't the numbers — it's whether the client is living their values and engaging with life.
 
 ### Chapter 27: Cognitive Flexibility
 
-Harris pushes back on the claim that "ACT doesn't change thinking." ACT does change thinking, but not through disputation — through defusion and cultivation of alternative patterns. The key insight: there's no delete button in the brain. Old unhelpful thoughts can't be removed; only added to.
+_Related: [Ch 11 — Notice That Thought](#chapter-11-notice-that-thought) · [Ch 12 — Deeper into Defusion](#chapter-12-deeper-into-defusion) · [Ch 13 — Defusion Smorgasbord](#chapter-13-the-defusion-smorgasbord) · [Ch 25 — Noticing Self](#chapter-25-the-noticing-self)_
 
-Techniques include:
+Harris pushes back on the claim that "ACT doesn't change your thinking." He says the opposite — ACT usually changes thinking dramatically — but not by disputing, disproving, or rewriting thoughts. It changes thinking through **defusion** from unhelpful cognitions and by **adding** new, more flexible patterns alongside the old ones.
 
-- Reframing — normalizing and validating thoughts as universal rather than dysfunctional
-- Flexible perspective taking — "if the roles were reversed, how would you feel?"
-- Compassion and self-compassion as new thinking patterns
-- Flexible goal setting, problem solving, and planning
-- Conceiving your mind as a guide, coach, or friend — wise guide vs. reckless guide, kind coach vs. harsh coach. "Right now, which is talking?"
+**No delete button in the brain.** The italicized move in the chapter is the phrase _in addition_. We don't get to eliminate unhelpful cognitive repertoires. Harris's line to clients: "If you learn to speak Hungarian, that won't eliminate English from your vocabulary." Old stories keep coming back; the work is to hold them lightly while building new ones.
+
+Five main levers for flexible thinking:
+
+- **Reframing.** Mostly **normalizing** and **validating** — unwanted thoughts and feelings are normal, not abnormal; valid, not invalid. Caveman mind reframes unhelpful thinking as a purposeful evolutionary leftover. Defusion reframes thoughts as "nothing more or less than words and pictures." Chapter 23 reframes emotions as allies, not enemies.
+- **Flexible perspective taking.** The less common meaning of self-as-context — the ability to see events from alternative points of view. Two classes: mindfulness skills (defusion, acceptance, noticing self) and thinking skills. Typical prompts Harris uses: _If the roles were reversed, how would you feel? / If you were in his shoes, what would you be thinking? / If the same thing happened to someone you love, what would you say to them? / If you were really the loving, patient, kind partner you want to be, how might you think about this differently?_ Inner-child work is flexible perspective taking. Asking "if this emotion could speak, what would it say?" is flexible perspective taking.
+- **Compassion and self-compassion.** For most clients these are radically new thinking patterns. Harris contrasts ruminating (_Why am I feeling so bad? What's wrong with me?_) and self-criticizing (_I should be tougher than this_) with a compassionate line: _This is a moment of suffering. Life is hard right now. Let's see what I can do to take care of myself._ Clients often actively resist this.
+- **Flexible goal setting, problem solving, planning, strategizing.** New thinking skills in themselves. Questions Harris keeps in rotation: _What's the worst that might happen, and how will you deal with it? What's your plan B? What's the best that might happen? What's most likely? What strategy are you using?_
+- **Mind as a guide, coach, or friend.** The metaphor Harris plays with most — and the one I want to steal. Three variants:
+  - **Wise Guide vs. Reckless Guide.** "Sometimes our mind is a wise guide; other times, it's a reckless guide. Right now, which one is talking?" Then: "What would the wise guide say?"
+  - **Overly Helpful Friend vs. Genuinely Helpful Friend.** "Is your mind being overly helpful right now? What would a genuinely helpful friend say?"
+  - **Harsh Coach vs. Kind Coach.** The harsh coach yells, judges, and comes down hard on mistakes. The kind coach encourages, builds on strengths, and gives honest feedback kindly. Harris's punch line: the harsh coaches are a dying breed because the kind coaches get better results. "Right now, which coach is your mind being?"
+
+The chapter's takeaway in one line: ACT changes thinking by defusing from the old patterns, accepting they'll keep recurring, and actively cultivating new ones in parallel.
 
 ### Chapter 28: Shame, Anger, and Other "Problem" Emotions
 
-How to work with any specific "problem" emotion — the chapter focuses on shame but the pattern applies to anger, guilt, and the rest. The framework: identify **fusion**, **experiential avoidance**, and **unworkable action** attached to the emotion, and work them one at a time.
+_Related: [Ch 18 — Hold Yourself Kindly](#chapter-18-hold-yourself-kindly) · [Ch 23 — Emotions as Allies](#chapter-23-emotions-as-allies) · [Ch 22 — Acceptance](#chapter-22-fifty-shades-of-acceptance) · [Ch 26 — Flexible Exposure](#chapter-26-flexible-exposure)_
 
-Harris distinguishes guilt from shame:
+The chapter answers a common question — "how do I work with shame / anger / guilt?" — with a single framework that applies to any emotion. Harris uses shame as the worked example.
 
-- **Guilt** = "I've DONE something bad." Often motivating: it points to an action I want to repair.
-- **Shame** = "I AM bad." Often demotivating: it shuts me down and triggers avoidance.
+**What makes an emotion "problematic"?** No emotion is inherently problematic in ACT. An emotion only becomes problematic in a specific context of **fusion**, **experiential avoidance**, and **unworkable action**. Change the context and the same emotion stops functioning badly. Harris's diagnostic questions up front:
 
-But the distinction is contextual — in a context of mindfulness and values, even shame can be motivating. The chapter covers inner-child imagery, urge surfing, and reframing shame as a reminder to practice self-compassion. The whole framework: change the _context_ of the emotion (from fusion/avoidance to mindfulness/values), not the emotion itself.
+- _Away moves:_ What do you do when this emotion hooks you? What does it pull you away from?
+- _Towards moves:_ If this emotion couldn't hook you anymore, what would you start/stop/do more of/do less of? Who would you be more present with?
+
+**Practical tip.** Depression is not an emotion. On the choice point, put the thoughts and feelings (_I'm not good enough_, sadness, guilt, shame) at the bottom, and the away moves in the away column. The away moves are what "depression" actually is — not the thoughts and feelings that trigger them.
+
+**The deconstruction.** For any problematic emotion, break the context into three elements and work them one at a time, in whatever order seems most useful:
+
+1. **Fusion** — with past, future, self-concept, reasons, rules, judgments.
+2. **Experiential avoidance** — of the sensations, cognitions, urges, and related material.
+3. **Unworkable action** — overt (substance use, aggression, social withdrawal) and covert (rumination, worry, disengagement).
+
+**Shame-specific fusion.** Harris expects to find four types predominating when working with shame: fusion with the **past** (rumination, reliving painful memories), the **future** (anxiety about negative evaluation, rejection, or others discovering "the truth"), **self-concept** (_I am bad / broken / disgusting / unworthy / hopeless_), and **reason-giving** (_because these shameful things happened, I can't change / don't deserve a better life_).
+
+**Guilt vs. Shame.** The canonical distinction:
+
+- **Guilt** = "I've DONE something bad." Often framed as motivating.
+- **Shame** = "I AM bad." Often framed as demotivating.
+
+Harris's correction: this is a gross oversimplification. No emotion is good or bad in itself — context is everything. In a context of fusion and avoidance, guilt can be demotivating and even shame can wreck a life. In a context of mindfulness and values, **shame can be motivating** — a reminder to explore the values buried underneath it. That's the whole ACT move on emotions in miniature.
+
+**Learning history.** Harris unpacks where shame came from to foster defusion and self-compassion. Abusive caregivers said things that fueled shame. In the case of childhood abuse, a child's mind unconsciously blames the child because consciously acknowledging the caregiver as a threat is unbearable — the caregiver is the child's life support. That's where the _It's my fault_ program comes from. Afterward Harris labels "I AM BAD" narratives as "old programming" and treats defusion as noticing the old code running.
+
+**Past functions of shame.** Harris walks clients through how shame has actually helped in the past, to normalize and validate it:
+
+- _Reducing punishment or hostility_ — looking ashamed can lessen others' aggression.
+- _Eliciting support or kindness_ — can bring sympathy and forgiveness.
+- _Avoiding pain_ — downcast eyes avoid the anxiety of eye contact.
+- _Sense-making_ — shame lets a child explain abuse in a way that spares them the terrible reality of their caregivers.
+
+Then he pivots to present functions (all the costs now) and offers the motivational bridge: _"In the past, shame helped you with X, Y, Z. But now it's getting in the way of the person you want to be. Would you be willing to learn some new skills to handle it differently?"_
+
+**Working with shame — the toolkit.** Harris runs through the hexaflex applied to shame:
+
+- **Body posture.** Shame has characteristic postural changes — head hanging, limited eye contact, slumped shoulders, hangdog face, fidgeting, covering eyes. Notice them; experiment with changes to foster engagement and vitality.
+- **Defusion.** Noticing and naming. _Here's shame. Here's my "I am BAD" schema. I'm having the thought that I'm BAD. Here is my mind trying to scare me._ Harris's elegant client script after past-function work: _Aha. Here you are again, shame. I know you're trying to help me or protect me like you have in the past. But I don't need that sort of help anymore — now I've got my values to help me._ Or: _Thanks for reminding me to practice self-compassion._ Warning: avoid zany defusion techniques (thanking your mind, singing your thoughts) with shame, at least early on — they invalidate.
+- **Inner-child imagery.** The client in present-day adult form travels back in time to comfort their childhood self, tell them the truth (_you didn't do anything wrong; it's the adults who are at fault_), and take them to a safe place. Harris never uses the phrase "inner child" with clients because it carries baggage — he just says "would you be willing to do an exercise with me?"
+- **Acceptance.** Starts with validating and normalizing. Then notice, name, and allow the thoughts, feelings, sensations, memories. Drop anchor — not to distract but to discover there's a lot more here in this moment than just shame.
+- **Self-compassion.** Reframe shame as "a reminder call to practice self-compassion" and run the six building blocks: acknowledge the wound, be human, disarm the critic, hold yourself kindly, make room for pain, see yourself in others.
+- **Self-as-context.** Step back and notice shame's thoughts, feelings, sensations, memories from the noticing self. Shame is not the essence of who you are; there's much more to you than it. The noticing self is unchanging while shame's contents shift.
+- **Values.** Once the client is more flexible with shame, mine it for values: _What does this shame tell you really matters? What does it remind you about how you want to treat yourself and others? What does it tell you that you need to stand up for, take a stand against, deal with?_
+- **Committed action.** Build new values-congruent repertoires as alternatives to the shame-driven ones, including explicit training in relationship skills (communication, assertiveness, intimacy, empathy).
+- **Exposure.** Nearly every intervention above is exposure — to the repertoire-narrowing stimuli of shame.
+- **Acting flexibly with shame.** The critical insight, experiential not didactic: the client can take values-guided action _while_ shame is still present. Simple in-session exercise — have the client mindfully move their arms and legs, stretch, shift posture, walk, eat, drink, with shame in the room. They discover they still have control over their actions.
+- **Urge surfing.** For urges to use substances, self-harm, withdraw, or retreat. Let the urge rise and fall like a wave without acting on it.
+
+The chapter's takeaway is the cleanest line in the book on emotions: **the aim is never to change the emotion — it's to change the context.** Shame can still hurt and still show up; it just no longer functions in a way that's toxic or self-defeating.
 
 ### Chapter 29: Flexible Relationships
 
-Applying ACT to relationships. Harris runs the challenge formula on every relationship: leave, stay and live values, or stay and give up. He distinguishes **influence** (what I can do) from **control** (impossible, even at gunpoint — history is full of war heroes who chose to die rather than talk) and emphasizes teaching concrete interpersonal skills — assertiveness, communication, negotiation, conflict resolution — as committed action. The two generative questions he asks every client: "What do you want to give to this relationship?" (values) and "What do you want to get from it?" (wants and needs).
+_Related: [Ch 21 — Do What It Takes](#chapter-21-do-what-it-takes) · [Ch 30 — I and Thou](#chapter-30-i-and-thou) · [Ch 19 — Know What Matters](#chapter-19-know-what-matters)_
+
+Relationships show up in every client Harris has ever seen. Any disorder damages them, and every client can help themselves by reaching out. So every ACT therapist needs to be able to teach basic **interpersonal skills**: assertiveness, communication, negotiation, conflict resolution. Harris treats this as non-negotiable — if you don't know them, learn them. On the hexaflex they live under committed action.
+
+**Exploring the relationship.** Harris runs a standard discovery pass:
+
+- **Who matters?** — most important people, quality of those relationships, who's there when it's hard.
+- **What's good?** — partner's strengths, moments when it's going well, things they like doing together, what helps them get along.
+- **What's bad?** — dislikes, weaknesses, most challenging moments, unhelpful patterns each of them runs.
+- **What have you tried?** — including the unworkable: yelling, withdrawing, going cold, going silent. Most clients discover far more unworkable strategies than workable ones — the creative-hopelessness move applied to the relationship.
+
+**The two generative questions.** The heart of the chapter. For any relationship, ask:
+
+- **A. What do you want to give?** → this leads to values: how I want to treat my partner and what I want to contribute.
+- **B. What do you want to get?** → this leads to wants and needs: what I want from my partner.
+
+Harris notes the easy scenario is a client focused on giving. The hard one is a client purely focused on getting, seeing the partner as the main problem, reluctant to look at their own role.
+
+**The Challenge Formula applied.** Three options, same as everywhere else in the book:
+
+1. **Leave.** Sometimes the right answer (abusive or narcissistic partner). Therapy then focuses on actions to leave and overcoming barriers to doing so.
+2. **Stay and live by your values** — change whatever you can, make room for the pain.
+3. **Stay and give up acting effectively** — do things that make no difference or make it worse.
+
+Most clients recognize they've been running option 3.
+
+**Workability over fault.** If the client says "it's all her fault, she needs to change," Harris validates, normalizes, then asks: _If you hold on tightly to those thoughts, where do they take you? Toward something new that might improve things, or more of the same stuff that's not working?_
+
+**Influence vs. Control.** The move I want to keep. Harris's script:
+
+> We all get into trouble in relationships because we forget the big difference between influence and control. We can _influence_ other people. We can't _control_ them. Even if you point a gun at someone's head you don't have total control — history is full of war heroes who chose to die rather than reveal secrets.
+
+The way we influence is through what we say and do. The question isn't _whose fault_ but _do you want a good relationship_ — because if you do, you have to focus on the one thing you actually have control over: your own words and actions. Harris is careful to say this is not blaming the client. It's the only lever that exists.
+
+**Rainbow or Roadblock?** Another Harris-ism:
+
+> Do you see your partner as a rainbow or as a roadblock?
+
+A rainbow is a unique, magnificent work of nature that enriches your life. A roadblock is an obstacle. Most clients locked in criticism see their partner as a roadblock. Harris asks them what it's like when someone looks at _them_ like a roadblock, then segues into defusion from blame and judgment.
+
+**What sort of partner do I want to be?** Values-clarification as early as possible. Harris's favorite is the **Connect and Reflect** exercise — recall a specific time when the relationship was good, you were doing something meaningful together, and look at yourself in that memory. What qualities are you bringing? Those are your values as a partner.
+
+**Influencing behavior — carrots and sticks.** Harris uses the Donkeys, Carrots, and Sticks metaphor from chapter 18. Healthy relationships need a ratio of **at least five carrots to every stick**. Carrots are anything that constructively influences the other person's behavior — sometimes as simple as "please" instead of demanding and "thank you" instead of taking things for granted.
+
+**Skills training as committed action.** Much of the session becomes role-play: assertiveness, communication, negotiation, saying no, setting boundaries. Plus fighting fairly, repair attempts after conflict, seeing things from the partner's view, building intimacy, giving and receiving feedback. Harris points to his own _ACT with Love_ for full coverage.
 
 ### Chapter 30: I and Thou
 
-The therapeutic relationship, which for Harris means embodying ACT in the room: be mindful, ask permission, say "I'm sorry" when you screw up, be playful, self-disclose wisely, notice problematic behavior as it occurs, declare your values, **slow down and lean in**, defuse from your own judgments, and reveal yourself as a novice when you are one. The "slow down and lean in" move is counter-instinct — when things get tense, most therapists speed up or pull back. Harris argues the correction is always the opposite.
+_Related: [Ch 29 — Flexible Relationships](#chapter-29-flexible-relationships) · [Ch 32 — Therapist's Journey](#chapter-32-the-act-therapists-journey) · [Ch 5 — Setting Up for Success](#chapter-5-setting-up-for-success)_
+
+The therapeutic relationship chapter. The whole thing is really one instruction — **embody ACT in the room** — unpacked into concrete moves.
+
+**Be mindful.** Make the client the center of my attention in an atmosphere of openness, curiosity, and compassion. Notice when I tune out, acknowledge it, come back. Every session becomes its own mindfulness practice.
+
+**Ask permission.** _"Is it okay if...? Could I ask you to...? Would you be willing to...?"_ The more painful an exercise is likely to be, the more essential real permission (not an automatic yes) becomes.
+
+**Say "I'm sorry."** When I screw up, invalidate, or offend, apologize explicitly and promptly. Harris is pointing out that in most intimate relationships apologies are remarkably rare, so this is also modeling.
+
+**Be playful.** Harris quotes the Zen line: _"The first sign of mental health is laughing at yourself."_ Playfulness, irreverence, and humor enhance rapport. Spontaneous laughter in session is usually a good sign. (Obvious caveat: never during crisis or heartbreak.)
+
+**Self-disclose wisely.** ACT actively advocates self-disclosure when it's likely to normalize, validate, model ACT, or strengthen the alliance. Four examples Harris keeps in rotation:
+
+- _"I have to confess, that's thrown me..."_ — when a client says something that knocks you off your feet. Often segue into dropping anchor together.
+- _"I feel disconnected from you / I feel like I'm losing you / It looks like you're not fully here right now."_ — when the client is dissociating, withdrawing, or wandering off inside.
+- _"I don't feel like we're a team here."_ — for relationship tension in the room. Follow it up with what you're noticing specifically (_"I feel a bit like I've turned into an obstacle you're trying to get around"_).
+- _"I'm noticing my mind pulling me in two directions. It's telling me ABC; it's also telling me DEF. What's your take on each?"_ — when you have conflicting opinions.
+
+**Notice and comment on problematic behavior as it occurs.** When a client rehashes the same story or blames everyone, most therapists grit their teeth because they're fused with _it would be rude to interrupt_ or afraid of the client's reaction. Harris's correction is to model all six ACT processes out loud:
+
+> I'm noticing something happening here and I want to bring it to your attention. My mind's telling me you're going to be upset by what I say, and I'm noticing a lot of anxiety in my body and a strong urge to just sit here and not say anything. However, I'm committed to helping you create the best life you can. If I sit here and say nothing, I'll be neglecting those values. So I'm going to do what matters here, even though my heart is racing.
+
+That one intervention is defusion, acceptance, values, committed action, and present-moment contact on display — and the client has your full attention.
+
+**Declare your values.** _"I have one main aim in this room: to help people build a better life."_ or _"You and I are a team working together, and my aim is to help you turn your life around."_ Genuine declared values unite therapist and client.
+
+**Slow down and lean in.** The move I want to bookmark. Picked up from a workshop with Robyn Walser. When I get stressed or anxious in session, my default is to speed up — talk more, talk louder, give advice, start lecturing — or lean back, disengage, withdraw. Harris says **do the opposite**: notice the tendency to speed up and lean back, connect with values, and lean in (literally and metaphorically) and slow down. Talk less, talk slower, ask more, listen more, pause frequently. Counter-instinctive and apparently always correct.
+
+**Defuse from your own judgments.** Minds are judgment machines. When a judgment pops up, name it silently — _Here's judgment!_ — and gently refocus on the client.
+
+**Reveal yourself as a novice.** When Harris first started doing ACT, he told every client he was a newbie, might stumble, might need to read from a script, and asked if that was okay. No client ever reacted negatively. It takes the pressure off and models openness, willingness, self-acceptance, and congruence — which is most of ACT already.
+
+The chapter's takeaway is that every move in it follows naturally from applying ACT to yourself as the therapist — and the more I act from mindfulness and values, the healthier every relationship in my life will be, inside and outside the room.
 
 ### Chapter 31: A Quick Guide to Getting Unstuck
 
-When therapy gets stuck, return to **workability**. Harris covers using workability to defuse, to amplify payoffs for new behavior, to catch yourself lecturing, and to handle "I've got no choice!" and "but it works!" (where the **Rickety Bicycle** metaphor comes in — yes, you can bike from New York to Mexico on a rickety bike, but you'll arrive in bad shape, and there are better ways).
+_Related: [Ch 24 — What's Stopping You](#chapter-24-whats-stopping-you) · [Ch 14 — Barriers to Defusion](#chapter-14-barriers-to-defusion) · [Ch 16 — Technique Overload](#chapter-16-technique-overload-and-other-perils) · [Ch 2 — Getting Hooked](#chapter-2-getting-hooked)_
 
-He reframes resistance as fertile ground and points back to HARD. Resistance generally boils down to four things: treatment mismatch (the client expected something else), reinforcing consequences (the stuck behavior pays off in some hidden way), a weak therapeutic relationship, or the HARD barriers themselves.
+Harris opens with a guarantee: you and your clients will get stuck. Repeatedly. The chapter is a tour of the tools for getting unstuck, and they all route back to one concept: **workability**.
+
+**Workability is best friend.** Harris quotes Kirk Strosahl: _"When we're doing ACT, workability is our best friend."_ From a stance of workability, I never need to judge, criticize, or persuade — I just help the client look honestly at their own behavior and ask if it's a towards move or an away move. The questions:
+
+- Is it working in the long run to make your life richer?
+- Is it taking you closer to the life you really want?
+- Is it helping you be the person you want to be?
+- Is it a towards move or an away move?
+
+Harris warns about **bullying**: deciding in advance what will work for the client and imposing that agenda. When I fuse with my own ideas about what's right for them, they end up saying what I want to hear and the whole exercise goes empty. Strosahl's line: _"You have to be relentlessly pragmatic and nonjudgmental — and truly mean it. This is not a game, a trick, or a form of therapeutic manipulation."_
+
+**Using workability to get unstuck.** Harris runs through specific situations:
+
+- **To defuse.** When a client insists a thought is true, don't debate. Instead: _"The last thing I want to do is debate whether this is true. Is it okay if we look at what happens when this thought hooks you?"_ Same move for "this won't work for me, I've tried before, I've got no control" — _"Fair enough. That's the sort of stuff minds say. I won't argue. But if we let your mind dictate what happens in this room, where do we go from here?"_
+- **To amplify payoffs for new behavior.** When a client starts doing something workable, reinforce it by asking what happened, what values were in play, whether it was a towards or away move, what happened to their sense of vitality, and — critically — _how did you make that happen? What difficult thoughts and feelings did you need to make room for? How did you unhook?_ That last line gets the client to name the skill they just used.
+- **To catch myself lecturing.** Harris apologizes openly the moment he notices he's arguing or convincing, and rewinds: _"I just realized what I've been doing. I've been trying to convince you, and that's not my role. We're supposed to be a team. Can we rewind?"_
+- **To find footing when lost.** 0–10 scale: how well is your life working right now? Low scores → _what would have to happen to get to a 5?_ That question surfaces either goals or psychological barriers.
+- **For "I've got no choice."** Validate the suffering, then reframe as a live choice: _"You have a choice now. One choice is to give up trying anything new and carry on. The other is to try something new and different even though your mind says it's pointless. The first comes with a guarantee — it's 100% guaranteed to keep your life going the way it is. The second is an experiment, no guarantee. So which do you choose?"_
+- **For "But it works!"** This is where the **Rickety Bicycle** metaphor comes in:
+
+  > You can cycle from New York to Mexico on a rickety old bicycle with bad suspension and a worn-out seat, and it will eventually get you there. But what condition will you be in by the time you arrive? There are many more effective ways to make that journey: cars, buses, trains, planes — or even a really good bicycle.
+
+  Then name the client's behavior (getting stoned, worrying, whatever) and ask if they'd like to learn an alternative that gets to the destination in better condition. Afterward, teach the relevant skill — strategic planning if they want to prepare for the worst, relaxation skills if they want to relax.
+
+**Resistance is fertile ground.** Harris reframes resistance as normal and workable. Anyone in the right context would resist therapy — he invokes the traditional healer who says the cure is eating a handful of live beetles three times a day. Resistance generally boils down to four things:
+
+- **Treatment mismatch.** Did you get real informed consent? Did you explain what ACT involves? Were they expecting something else (psychoanalysis, someone to listen)? Did you set behavioral goals? Some clients aren't open to ACT and need a referral.
+- **Reinforcing consequences.** Every stuck behavior has payoffs — sometimes legal settlements, disability benefits, care and attention from others in the sick role, or avoiding the anxiety of dealing with challenges. Bring these gently into the client's awareness and work them openly (_"if you keep doing this, there are real short-term benefits — X, Y, Z — and real long-term costs — A, B, C. When you weigh them, how does it look?"_).
+- **Therapeutic relationship.** The fix is to embody ACT in session (chapter 30) and see the client as a rainbow, not a roadblock.
+- **HARD barriers.** The same HARD from committed action — Hooked, Avoiding discomfort, Remote from values, Doubtful goals — now pointed at the therapy itself. And Harris turns the mirror back on the therapist: _we_ get hooked by _can't do it_, _won't work_, _client will react negatively_. _We_ avoid experimenting with new tools. _We_ get remote from our values as a therapist. _We_ set doubtful goals for how much ACT we'll actually bring in. Again: apply ACT to yourself if you want to do it well with others.
+
+When a client seems stuck, Harris's first move is mindful: _"Is it okay if we press pause for a moment and notice what's happening here?"_ Then nonjudgmentally explore which of the four factors is live.
 
 ### Chapter 32: The ACT Therapist's Journey
 
-Harris closes with advice for learning ACT: you start "chunky and clunky" and eventually get "fluid and flexible." Expect to take a year of devoted practice. Be yourself, modify everything, practice on yourself, make mistakes, and come back to your values again and again. His closing line is from Churchill: "Success is the ability to go from failure to failure without loss of enthusiasm." The chapter is also the clearest statement in the book that **if you aren't using ACT on yourself, you can't use it well with others** — which is the line I'm taking forward whether or not I'm ever a therapist.
+_Related: [Ch 30 — I and Thou](#chapter-30-i-and-thou) · [Ch 16 — Technique Overload](#chapter-16-technique-overload-and-other-perils) · [Ch 31 — Getting Unstuck](#chapter-31-a-quick-guide-to-getting-unstuck)_
+
+The closing chapter, and the one I'm taking forward whether or not I ever sit across from a client.
+
+**From chunky and clunky to fluid and flexible.** When we start, almost all of us do "chunky ACT" — one process per session, defusion today, values next week. That's natural and fine. Over time it becomes **blended**: we learn to "dance around the hexaflex," working several or all processes in each session. Harris points out that almost every intervention already contains multiple overlapping processes if you look closely — a single "notice this feeling with curiosity from your noticing self" exercise is defusion, self-as-context, flexible attention, and acceptance, with values and committed action implicit underneath.
+
+**Expect a year.** Harris is honest: ACT is huuuuuge. Layers within layers. Most therapists take at least a year of devoted practice, reading, and learning to get a thorough handle. His Aesop line: _"Little by little does the trick."_
+
+**Expect to fail a lot.** The journey from chunky to fluid requires time, practice, patience, persistence, and the willingness to make room for a great deal of anxiety and fear of failure. And the reality is you will make mistakes, often and repeatedly. Harris's anchor is Churchill:
+
+> Success is the ability to go from failure to failure without loss of enthusiasm.
+
+Every skill I take for granted — reading, writing, walking, talking, using a knife and fork — I learned by making many, many mistakes. ACT is no different. Thank your mind for the _I'm a lousy therapist_ story, practice self-compassion, reflect with openness and curiosity. _What did I do that worked? What didn't? What did I miss? What did I fuse with? What could I do more of, less of, or differently next time?_
+
+**Parting words — the four instructions:**
+
+- **Be yourself.** Don't parrot the book. Modify, adapt, improvise, use your own words and your own style. If something in the book doesn't suit your way of working, leave it out. ACT is process-based, not technique-based — different trainers do it in wildly different ways, and that's fine.
+- **Practice, practice, practice.** Practice doesn't make perfect but it does make better. If I haven't done the homework, look at what's stopping me. Fused with _too hard_, _too busy_, _do it later_? Avoiding the anxiety of trying new things? Run the HARD diagnostic on myself and respond with the matching process.
+- **Make mistakes.** You will screw up. When it happens, run ACT on yourself: unhook from harsh self-judgment, open up to the frustration and disappointment, hold yourself kindly, reflect, learn.
+- **Come back to your values.** Again and again and again. Connect with why you went into this work in the first place. Appreciate the privilege of getting to see deeply into other people and help them connect with the healing forces inside themselves.
+
+**The line I'm taking forward.** Harris states it twice in this chapter, once in parentheses and once plain:
+
+> The more you apply ACT to yourself, the better you'll be able to do it with others. If you aren't using it on yourself, you won't do it well with others.
+
+I'm not a therapist and I may never be. But the proposition that the only way to offer any of this to anyone else is to be living it myself lands hard. The whole book collapses into that line. Every metaphor, every exercise, every framework is a tool I can use on myself starting today. And the Churchill quote is the operating system: I'm going to fumble the Continuous You exercise, forget the HARD acronym in the moment I need it most, over-identify with a thought I thought I was defused from, and fail to drop anchor when the storm hits. Fine. Failure to failure without loss of enthusiasm. That's the whole journey.
 
 ## Related Posts
 

--- a/back-links.json
+++ b/back-links.json
@@ -564,10 +564,10 @@
         },
         "/act": {
             "description": "ACT is a therapy tradition I’ve circled for years without ever sitting down with it. Russ Harris’s ACT Made Simple is the practitioner primer — the book therapists actually read when learning Acceptance and Commitment Therapy. These are the concepts I want to lift into my own practice.\n\n",
-            "doc_size": 62000,
+            "doc_size": 268000,
             "file_path": "_site/act.html",
             "incoming_links": [],
-            "last_modified": "2026-04-10T14:28:52+00:00",
+            "last_modified": "2026-04-11T01:58:47.914596+00:00",
             "markdown_path": "_d/act.md",
             "outgoing_links": [
                 "/anxiety",


### PR DESCRIPTION
## Summary

Expands `/act` from a ~450-line draft into a 1580-line two-part reference for Russ Harris's *ACT Made Simple*.

- **Part 1 (takeaways):** 6 new concept sections beyond the hexaflex — Choice Point, Workability + functional contextualism, Creative Hopelessness/DOTS, mindfulness-as-4-skills, Self-Compassion 6 building blocks, Emotions as Allies. Also deepens Self-as-Context / Observing Self with Harris's five aims, three metaphor families (Stage Show, Sky & Weather, Chessboard), and the five-rung exercise ladder from the one-line seed up through the 15-minute Continuous You.
- **Part 2 (chapter reference):** every chapter expanded from a 2–4 sentence stub to a deep reference matching the Chapter 25 style — definitions, aims, metaphors with names, numbered exercise ladders, and Harris's honest disclaimers. Generated via 6 parallel Explore subagents each reading a chapter batch directly from the raw ebook.
- **Cross-linking:** 55 Part 1 → Part 2 anchor links (section tails + every metaphor + every practice), plus 32 Part 2 `_Related:_` lines linking each chapter to 2–4 thematically adjacent chapters. Zero broken anchors verified against the regenerated TOC.

## Screenshot

![ACT post top of page](https://gist.githubusercontent.com/idvorkin-ai-tools/b60ec94687d6cbfb866a566f8e880da7/raw/act-screenshot.jpg)

## Test plan

- [x] `prek run --files _d/act.md` — all hooks passing (typo, prettier, markdown anchors, JSON, fast tests)
- [x] Jekyll renders at `http://localhost:4003/act` — HTTP 200, screenshot verified
- [x] TOC regenerated via `:Mtoc update` — all 44 h3 headings indexed
- [x] Zero broken internal anchors — verified by diffing used anchors against TOC
- [x] ai-slop label still at 90%% — Igor will lower as he edits
- [ ] Igor reads through and lowers the ai-slop percent as he rewrites in his own voice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal metadata records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->