### PR TITLE
ci(changelog): observability + Skill(changelog) allowlist

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -51,8 +51,13 @@ jobs:
           fi
 
       - name: Generate Changelog
+        id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          # Unhide Claude's tool calls and intermediate messages in the job log.
+          # Default is false, which shows only a terse result summary — making it
+          # impossible to tell what Claude did or why permission denials happened.
+          show_full_output: true
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Scheduled runs have `github-actions[bot]` as the triggering actor;
           # without this, the action's default bot-exclusion would block the
@@ -105,6 +110,63 @@ jobs:
             Exit immediately after writing `_d/changelog.md`. Do not hang around, do not
             wait for approval, do not try additional verification steps. The workflow
             has a 10-minute budget for the whole job — aim to finish generation in under 8.
+
+      - name: Upload Claude transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-output
+          path: /home/runner/work/_temp/claude-execution-output.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Summarize Claude run
+        if: always()
+        run: |
+          F=/home/runner/work/_temp/claude-execution-output.json
+          if [ ! -f "$F" ]; then
+            echo "No Claude transcript at $F" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # Transcript format: one event per line (JSONL) OR a single JSON array.
+          # The `result` event carries the totals. Try JSONL first, then array fallback.
+          RESULT=$(
+            jq -c 'select(.type == "result")' "$F" 2>/dev/null | tail -n 1
+          )
+          if [ -z "$RESULT" ]; then
+            RESULT=$(
+              jq -c '.[] | select(.type == "result")' "$F" 2>/dev/null | tail -n 1
+            )
+          fi
+          if [ -z "$RESULT" ]; then
+            {
+              echo "## Claude run summary"
+              echo ""
+              echo "Could not parse transcript. First 40 lines:"
+              echo ""
+              echo '```'
+              head -n 40 "$F"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          DUR_MS=$(echo "$RESULT" | jq -r '.duration_ms // 0')
+          DUR_S=$((DUR_MS / 1000))
+          TURNS=$(echo "$RESULT" | jq -r '.num_turns // "n/a"')
+          COST=$(echo "$RESULT" | jq -r '.total_cost_usd // "n/a"')
+          DENIALS=$(echo "$RESULT" | jq -r '.permission_denials_count // 0')
+          IS_ERROR=$(echo "$RESULT" | jq -r '.is_error // false')
+          {
+            echo "## Claude run summary"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|---|---|"
+            echo "| Duration | ${DUR_S}s |"
+            echo "| Turns | ${TURNS} |"
+            echo "| Cost | \$${COST} |"
+            echo "| Permission denials | ${DENIALS} |"
+            echo "| Success | $([ "$IS_ERROR" = "false" ] && echo yes || echo no) |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify changelog was updated
         run: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -72,8 +72,13 @@ jobs:
           # leaving the verify step to fail the job with a confusing error.
           # Edit/Read/Write/Grep/Glob are needed for reading the existing
           # changelog, editing the TOC, and writing the new entry.
+          # Skill(changelog) lets Claude invoke `/changelog` via the Skill
+          # tool directly. Without it, the Skill invocation is refused (seen
+          # as permission_denials_count: 1 in run 24316228228) and Claude
+          # falls back to reading SKILL.md and executing steps manually —
+          # the run still succeeds but skips the formal slash-command flow.
           claude_args: |
-            --allowedTools "Bash,Edit,Read,Write,Grep,Glob"
+            --allowedTools "Bash,Edit,Read,Write,Grep,Glob,Skill(changelog)"
           prompt: |
             /changelog
             Look back ${{ inputs.days || '7' }} days. The week-of date is ${{ steps.date.outputs.week_of }} (UTC).


### PR DESCRIPTION
## Summary

Makes the weekly changelog workflow auditable and fixes a silent permission denial discovered while debugging run [24315089298](https://github.com/idvorkin/idvorkin.github.io/actions/runs/24315089298).

Two commits, both touching only `.github/workflows/changelog.yml`:

### 1. `show_full_output: true` + transcript artifact + job summary

The action defaults to hiding tool calls behind `"full output hidden for security"`. You see only a terse result JSON at the end, which is how the permission denial in (1) went unnoticed for multiple runs.

- **`show_full_output: true`** — every tool call and intermediate message now lands in the step log.
- **Upload `claude-execution-output.json` as artifact** — the action already writes this to `/home/runner/work/_temp/`, but it vanishes with the log. 30-day retention, `if-no-files-found: warn` so failures before Claude boots don't fail the workflow.
- **`Summarize Claude run` step** — parses the transcript and writes a table to `GITHUB_STEP_SUMMARY` showing duration, turns, cost, permission denials, and success. Handles both JSONL and JSON-array transcript formats with a fallback that dumps the file head if parsing fails. Guarded with `if: always()` so it runs even when Claude fails.

### 2. Add `Skill(changelog)` to `--allowedTools`

Prior runs showed `permission_denials_count: 1`. With `show_full_output: true` you could see the denied call was the `Skill` tool trying to invoke the `changelog` skill — not in the allowlist. Claude fell back to reading `SKILL.md` and executing steps manually. Scoped to `Skill(changelog)` so this doesn't open up every skill.

## Verification — real end-to-end test on my fork

Dispatched this exact branch (well, its first commit — the second went in after) against `idvorkin-ai-tools/blog7`'s main: [run 24316228228](https://github.com/idvorkin-ai-tools/blog7/actions/runs/24316228228).

- ✓ End-to-end success in 4m 34s wall / 4m 1s Claude-side
- ✓ Claude wrote a full Week of 2026-04-12 changelog (5 themed entries)
- ✓ Transcript artifact uploaded (509KB, 3124 lines)
- ✓ Job summary rendered with the metrics table
- ✓ `Create Pull Request` step worked (opened a phantom PR on the fork that I'll clean up)
- ✓ Pre-fix: `permission_denials_count: 1`, which gave us the `Skill(changelog)` finding

Scaffolding is proven. The `Skill(changelog)` syntax itself hasn't been verified against a live run — I'm assuming claude-code-action@v1 honors the same `Tool(pattern)` permission format the SDK uses. First Monday-2pm run (or a manual dispatch) on upstream main will confirm denials drop to 0.

## Notes

- Unrelated annotation surfaced in the run: `actions/upload-artifact@v4` and `oven-sh/setup-bun` are pinned to Node 20, forced to Node 24 by 2026-06-02. Not urgent, not in scope for this PR.
- The internal `directory mismatch for directory ".../tsconfig.json", fd 4` error from the action is known-benign — the action itself says "you don't need to do anything".

## Test plan

- [x] Dry-run on fork main — full end-to-end pass
- [ ] Manual `workflow_dispatch` on upstream main after merge to confirm `Skill(changelog)` works and denials = 0
- [ ] First scheduled Monday-2pm run produces a clean changelog PR with visible Claude output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub workflow to capture and report detailed execution metrics to the GitHub UI.
  * Improved error handling with better diagnostics and logging for changelog generation processes.
  * Added artifact uploads for workflow execution tracking and transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->