### PR TITLE
ci: grant id-token: write to changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,6 +22,11 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  # Required by anthropics/claude-code-action@v1: its setupGitHubToken flow
+  # calls getOidcToken, which fails with "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL
+  # env variable" unless id-token: write is granted. Sibling workflows
+  # (claude.yml, claude-code-review.yml) already have this.
+  id-token: write
 
 jobs:
   changelog:


### PR DESCRIPTION
## Summary
- Add `id-token: write` to `.github/workflows/changelog.yml` permissions block.
- Without it, `anthropics/claude-code-action@v1` → `setupGitHubToken` → `getOidcToken` fails with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`, which broke the Weekly Changelog run [24313114048](https://github.com/idvorkin/idvorkin.github.io/actions/runs/24313114048).
- Sibling workflows (`claude.yml`, `claude-code-review.yml`) already carry this permission — `changelog.yml` was the outlier.

## Root cause
`claude-code-action@v1` authenticates to the GitHub App via an OIDC token, and GitHub only exposes `ACTIONS_ID_TOKEN_REQUEST_URL` to steps whose job has `id-token: write`. The changelog workflow only granted `contents: write` + `pull-requests: write`, so the three retry attempts all failed identically.

## Test plan
- [ ] Re-run the Weekly Changelog workflow via `workflow_dispatch` after merge and confirm the `Generate Changelog` step passes.
- [ ] Confirm PR creation step still runs (it's gated by `Verify changelog was updated`).

Closes blog-a5r

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enhance CI/CD authentication and security protocols. This infrastructure improvement ensures more secure and reliable automated deployment processes, enabling better integration with external development and testing tools. No user-facing features were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->