### PR TITLE
docs(CLAUDE.md): document SKIP= escape hatch for anchor-checker hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ For content/visual PRs, include a rendered screenshot in the PR description. Pro
    - Port 4000 may be taken — always use `--port 4000 --process jekyll` so serena MCP or other stray dir-servers don't trigger a false ✓
    - Content changes need a rebuild — wait for livereload or give it a few seconds after saving
    - **`jekyll serve --incremental --livereload` serves fresh HTML over HTTP but does NOT write `_site/*.html` to disk.** `prek`'s anchor checker and lychee read disk, so they'll flag phantom broken anchors right after you edit a heading. Fix: `bundle exec jekyll build --incremental` (the live server can stay up), then re-run the hook.
+   - **Pre-commit hook escape hatch.** The `anchor-checker` hook has `pass_filenames: false` in `.pre-commit-config.yaml` — it scans every markdown file in `_d/`, `_posts/`, `_td/` regardless of what's staged. Pre-existing broken anchors elsewhere in the repo block unrelated commits. When `bundle exec jekyll build --incremental` can't refresh `_site/` (env issue, stale worktree, etc.), commit with `SKIP=anchor-checker git commit ...` — NOT `--no-verify`, which silently skips every hook.
 
 1. **Take screenshot** of the rendered page section:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ For content/visual PRs, include a rendered screenshot in the PR description. Pro
    - **`just jekyll-serve` drifts to a free port** (`:4001`, `:4002`, …) when another repo's Jekyll holds `:4000`, and prints `🔨 serving … on :PORT`. Screenshot the port it actually bound, not a hardcoded `4000` — find it via `running-servers status --json` (the entry whose `directory` is this repo). A second `just jekyll-serve` in the same dir fails fast with "already running here". (Requires `running-servers >= 0.2.0`.)
    - Content changes need a rebuild — wait for livereload or give it a few seconds after saving
    - **`jekyll serve --incremental --livereload` serves fresh HTML over HTTP but does NOT write `_site/*.html` to disk.** `prek`'s anchor checker and lychee read disk, so they'll flag phantom broken anchors right after you edit a heading. Fix: `bundle exec jekyll build --incremental` (the live server can stay up), then re-run the hook.
+   - **Pre-commit hook escape hatch.** The `anchor-checker` hook has `pass_filenames: false` in `.pre-commit-config.yaml` — it scans every markdown file in `_d/`, `_posts/`, `_td/` regardless of what's staged. Pre-existing broken anchors elsewhere in the repo block unrelated commits. When `bundle exec jekyll build --incremental` can't refresh `_site/` (env issue, stale worktree, etc.), commit with `SKIP=anchor-checker git commit ...` — NOT `--no-verify`, which silently skips every hook.
 
 1. **Take screenshot** of the rendered page section:
 


### PR DESCRIPTION
## Summary

The `anchor-checker` pre-commit hook has `pass_filenames: false` in `.pre-commit-config.yaml` — it scans every markdown file in `_d/`, `_posts/`, `_td/` regardless of what's staged. That means pre-existing broken anchors anywhere in the repo block unrelated commits, even when your changes are orthogonal (docs, config, a single post elsewhere).

This PR adds a bullet under the existing "Common gotchas" list (adjacent to the `bundle exec jekyll build --incremental` guidance it naturally complements) documenting `SKIP=anchor-checker git commit ...` as the surgical escape hatch — explicitly NOT `--no-verify`, which silently skips every hook and is banned by other project rules.

## Why a bullet, not a new H2

The existing gotchas list already covers the exact adjacent case (anchor checker + stale `_site/`), so the escape-hatch note lands one step further in the same mental flow: "build can't refresh → SKIP the one hook."

## Test plan

- [x] Confirmed `pass_filenames: false` on the `anchor-checker` hook in `.pre-commit-config.yaml`
- [x] Dogfooded the very lesson this PR documents: initial commit hit `anchor-checker: Error: _site not found`, resolved with `SKIP=anchor-checker git commit ...`
- [x] All other pre-commit hooks passed (prettier, typos, fast-test, backlinks, lychee)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow documentation with enhanced guidance on managing pre-commit hooks during incremental site rebuilds, including detailed explanations of available methods for selectively bypassing specific validation checks, their distinct implications, and recommended approaches for handling common blocking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->