### PR TITLE
how-igor-chops: add 'The Flow Question' (yes, flow survives CHOP)

### DIFF
--- a/_d/how-igor-chops.md
+++ b/_d/how-igor-chops.md
@@ -70,6 +70,7 @@ I mumble to Claude on my couch while my family wonders who I'm talking to. I vib
   - [Revenge of the SDET](#revenge-of-the-sdet)
   - [Hyper-Personalized Software](#hyper-personalized-software)
   - [The Joy Question](#the-joy-question)
+  - [The Flow Question](#the-flow-question)
   - [What I'm Betting On](#what-im-betting-on)
 - [Appendix: Open Questions](#appendix-open-questions)
   - [What happens when execution is no longer the bottleneck?](#what-happens-when-execution-is-no-longer-the-bottleneck)
@@ -417,6 +418,14 @@ My take: the joy shifts, it doesn't disappear. Less joy in typing code, more joy
 - Solving problems I couldn't tackle alone
 
 It's like the transition from assembly to high-level languages. Some people mourned losing the craft of register allocation. Most found new joys in the problems they could now solve.
+
+### The Flow Question
+
+Someone asked me: "Can you still get flow when you're chopping? You're not even writing the code." They assumed no — that flow lives in the typing.
+
+I'm in flow constantly. It comes from orchestrating — juggling two or three agents at different points in their loops, nudging one, reviewing another, letting the third cook. That rhythm is its own zone, which is exactly why I built [the cockpit](#the-control-panel---for-this-human). And it comes from mastery — I'm nowhere near done learning how to operate these things (see [/ai-operator](/ai-operator)), and challenge-meeting-skill is where flow has always lived.
+
+That's where the joy of chopping comes from for me. Not mourning the typing — being in the zone while orchestrating a team.
 
 ### What I'm Betting On
 

--- a/back-links.json
+++ b/back-links.json
@@ -3466,7 +3466,7 @@
         },
         "/how-igor-chops": {
             "description": "I mumble to Claude on my couch while my family wonders who I’m talking to. I vibe code in the car while my son drives. I rent the most expensive brain I can get. This is my CHOP (Chat-Oriented Programming) setup: the infrastructure, the tools, and what I’ve learned.\n\n",
-            "doc_size": 50000,
+            "doc_size": 51000,
             "file_path": "_site/how-igor-chops.html",
             "incoming_links": [
                 "/ai",
@@ -3479,11 +3479,12 @@
                 "/y25",
                 "/y26"
             ],
-            "last_modified": "2026-02-22T22:09:55+00:00",
+            "last_modified": "2026-04-11T15:16:14.918308+00:00",
             "markdown_path": "_d/how-igor-chops.md",
             "outgoing_links": [
                 "/40yo",
                 "/ai-cockpit",
+                "/ai-operator",
                 "/chop",
                 "/chow",
                 "/enable",


### PR DESCRIPTION
## Summary

- Adds a short **"The Flow Question"** section to `/how-igor-chops`, placed right next to the existing "The Joy Question" in the Long View appendix.
- Answers the common pushback — _"you're not typing the code, so you can't be in flow"_ — with the first-person take: flow comes from **orchestrating agents** and the **mastery ladder**, not from the typing.
- Cross-links to the existing Control Panel / cockpit section and to `/ai-operator` (where the mastery-is-the-meta-skill thesis lives), so the section connects into the rest of the CHOP cluster without duplicating anything.
- TOC regenerated via `:Mtoc update`.

## Why here and not in `/chop`?

`/chop` has the canonical essay-style "Will CHOP Kill the Joy of Coding?" section. `/how-igor-chops` is the first-person CHOP post and already owns "The Joy Question" as a personal-voice appendix that links _out_ to the canonical one. Flow is also a personal-testimony claim ("I am in flow"), so it fits right next to Joy in the same appendix.

## Preview

![The Flow Question — rendered](https://gist.githubusercontent.com/idvorkin-ai-tools/7454d0732e47c7856fee5e644e64cc9e/raw/flow-question.jpg)

## Test plan

- [x] `prek run --files _d/how-igor-chops.md` — markdown, prettier, lychee links, anchors all pass for this file (pre-existing anchor failures in `act.md` / `ai-operator.md` are unrelated)
- [x] TOC regenerated; new "The Flow Question" entry visible in nav
- [x] Rendered in local Jekyll — internal links (`#the-control-panel---for-this-human`, `/ai-operator`) resolve, section anchor scrolls correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "The Flow Question" section to the Igor Chops article. This new content reframes flow as an outcome of orchestrating multiple agents and mastery-based learning, directly contrasting it with common assumptions that flow fundamentally depends on traditional coding work and development activities.
  * Updated article metadata and cross-references following the content expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->