### PR TITLE
content(act): retitle — "ACT: Acceptance and Commitment Therapy, or Reverse-Engineered Buddhism"

### DIFF
--- a/_d/act.md
+++ b/_d/act.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "ACT aka Applied Buddhism"
+title: "ACT: Acceptance and Commitment Therapy, or Reverse-Engineered Buddhism"
 author: "Igor Dvorkin"
 permalink: /act
 tags:

--- a/back-links.json
+++ b/back-links.json
@@ -570,7 +570,7 @@
             "incoming_links": [
                 "/changelog"
             ],
-            "last_modified": "2026-04-15T03:17:36.331824+00:00",
+            "last_modified": "2026-04-15T03:24:18.354841+00:00",
             "markdown_path": "_d/act.md",
             "outgoing_links": [
                 "/addiction",
@@ -596,7 +596,7 @@
                 "/y26"
             ],
             "redirect_url": "",
-            "title": "ACT aka Applied Buddhism",
+            "title": "ACT: Acceptance and Commitment Therapy, or Reverse-Engineered Buddhism",
             "url": "/act"
         },
         "/activation": {


### PR DESCRIPTION
## Summary

Follow-up to #509 (merged). Retitle only.

**Before:** \`ACT aka Applied Buddhism\`
**After:** \`ACT: Acceptance and Commitment Therapy, or Reverse-Engineered Buddhism\`

Keeps the full therapy name up front for SEO and leans into the engineering-flavored framing — ACT as the behavioral-science repackaging of a 2500-year-old contemplative tradition.

## Test plan

- [x] \`prek run\` passes
- [x] Local Jekyll build succeeds
- [ ] Spot-check title renders in browser tab + index pages