### PR TITLE
content(ai-operator): link to new chop-conventions skills

### DIFF
--- a/_d/ai-operator.md
+++ b/_d/ai-operator.md
@@ -34,7 +34,7 @@ The operators who get better aren't the ones who just practice. They're the ones
 
 ## You Have a Finite Number of Thinking Tokens
 
-_Skills: [things you love](/balloon) · [things good for you](/four-healths)_
+_Skills: [things you love](/balloon) · [things good for you](/four-healths) · [`delegate-to-other-repo`](https://github.com/idvorkin/chop-conventions/blob/main/skills/delegate-to-other-repo/SKILL.md)_
 
 You've had this happen. You're in the middle of making changes — momentum, focus, real progress — and the AI hits its token limit. "Start a new conversation," it says. The context you'd been building together is gone. You're stuck until the window resets.
 
@@ -46,7 +46,7 @@ The point of AI is to extend what you can get done in a day. If you spend your t
 
 ## You Need to Get On the Loop
 
-_Skills: [`show-your-work`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/show-your-work/SKILL.md) · [`walk-the-store`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/walk-the-store/SKILL.md)_
+_Skills: [`show-your-work`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/show-your-work/SKILL.md) · [`walk-the-store`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/walk-the-store/SKILL.md) · [`architect-review`](https://github.com/idvorkin/chop-conventions/blob/main/skills/architect-review/SKILL.md)_
 
 Working with an AI agent always looks the same: there's a loop. The AI tries something. Something checks whether it worked. If not, adjust and try again. Repeat until it's good. Coding, writing, anything — every interaction with an agent is some version of try → check → fix → try.
 
@@ -86,7 +86,7 @@ Do those three and the AI stops guessing at the constraints you forgot to mentio
 
 ## You Can Throw It Away
 
-_Skills: [`walk-the-store`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/walk-the-store/SKILL.md)_
+_Skills: [`walk-the-store`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/walk-the-store/SKILL.md) · [`image-explore`](https://github.com/idvorkin/chop-conventions/blob/main/skills/image-explore/SKILL.md)_
 
 When the AI drives off course, throw it away. Start over. You already got the expensive part — the _learning_ — and the code itself was basically free to generate. The next attempt will be better because you know more now.
 


### PR DESCRIPTION
## Summary

Wire three new chop-conventions skills into `_d/ai-operator.md` so readers find them from the section where the theme naturally fits. Pure text addition (three underlined words in existing Skills lines) — no layout change.

- **`delegate-to-other-repo`** → *You Have a Finite Number of Thinking Tokens* — preserves the parent session's context by isolating cross-repo work to a subagent. Direct token-preservation move.
- **`architect-review`** → *You Need to Get On the Loop* — iterative spec hardening is the quintessential on-the-loop pattern: define the checkpoint, let the agent converge, come back when it stabilizes.
- **`image-explore`** → *You Can Throw It Away* — parallel generation and discarding losers is the section's ethos made concrete; also broadens the post's reach beyond coding examples.

Not added (considered and skipped): `docs`, `background-usage`, `showboat`, `up-to-date`, `machine-doctor`, `gist-image`, `clock`, `ammon`, `build-bd`, `gen-image`. Either utility/mechanics rather than operator skills, or too indirect a thematic fit.

## Test plan

- [x] `prek run --files _d/ai-operator.md` passes (markdown, typos, fast tests, internal links on the real additions)
- [x] All three new links point at valid `SKILL.md` files in `idvorkin/chop-conventions`
- [x] Reading order preserved — new skills appended at end of each Skills line
- [ ] Visual confirmation on the deployed/preview page

🤖 Generated with [Claude Code](https://claude.com/claude-code)