### PR TITLE
Fix etserver auto-start docs: init.d alone won't survive OrbStack reboots

### DIFF
--- a/_td/mosh.md
+++ b/_td/mosh.md
@@ -40,9 +40,11 @@ ss -tlnp | grep 2022
 
 Running etserver via `sudo` keeps the pidfile owned by root (644) — matches the init.d behavior below and avoids a world-writable pidfile.
 
-#### Auto-start on boot (init.d)
+#### Auto-start on boot (init.d script + shell hook)
 
-OrbStack containers don't have systemd, so use an init.d script:
+OrbStack containers have neither systemd nor sysv-init — PID 1 is a trivial `sh` loop that never runs `/etc/rc*.d/*`. So `update-rc.d` alone won't bring etserver back after a VM restart. The working pattern here is the same one tailscaled uses: an init.d script that owns start/stop, plus a one-line hook in `~/.zshrc` that calls it when the first interactive shell comes up.
+
+First, the init.d script:
 
 ```bash
 sudo tee /etc/init.d/etserver << 'EOF'
@@ -103,8 +105,19 @@ esac
 exit 0
 EOF
 sudo chmod +x /etc/init.d/etserver
-sudo update-rc.d etserver defaults
 ```
+
+Then the shell hook — drop this into `~/.zshrc` next to your tailscaled bootstrap:
+
+```bash
+# Start Eternal Terminal server if not already running.
+# OrbStack's PID 1 is a trivial sh loop, so /etc/rc*.d never runs — hook it here.
+if [ -x /etc/init.d/etserver ] && ! pgrep -x etserver > /dev/null; then
+    sudo /etc/init.d/etserver start &>/dev/null &
+fi
+```
+
+After a VM reboot, the first zsh you launch brings etserver back. Without this hook, the init.d script just sits there — nothing ever calls it.
 
 ### Install on Mac (client only)
 
@@ -123,7 +136,8 @@ et developer@<tailscale-hostname>
 - **Symlinks are mandatory** — ET's client SSHes in and runs `etterminal` (not `etserver`). Tailscale SSH non-interactive sessions only have `/usr/local/bin` in PATH, not `/home/linuxbrew/.linuxbrew/bin`. Without the symlinks, `etterminal` isn't found and the connection fails silently.
 - **Bind to 0.0.0.0** — ET defaults to localhost, but Tailscale traffic arrives on the tailscale0 interface.
 - **Port 2022** — Make sure your Tailscale ACLs allow port 2022 between nodes.
-- **You DO need to run etserver as a daemon with Tailscale SSH** — ET normally bootstraps its own server via SSH, but Tailscale SSH's environment doesn't support this. Run `etserver --daemon` and set up the init.d script above for persistence across reboots.
+- **You DO need to run etserver as a daemon with Tailscale SSH** — ET normally bootstraps its own server via SSH, but Tailscale SSH's environment doesn't support this. Run `etserver --daemon` and set up the init.d script + `~/.zshrc` hook above for persistence across reboots.
+- **`update-rc.d` is a trap on OrbStack** — the rc.d symlinks land in place but OrbStack's PID 1 is a bare `sh -c 'while true; do tmux...'` loop. Nothing executes `/etc/rc2.d/*` on boot. The `~/.zshrc` hook is what actually restarts etserver after a VM restart.
 - **Pidfile permissions** — `etserver --daemon` writes to `/var/run/etserver.pid`. In OrbStack containers the file may not exist yet — create it with `sudo touch /var/run/etserver.pid && sudo chmod 644 /var/run/etserver.pid` and run etserver via `sudo` so root owns the pidfile. Don't `chmod 666` it (world-writable pidfile = anyone can write a fake PID that the init script would then `kill` as root).
 
 ### Verify


### PR DESCRIPTION
## Summary

- The prior ET setup fix (43e3d39a5) claimed `update-rc.d etserver defaults` would auto-start etserver on boot. It doesn't — OrbStack's PID 1 is a trivial `sh -c 'while true; do tmux...'` loop, so nothing ever executes `/etc/rc*.d/*`.
- Discovered this after a VM reboot left etserver dead with a stale pidfile. Tailscaled survived because `~/.zshrc` already has an explicit bootstrap hook for it; etserver needs the same pattern.
- Rewrites the "Auto-start on boot" section to show the init.d script + `~/.zshrc` hook combo, and adds an "`update-rc.d` is a trap on OrbStack" gotcha so future-me doesn't fall into this again.

## What changed in `_td/mosh.md`

- Section heading: "Auto-start on boot (init.d)" → "Auto-start on boot (init.d script + shell hook)"
- Intro now explains why `update-rc.d` doesn't work on OrbStack
- Removed the misleading `sudo update-rc.d etserver defaults` line from the init.d setup
- Added the `~/.zshrc` hook block (mirrors the existing tailscaled bootstrap)
- New gotcha bullet calling out the `update-rc.d` trap

## Test plan

- [x] etserver is running (PID 3599) and listening on `0.0.0.0:2022` and `[::]:2022`
- [x] `~/.zshrc` hook edited and syntax-checked with `zsh -n`
- [x] Hook is idempotent: no-op when etserver is already running (tested with `pgrep -x etserver`)
- [ ] Next OrbStack VM reboot verifies the zshrc hook brings etserver back automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated service auto-start on boot guidance with an improved initialization method to ensure reliable service recovery after system reboot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->