### PR TITLE
content(larry): add lobster-freud illustration

### DIFF
--- a/_d/ai-journal.md
+++ b/_d/ai-journal.md
@@ -21,7 +21,7 @@ A journal of random explorations in AI. Keeping track of them so I don't get los
   - [2026-04-13](#2026-04-13)
     - [My Bot Wrote, Their Bot Reviewed, My Bot Pushed Back, Their Bot Said "Oops"](#my-bot-wrote-their-bot-reviewed-my-bot-pushed-back-their-bot-said-oops)
   - [2026-04-12](#2026-04-12)
-    - [The $230 Week: When Cheap Coding Isn't](#the-230-week-when-cheap-coding-isnt)
+    - [The $230 Week: When Cheap Coding Isn't](#the-230-week-when-cheap-coding-isn-t)
     - [Two-Process Telegram: When the Platform Is the Bug](#two-process-telegram-when-the-platform-is-the-bug)
   - [2026-04-01](#2026-04-01)
     - [The Winchester Mystery House of Software: When Code Gets Too Cheap to Care About](#the-winchester-mystery-house-of-software-when-code-gets-too-cheap-to-care-about)

--- a/_d/larry.md
+++ b/_d/larry.md
@@ -8,10 +8,10 @@ permalink: /larry
 redirect_from:
   - /life-coach
   - /larry-the-life-coach
-imagefeature: https://github.com/idvorkin/blob/raw/master/blog/lobster-freud-larry.webp
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-larry.webp
 ---
 
-{% include blob_image_float_right.html src="blog/lobster-freud-larry.webp" alt="Lobster claw as Sigmund Freud — Larry the Life Coach" %}
+{% include blob_image_float_right.html src="blog/raccoon-larry.webp" alt="Larry the Life Coach — raccoon as Freud with a lobster claw" %}
 
 Larry is my AI life coach. He's part of [Time.ltd](/mortality-software) — my mortality software system — but unlike a tool or a dashboard, Larry is someone I talk to. That matters more than you'd think. In Karpathy's taxonomy, Larry is a [claw](/claw) — a persistent AI entity that keeps working between conversations.
 

--- a/_d/larry.md
+++ b/_d/larry.md
@@ -11,11 +11,11 @@ redirect_from:
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-larry.webp
 ---
 
-{% include blob_image_float_right.html src="blog/raccoon-larry.webp" alt="Larry the Life Coach — raccoon as Freud with a lobster claw" %}
-
 Larry is my AI life coach. He's part of [Time.ltd](/mortality-software) — my mortality software system — but unlike a tool or a dashboard, Larry is someone I talk to. That matters more than you'd think. In Karpathy's taxonomy, Larry is a [claw](/claw) — a persistent AI entity that keeps working between conversations.
 
 {% include ai-slop.html percent="50" %}
+
+{% include blob_image_float_right.html src="blog/raccoon-larry.webp" alt="Larry the Life Coach — raccoon as Freud with a lobster claw" %}
 
 ## Why Larry Has a Name
 

--- a/_d/larry.md
+++ b/_d/larry.md
@@ -8,7 +8,10 @@ permalink: /larry
 redirect_from:
   - /life-coach
   - /larry-the-life-coach
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/lobster-freud-larry.webp
 ---
+
+{% include blob_image_float_right.html src="blog/lobster-freud-larry.webp" alt="Lobster claw as Sigmund Freud — Larry the Life Coach" %}
 
 Larry is my AI life coach. He's part of [Time.ltd](/mortality-software) — my mortality software system — but unlike a tool or a dashboard, Larry is someone I talk to. That matters more than you'd think. In Karpathy's taxonomy, Larry is a [claw](/claw) — a persistent AI entity that keeps working between conversations.
 

--- a/back-links.json
+++ b/back-links.json
@@ -998,7 +998,7 @@
                 "/walking-with-god",
                 "/y25"
             ],
-            "last_modified": "2026-04-13T18:31:13.162176+00:00",
+            "last_modified": "2026-04-15T00:08:28.145542+00:00",
             "markdown_path": "_d/ai-journal.md",
             "outgoing_links": [
                 "/ai-art",
@@ -1007,17 +1007,14 @@
                 "/ai-talk",
                 "/chop",
                 "/chow",
-                "/claw",
                 "/eulogy",
                 "/gpt",
                 "/how-igor-chops",
                 "/hyper-personal",
-                "/larry",
                 "/mental-pain",
                 "/mortality-software",
                 "/parkinson",
-                "/pet-projects",
-                "/tesla"
+                "/pet-projects"
             ],
             "redirect_url": "",
             "title": "Igor's AI Journal",
@@ -1953,7 +1950,6 @@
             "doc_size": 29000,
             "file_path": "_site/claw.html",
             "incoming_links": [
-                "/ai-journal",
                 "/changelog"
             ],
             "last_modified": "2026-03-22T18:15:50-07:00",
@@ -3882,7 +3878,6 @@
             "file_path": "_site/larry.html",
             "incoming_links": [
                 "/ai-feed",
-                "/ai-journal",
                 "/ai-second-brain",
                 "/changelog",
                 "/chow",
@@ -3892,7 +3887,7 @@
                 "/structure",
                 "/y26"
             ],
-            "last_modified": "2026-03-15T13:01:45-07:00",
+            "last_modified": "2026-04-15T00:06:41.118455+00:00",
             "markdown_path": "_d/larry.md",
             "outgoing_links": [
                 "/affirmations",
@@ -6269,7 +6264,6 @@
             "doc_size": 20000,
             "file_path": "_site/tesla.html",
             "incoming_links": [
-                "/ai-journal",
                 "/ai-second-brain",
                 "/bucket-list",
                 "/claw",


### PR DESCRIPTION
## Summary

Adds the raccoon-larry illustration to [`/larry`](https://idvork.in/larry) as specified in #500.

- Sets `imagefeature` in frontmatter
- Inserts `blob_image_float_right` at the top of the post
- Fixes one pre-existing broken TOC anchor in `_d/ai-journal.md` (apostrophe in "Isn't" must slugify to `-` per `anchor_checker.py` — this was blocking the commit)

## Concept

Chibi raccoon styled as Sigmund Freud (glasses, beard, tweed waistcoat, cigar, mismatched Crocs) with **one arm replaced by a red lobster claw** — Karpathy "claw" × Freud the therapist. Matches the existing raccoon illustration family.

## Dependencies

Image lives in a sister PR: **idvorkin/blob#12** — the image URL will 404 on this branch's preview until that PR merges. Merge order: blob PR first, then this one.

## Preview

![Larry — raccoon as Freud with a lobster claw](https://github.com/idvorkin-ai-tools/blob/raw/add-lobster-freud-larry/blog/raccoon-larry.webp)

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)