### PR TITLE
CLAUDE.md: add 'Before Creating a New Post' guideline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,9 @@ Just do it - including obvious follow-up actions. Only pause when:
 
 ## Content Skills — Use These First
 
-**Before working on any blog content, invoke the appropriate skill.** Skills load full guidelines, set up branches, and enforce correct workflows. Skipping them leads to mistakes (wrong ai-slop placement, missing cross-links, etc).
+**Before working on any blog content, invoke the appropriate skill.** Skills load full guidelines, set up branches, and enforce correct workflows. Skipping them leads to mistakes (wrong ai-slop placement, missing cross-links, AI voice tells that will be rejected).
+
+**If you catch yourself about to write more than 2-3 sentences of prose** that will land in `_d/`, `_td/`, or `_posts/`, stop and load `content_guidelines.md` (via `/content`, `/ai-content`, or directly). AI voice patterns show up almost immediately in unguided prose — see `content_guidelines.md` § Avoiding AI Writing Patterns for the full list to scrub. Cost of skipping: freestyle content gets rewritten or dropped on review.
 
 | Task                      | Skill                             | What it does                                                         |
 | ------------------------- | --------------------------------- | -------------------------------------------------------------------- |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,10 @@ Run pre-commit to check: `prek run --files <your-files>`
 
 Use Grep/Glob directly on `_d/`, `_posts/`, and `_td/` directories for text search — faster than the blog MCP. For frontmatter metadata queries (tags, dates, incoming/outgoing links), use `/find-content`.
 
+### Before Creating a New Post
+
+Search `_d/`, `_td/`, and `_posts/` for the topic first. Technical content that fits an existing post's scope (e.g., `/how-igor-chops` for dev environment, `/ai-cockpit` for agent orchestration, `/mosh` for remote access) belongs there as a brief mention — one bullet or one paragraph — not a new standalone reference. Create a new post only when the topic has no existing home.
+
 ## Generating Tables of Contents
 
 Blog posts use a TOC block between HTML fence markers. Igor's convention comes from `idvorkin/markdown-toc.nvim` (installed in his nvim config):

--- a/back-links.json
+++ b/back-links.json
@@ -4417,12 +4417,12 @@
         },
         "/mosh": {
             "description": "Copied from my GitHub techdiary\n\n",
-            "doc_size": 17000,
+            "doc_size": 24000,
             "file_path": "_site/mosh.html",
             "incoming_links": [
                 "/changelog"
             ],
-            "last_modified": "2026-04-06T08:28:46-07:00",
+            "last_modified": "2026-04-11T13:29:32.069129+00:00",
             "markdown_path": "_td/mosh.md",
             "outgoing_links": [],
             "redirect_url": "",


### PR DESCRIPTION
## Summary

Codify a workflow rule that would have prevented two wrong placements in a recent session. Content that fits an existing post's scope should be added there as a brief mention, not broken out into a new standalone reference.

A recent CPU-guard mention went through:
1. New \`_td/cpu-guards.md\` — rejected ("drop this file")
2. Section in \`_d/ai-cockpit.md\` — rejected ("wrong post")
3. One bullet in \`_d/how-igor-chops.md\` under Container Setup — accepted

The rule: search \`_d/\`, \`_td/\`, \`_posts/\` first. Technical content that fits an existing post (\`/how-igor-chops\` for dev environment, \`/ai-cockpit\` for agent orchestration, \`/mosh\` for remote access) belongs there, not in a new file.

## Test plan

- [x] Placement: new subsection under \"Finding Related Blog Content\" — topically adjacent
- [x] No typos (pre-commit passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)