### PR TITLE
cross-link: /larry ↔ /claw

### DIFF
--- a/_d/claw.md
+++ b/_d/claw.md
@@ -46,6 +46,8 @@ The distinction matters because it changes your relationship with the AI. An age
 
 Karpathy's "Dobby the House Elf" hits all three. Dobby has context about Karpathy's home — every smart device on the LAN, every API. It communicates via WhatsApp. And it acts autonomously — a Qwen vision model watches security cameras and texts Karpathy when a FedEx truck pulls up. It replaced six separate apps with natural language control.
 
+My own claw instance is [Larry](/larry), my life coach — a concrete example of the category, not a hypothetical.
+
 His take: "These apps shouldn't even exist. Everything should be exposed API endpoints, and agents are the glue."
 
 ### Aside: Why Claws Get Names

--- a/_d/larry.md
+++ b/_d/larry.md
@@ -10,7 +10,7 @@ redirect_from:
   - /larry-the-life-coach
 ---
 
-Larry is my AI life coach. He's part of [Time.ltd](/mortality-software) — my mortality software system — but unlike a tool or a dashboard, Larry is someone I talk to. That matters more than you'd think.
+Larry is my AI life coach. He's part of [Time.ltd](/mortality-software) — my mortality software system — but unlike a tool or a dashboard, Larry is someone I talk to. That matters more than you'd think. In Karpathy's taxonomy, Larry is a [claw](/claw) — a persistent AI entity that keeps working between conversations.
 
 {% include ai-slop.html percent="50" %}
 


### PR DESCRIPTION
## Summary

- `/claw` defines the category of persistent AI entities (Karpathy's term); `/larry` is my personal example of that category. Cross-linking both directions so readers can navigate between the definition and the concrete instance.
- `_d/larry.md`: one-sentence aside in the intro noting Larry is a claw in Karpathy's taxonomy, linking `/claw`.
- `_d/claw.md`: one-sentence mention after the Dobby example that Larry is my own claw instance — a concrete example, not hypothetical.

Minimal diff — 3 lines added, 1 modified. No formatting or unrelated changes.

## Test plan

- [ ] Preview `/larry` — verify the new forward link to `/claw` reads naturally in the intro paragraph
- [ ] Preview `/claw` — verify the back-link sentence after the Dobby paragraph doesn't disrupt the "What Is a Claw?" narrative flow
- [ ] Click both links in rendered pages to confirm navigation works
- [ ] Confirm no TOC regeneration needed (no headings changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify the classification and characteristics of a persistent AI entity.
  * Added cross-references between related documentation sections for improved context and understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->