### PR TITLE
ci(backlinks): force our back-links.json on push rejection

### DIFF
--- a/.github/workflows/update-backlinks.yml
+++ b/.github/workflows/update-backlinks.yml
@@ -82,4 +82,26 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add back-links.json
           git commit -m "chore: update backlinks [skip ci]"
-          git push
+
+          # back-links.json is fully derived — on push rejection, take our
+          # freshly-built version on top of latest main. No merge logic needed.
+          for attempt in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            echo "Push attempt $attempt rejected — re-applying back-links.json onto origin/main"
+            OUR_SHA=$(git rev-parse HEAD)
+            git fetch origin main
+            git reset --hard origin/main
+            git checkout "$OUR_SHA" -- back-links.json
+            # checkout staged the file; --cached compares index (our version) to
+            # HEAD (origin/main). Plain `git diff` would compare working tree to
+            # index — both updated by checkout — and falsely report no diff.
+            if git diff --cached --quiet -- back-links.json; then
+              echo "back-links.json already matches origin/main"
+              exit 0
+            fi
+            git commit -m "chore: update backlinks [skip ci]"
+          done
+          echo "Failed to push after 3 attempts" >&2
+          exit 1


### PR DESCRIPTION
## Summary

- The Update Backlinks workflow's final `git push` fails when `main` advances between `actions/checkout` and the push. The full-rebuild path is most exposed because it runs longer than a delta. Run [24434794506](https://github.com/idvorkin/idvorkin.github.io/actions/runs/24434794506) hit this exact race.
- On rejection, hard-reset to `origin/main` and re-apply our freshly-built `back-links.json` on top, then push. Repeat up to 3 times.
- Safe because `back-links.json` is fully derived from the content tree — there's no human-authored content to merge or lose. Our latest build is always authoritative.
- Concurrency group `update-backlinks` already serializes this job against itself; this fix only handles unrelated commits landing on `main` mid-run.

## Test plan

- [ ] Re-trigger the failed `workflow_dispatch` run with `mode=full` and confirm the push succeeds.
- [ ] Future delta runs continue to pass (no behavior change when the push is accepted on the first try).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the backlinks update process with improved conflict resolution and retry mechanisms to increase reliability when synchronizing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->