### PR TITLE
fix(share-link): preserve whole bullets, sentence-aware truncation

### DIFF
--- a/src/__tests__/header-copy-link.test.ts
+++ b/src/__tests__/header-copy-link.test.ts
@@ -323,6 +323,98 @@ describe("Header Copy Link", () => {
       expect(mockClipboard).toHaveBeenCalledWith("https://tinyurl.com/igor-blog/?path=manager-book%23test-section");
     });
 
+    it("should preserve whole bullets and not clip mid-sentence (regression: #487)", async () => {
+      // Regression test for the share-link mid-sentence clip bug: the old
+      // code double-truncated (500 in getFirstParagraphAfterHeader, then 400
+      // in truncateText with word-boundary snap) so a 3-bullet list with a
+      // ~350-char lead bullet would clip inside bullet 3 mid-word, producing
+      // shares like: • CodeRabbit: "Your code...
+      //
+      // The fix keeps whole bullets and prefers sentence/bullet boundaries
+      // when truncation is needed.
+      const mockClipboard = vi.fn().mockResolvedValue(undefined);
+      (
+        globalThis as unknown as {
+          navigator: { clipboard: { writeText: typeof mockClipboard } };
+        }
+      ).navigator.clipboard.writeText = mockClipboard;
+
+      mockWindow.location.href = "http://localhost:4000/ai-journal#my-bot-wrote";
+
+      // Mimic the real DOM where getElementById returns the header element
+      // that shareOrCopyHeaderLink uses to look up the preview text.
+      const makeLi = (text: string) => ({
+        tagName: "LI",
+        childNodes: [{ nodeType: 3, textContent: text }], // TEXT_NODE = 3
+      });
+
+      const bullet1 =
+        "TOP Takeaway: The whole code review loop ran between AI agents. " +
+        "My Larry wrote the code, CodeRabbit reviewed and flagged it as wrong, " +
+        "Larry pushed back with empirical proof, CodeRabbit said oops. " +
+        "I wasn't in the loop — I read the transcript after.";
+      const bullet2 = "The thread (chop-conventions#71):";
+      const bullet3 = "CodeRabbit: Your code comment is wrong — gh repo view has a -R/--repo flag.";
+      const bullet4 = "Larry: No, you're wrong. Here's the --help output.";
+
+      const listItems = [makeLi(bullet1), makeLi(bullet2), makeLi(bullet3), makeLi(bullet4)];
+      const mockList = {
+        tagName: "UL",
+        querySelectorAll: vi.fn(() => listItems),
+        nextElementSibling: null,
+      };
+
+      const mockHeaderWithList: any = {
+        id: "my-bot-wrote",
+        textContent: "My Bot Wrote",
+        tagName: "H4",
+        appendChild: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        querySelector: vi.fn(() => null),
+        getBoundingClientRect: vi.fn(() => ({ bottom: 0, left: 0, right: 0, top: 0, width: 0, height: 0 })),
+        nextElementSibling: mockList,
+        childNodes: [{ nodeType: 3, textContent: "My Bot Wrote" }],
+        previousElementSibling: null,
+      };
+
+      mockDocument.querySelectorAll.mockReturnValue([mockHeaderWithList]);
+      mockDocument.getElementById.mockImplementation((id: string) => {
+        if (id === "my-bot-wrote") return mockHeaderWithList;
+        return null;
+      });
+      // getPreviewText's fallback hits document.querySelector("article") etc.
+      // Return null so only the anchor path is exercised.
+      mockDocument.querySelector.mockReturnValue(null);
+
+      initHeaderCopyLinks();
+
+      const copyIcon = mockHeaderWithList.appendChild.mock.calls[0][0];
+      const clickHandler = copyIcon.addEventListener.mock.calls.find((call: any[]) => call[0] === "click")?.[1];
+      expect(clickHandler).toBeDefined();
+
+      await clickHandler({ preventDefault: vi.fn(), stopPropagation: vi.fn() });
+
+      expect(mockClipboard).toHaveBeenCalled();
+      const clipboardText = mockClipboard.mock.calls[0][0] as string;
+
+      // Should NOT end mid-word inside a bullet's quoted content — the old
+      // bug produced `• CodeRabbit: "Your code...` which is incoherent.
+      expect(clipboardText).not.toMatch(/Your code\.\.\./);
+
+      // Should contain the TinyURL appended AFTER the preview (not lost).
+      expect(clipboardText).toContain("https://tinyurl.com/igor-blog/");
+
+      // The first bullet must be complete.
+      expect(clipboardText).toContain("I wasn't in the loop");
+
+      // Preview portion (everything before the TinyURL) should be within
+      // the PREVIEW_MAX_LENGTH cap plus a small fudge for the "..." suffix.
+      const urlIdx = clipboardText.indexOf("https://tinyurl.com/");
+      const previewPortion = clipboardText.substring(0, urlIdx).trim();
+      expect(previewPortion.length).toBeLessThanOrEqual(900); // includes "From: ..." breadcrumb + preview
+    });
+
     it("should handle clipboard API failure gracefully", async () => {
       // Mock clipboard API to fail
       const mockFailingClipboard = vi.fn().mockRejectedValue(new Error("Clipboard failed"));
@@ -1171,7 +1263,7 @@ describe("Header Copy Link", () => {
       }
     });
 
-    it("should truncate long content excerpts to 500 characters", () => {
+    it("should truncate long content excerpts to the preview max length", () => {
       const mockOpen = vi.fn();
       (globalThis as any).window.open = mockOpen;
 
@@ -1265,11 +1357,14 @@ describe("Header Copy Link", () => {
         expect(decodedUrl).toContain("#### Long Section");
         expect(decodedUrl).toContain("...");
 
-        // Extract the content excerpt from the URL
+        // Extract the content excerpt from the URL. The cap was bumped from
+        // 500 to 600 chars (PREVIEW_MAX_LENGTH) when fixing the mid-sentence
+        // clip bug in #487; recipients render 600 chars cleanly in both
+        // Telegram and iMessage. Allow a small fudge for the "..." suffix.
         const excerptMatch = decodedUrl.match(/## Content Excerpt\n\n> ([^\n]+)/);
         if (excerptMatch) {
           const excerpt = excerptMatch[1];
-          expect(excerpt.length).toBeLessThanOrEqual(500);
+          expect(excerpt.length).toBeLessThanOrEqual(603);
         }
       }
     });

--- a/src/header-copy-link.ts
+++ b/src/header-copy-link.ts
@@ -513,7 +513,19 @@ function getOrCreateHeaderId(header: HTMLElement): string {
 }
 
 /**
- * Gets the first non-empty paragraph of content after a header
+ * Maximum length for share/copy preview text. Telegram and iMessage both render
+ * ~600 characters cleanly, which is enough for ~3-4 bullets of real content
+ * without forcing the TinyURL off-screen.
+ */
+const PREVIEW_MAX_LENGTH = 600;
+
+/**
+ * Gets the first non-empty paragraph of content after a header.
+ *
+ * Returns untruncated text — truncation is the caller's responsibility
+ * (see `truncateText`). Previously this function pre-truncated at 500 chars,
+ * then `getPreviewText` re-truncated at 400 chars, yielding double-truncation
+ * that clipped bullet lists mid-sentence. See issue #487.
  */
 function getFirstParagraphAfterHeader(header: HTMLElement): string {
   let nextElement = header.nextElementSibling;
@@ -529,12 +541,16 @@ function getFirstParagraphAfterHeader(header: HTMLElement): string {
     if (nextElement.tagName === "P") {
       const text = (nextElement.textContent || "").trim();
       if (text.length > 0) {
-        // Found non-empty paragraph - truncate if too long
-        return text.length > 500 ? `${text.substring(0, 497)}...` : text;
+        return text;
       }
     }
 
-    // If it's a list (UL or OL), get text from the list items
+    // If it's a list (UL or OL), get text from the list items.
+    // Keep whole bullets intact: stop accumulating as soon as adding the
+    // next bullet would exceed PREVIEW_MAX_LENGTH (with a small safety
+    // margin for the joining newlines and bullet markers). We always keep
+    // at least the first bullet, even if it alone exceeds the cap — the
+    // outer truncateText will trim that case gracefully.
     if (nextElement.tagName === "UL" || nextElement.tagName === "OL") {
       const listItems = nextElement.querySelectorAll("li");
       const itemTexts: string[] = [];
@@ -554,17 +570,23 @@ function getFirstParagraphAfterHeader(header: HTMLElement): string {
           .join(" ")
           .trim();
 
-        if (text.length > 0) {
-          itemTexts.push(`• ${text}`);
-          totalLength += text.length;
-          if (totalLength > 400) break; // Stop if we have enough text
+        if (text.length === 0) continue;
+
+        const bulletLen = text.length + 2; // "• " prefix
+        // If we already have at least one bullet and adding this one would
+        // blow the cap, stop here and let the outer truncator append an
+        // ellipsis. This keeps bullet boundaries clean.
+        if (itemTexts.length > 0 && totalLength + bulletLen + 1 > PREVIEW_MAX_LENGTH) {
+          break;
         }
+
+        itemTexts.push(`• ${text}`);
+        totalLength += bulletLen + 1; // +1 for the joining newline
       }
 
       if (itemTexts.length > 0) {
-        // Join with newlines for better formatting
-        const combinedText = itemTexts.join("\n");
-        return combinedText.length > 500 ? `${combinedText.substring(0, 497)}...` : combinedText;
+        // Join with newlines for better formatting.
+        return itemTexts.join("\n");
       }
     }
 
@@ -575,17 +597,46 @@ function getFirstParagraphAfterHeader(header: HTMLElement): string {
 }
 
 /**
- * Truncates text to a maximum length, preserving word boundaries
+ * Truncates text to a maximum length, preferring sentence boundaries
+ * (`. `, `! `, `? `), then bullet boundaries (`\n•`), then word boundaries,
+ * and finally a hard cut. Appends `...` when truncation occurs.
+ *
+ * Sentence-aware truncation keeps shared previews readable: the old
+ * word-boundary-only version would clip mid-sentence inside a quote like
+ * `• CodeRabbit: "Your code...`, which looks broken to recipients. See #487.
  */
-function truncateText(text: string, maxLength = 400): string {
+function truncateText(text: string, maxLength = PREVIEW_MAX_LENGTH): string {
   if (text.length <= maxLength) {
     return text;
   }
 
-  // Truncate to maxLength and find the last space
   const truncated = text.substring(0, maxLength);
-  const lastSpace = truncated.lastIndexOf(" ");
 
+  // Prefer a sentence end (period/exclamation/question followed by space or
+  // newline) in the last ~40% of the window. Searching too early would
+  // throw away too much content.
+  const minBoundary = Math.floor(maxLength * 0.6);
+  const sentenceEnders = [". ", "! ", "? ", ".\n", "!\n", "?\n"];
+  let bestBoundary = -1;
+  for (const ender of sentenceEnders) {
+    const idx = truncated.lastIndexOf(ender);
+    if (idx >= minBoundary && idx + ender.length > bestBoundary) {
+      // +1 so we include the terminal punctuation but drop the trailing space/newline.
+      bestBoundary = idx + 1;
+    }
+  }
+  if (bestBoundary > 0) {
+    return `${truncated.substring(0, bestBoundary).trimEnd()}...`;
+  }
+
+  // Next, try a bullet boundary (newline followed by a bullet marker).
+  const bulletBoundary = truncated.lastIndexOf("\n•");
+  if (bulletBoundary >= minBoundary) {
+    return `${truncated.substring(0, bulletBoundary).trimEnd()}...`;
+  }
+
+  // Fall back to word boundary.
+  const lastSpace = truncated.lastIndexOf(" ");
   if (lastSpace > 0) {
     return `${truncated.substring(0, lastSpace)}...`;
   }


### PR DESCRIPTION
Fixes #487.

## Summary

- Stops the double-truncation in the share/copy-header-link flow. `getFirstParagraphAfterHeader` no longer pre-truncates — it returns complete bullets, and the outer `truncateText` handles a single final cap.
- Makes `truncateText` sentence-aware: it prefers `. `, `! `, `? ` (and newline variants), then `\n•` bullet boundaries, then word boundaries, then a hard cut. Sentence search is constrained to the last 40% of the window so we don't discard too much.
- Bumps `PREVIEW_MAX_LENGTH` from 400 to 600. Telegram and iMessage both render 600 cleanly and it comfortably fits 3–4 bullets.
- Adds a regression test that mocks the exact 4-bullet shape from the reproduction and asserts the preview does not end with `Your code...` and that the TinyURL still lands in the clipboard text.
- Bumps the existing "long content excerpts" test assertion from `≤ 500` to `≤ 603` to match the new cap.

## Before / after

Reproduction: share the `#my-bot-wrote-their-bot-reviewed-...` anchor on `_d/ai-journal.md`.

Before:
```
• TOP Takeaway : The whole code review loop ran between AI agents. ...
• The thread ( chop-conventions#71 ):
• CodeRabbit : "Your code...
```
(ends mid-word, inside a quote, TinyURL glued on after)

After: the first 3 complete bullets survive, truncation lands at a bullet or sentence boundary, TinyURL follows cleanly.

## Test plan

- [x] `npx biome check src/header-copy-link.ts src/__tests__/header-copy-link.test.ts` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 257 passed, 5 skipped (all pre-existing)
- [x] `prek run --files src/header-copy-link.ts src/__tests__/header-copy-link.test.ts` — all hooks pass (Biome, typos, vitest on changed files)
- [ ] Manual: share a bulleted section from the blog (e.g. the AI journal bot-vs-bot entry) and paste into Telegram/iMessage to visually confirm the preview ends on a clean boundary

## Notes for reviewer

- `PREVIEW_MAX_LENGTH` is exported as a module-local `const`, not configurable via options. If that's worth making tunable, happy to plumb it through `CopyLinkOptions` in a follow-up.
- The sentence-boundary heuristic uses a 40% floor. On a 600-char window that means we'll search back at most 240 chars — tunable if it feels off on real content.
- Happy to split the cap bump (400 → 600) into a separate commit if you prefer smaller surface area per change.

Filed on Igor's behalf by a Claude Code agent while Igor was asleep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression where copying header content containing bullet lists would truncate mid-sentence. The copy function now preserves complete bullet points when generating previews.
  * Enhanced text truncation to intelligently respect sentence boundaries, bullet breaks, and word boundaries instead of cutting arbitrarily in the middle of text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->