### PR TITLE
chore: remove .worktrees/ from .gitignore (use .git/info/exclude)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,6 +398,3 @@ robots.txt
 # subdirectory stays on disk only.
 docs/superpowers/plans/private/
 docs/superpowers/specs/private/
-
-# Local git worktrees
-.worktrees/


### PR DESCRIPTION
## Summary

Remove the \`.worktrees/\` entry from \`.gitignore\` that was added in #506. It's already in \`.git/info/exclude\` for this repo, which is where it belongs per chop-conventions' Git Inner-Loop rule:

> \`.git/info/exclude\` for local-only ignores. Ephemeral or per-machine ignore entries (worktree dirs, caches, editor state) that must NOT touch branch history go in \`.git/info/exclude\`, not \`.gitignore\`.

Missed this rule when opening #506. No functional difference — the dir stays ignored — but gets the rule out of branch history where it doesn't belong.

## Test plan

- [x] \`git check-ignore -v .worktrees/foo\` still matches (via \`.git/info/exclude\`)
- [x] Pre-commit passes
- [x] No other references to \`.worktrees/\` in \`.gitignore\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)