### PR TITLE
fix(ci): add full-rebuild mode to update-backlinks workflow_dispatch

### DIFF
--- a/.github/workflows/update-backlinks.yml
+++ b/.github/workflows/update-backlinks.yml
@@ -5,10 +5,21 @@ on:
     branches: [main]
     paths: ['_d/**', '_td/**', '_ig66/**']
   workflow_dispatch:
+    inputs:
+      mode:
+        description: 'delta (HEAD~1..HEAD) or full (rebuild back-links.json from scratch)'
+        required: true
+        default: 'full'
+        type: choice
+        options:
+          - full
+          - delta
 
 concurrency:
   group: update-backlinks
-  cancel-in-progress: true
+  # Queue rather than cancel — a manual full rebuild takes longer than a push
+  # delta and we don't want a push to kill it mid-flight.
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -34,20 +45,33 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Find changed content files (github.event.before is empty on workflow_dispatch)
-          BEFORE="${{ github.event.before }}"
-          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            BEFORE="HEAD~1"
-          fi
-          CHANGED=$(git diff --name-only "$BEFORE"..HEAD | grep -E '^(_d|_td|_ig66)/.*\.md$' || true)
+          # `inputs.mode` is defined only on workflow_dispatch; falls back to
+          # `delta` on push events so existing behavior is untouched. The
+          # shell-level `${MODE:-delta}` is belt-and-suspenders in case the
+          # expression ever renders empty.
+          MODE="${{ inputs.mode || 'delta' }}"
+          MODE="${MODE:-delta}"
+          echo "Mode: $MODE"
 
-          if [ -z "$CHANGED" ]; then
-            echo "No content markdown changes"
-            exit 0
-          fi
-          echo "Changed: $CHANGED"
+          if [ "$MODE" = "full" ]; then
+            # Match delta's 62-min threshold so a full rebuild of an in-sync
+            # repo doesn't churn timestamps 5-62 minutes old.
+            uv run ./build_back_links.py build --threshold-minutes 62
+          else
+            # github.event.before is empty on workflow_dispatch; fall back to HEAD~1
+            BEFORE="${{ github.event.before }}"
+            if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              BEFORE="HEAD~1"
+            fi
+            CHANGED=$(git diff --name-only "$BEFORE"..HEAD | grep -E '^(_d|_td|_ig66)/.*\.md$' || true)
 
-          echo "$CHANGED" | xargs uv run ./build_back_links.py delta
+            if [ -z "$CHANGED" ]; then
+              echo "No content markdown changes"
+              exit 0
+            fi
+            echo "Changed: $CHANGED"
+            echo "$CHANGED" | xargs uv run ./build_back_links.py delta
+          fi
 
           if git diff --quiet back-links.json; then
             echo "back-links.json unchanged"

--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,6 @@ robots.txt
 # subdirectory stays on disk only.
 docs/superpowers/plans/private/
 docs/superpowers/specs/private/
+
+# Local git worktrees
+.worktrees/


### PR DESCRIPTION
## Summary

Fixes #502. Adds a \`mode\` input to \`.github/workflows/update-backlinks.yml\` so manual runs via the Actions UI can force a full rebuild of \`back-links.json\`.

Before: \`workflow_dispatch\` runs silently did HEAD~1..HEAD delta because \`github.event.before\` is empty on non-push events — you couldn't recover from a stale/broken \`back-links.json\` from the button.

After: manual runs get a \`full | delta\` dropdown (default \`full\`), and \`full\` invokes \`uv run ./build_back_links.py build\` which scans every collection page.

## Changes

- **Add \`workflow_dispatch.inputs.mode\`** — choice (\`full\` | \`delta\`), default \`full\`. Description in the Actions UI explains what each does.
- **Branch script on mode** — \`full\` → \`build_back_links.py build --threshold-minutes 62\`; \`delta\` → existing git-diff path.
- **Threshold parity** — pass \`--threshold-minutes 62\` to \`build\` so the full rebuild uses the same timestamp-update threshold as \`delta\` (default 5 min would churn \`last_modified\` for pages touched in the prior hour).
- **Concurrency** — switch \`cancel-in-progress: true\` → \`false\`. Full rebuild takes longer than a delta, and we don't want a push mid-run to cancel a manual recovery.
- **Expression hardening** — use \`\${{ inputs.mode || 'delta' }}\` (top-level \`inputs\` context, defined for all event types) plus a shell-level \`MODE="\${MODE:-delta}"\` belt-and-suspenders.
- **Ignore \`.worktrees/\`** — small \`.gitignore\` addition so local git worktrees don't pollute status.

## Test plan

- [x] YAML parses and triggers render as expected (\`yaml.safe_load\`)
- [x] \`uv run ./build_back_links.py build --threshold-minutes 62\` completes locally — 332 pages processed, 2.3s
- [x] Pre-commit hooks pass (Dasel YAML validator, typos, fast tests)
- [ ] After merge: hit "Run workflow" in Actions tab, confirm dropdown shows both options, run \`full\` and verify it either no-ops or produces a single \`chore: update backlinks [skip ci]\` commit
- [ ] After merge: next content push to \`main\` produces a delta commit as before

## Reviewed by

- Architect review pass (flagged threshold mismatch, concurrency semantics, expression fragility — all addressed)
- Code review pass (no blockers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)