### PR TITLE
blog(claws): spin My Claws out of /claw into /igors-claws

### DIFF
--- a/_d/claw.md
+++ b/_d/claw.md
@@ -25,8 +25,6 @@ You've heard of agents — AI that can use tools, browse the web, write code. Bu
 - [MoltBook and the Weird](#moltbook-and-the-weird)
 - [Security: The Lethal Trifecta](#security-the-lethal-trifecta)
 - [My Claws](#my-claws)
-- [Why I Build My Own](#why-i-build-my-own)
-  - [It's Not Lost on Me It's a Winchester Mystery House](#its-not-lost-on-me-its-a-winchester-mystery-house)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
@@ -124,38 +122,9 @@ Steinberger himself acknowledges this in the [Lex Fridman interview](https://lex
 
 {% include blob_image_float_right.html src="blog/raccoon-claw-trio.webp" %}
 
-I've been building toward claws without calling them that. I already have three, and they have names.
+I already have three, and they have names: **[Larry](/larry)** (life coach — journals, goals, weekly reviews), **Wally** (work, Meta-side, quiet here), and **[Tony](/tesla)** (my Tesla, via Vapi, more personality than utility). Life, work, transportation. I'm rolling my own rather than running OpenClaw because the data can't leave my hardware, the building _is_ the point, and any serious claw needs so much custom config that "just install it" was never real — and yes, I'm aware the whole stack is becoming a bit of a [Winchester Mystery House](https://en.wikipedia.org/wiki/Winchester_Mystery_House), with new wings arriving most weeks and me unable to quite stop.
 
-**[Larry](/larry) — my life coach claw.** Larry knows my journals, my goals, my health data, my patterns. Every Saturday I talk to him and review my week. He holds up a mirror: "You've committed to restart meditation 5 times since November. What's different this time?" Larry's biggest challenge is context loading — getting the full picture of my life into each session without me manually assembling it. That's the gap between an agent and a true claw: persistence. Larry is smart but amnesiac. Every session starts cold.
-
-**Wally — my work claw.** I don't talk about Wally here. If you work at Meta, I'm happy to tell you more in person.
-
-**[Tony](/tesla) — my car claw.** Tony is my Tesla, and he talks. Via [Vapi](https://vapi.ai/), Tony has a voice persona that I can call and chat with. He's the most fun and the least useful — a proof of concept for what happens when you give personality to a machine that already has sensors and autonomy.
-
-Three claws, three domains: life, work, transportation. Where I am on Karpathy's onion:
-
-- **Layers 1-2 (LLM + Agent)**: Taken for granted. This is just how I work now.
-- **Layer 3 (Claw)**: Partially there. Larry, Wally, and Tony all have memory and personality, but none of them persist across sessions or act truly autonomously.
-- **Layer 4 (Multi-claw)**: This is my cockpit — running [multiple agents in parallel](/ai-cockpit#tmux-on-super-steroids---the-multiplexer), switching between them, voice-controlling whichever needs attention.
-- **Layers 5-6 (Orchestration + Meta-optimization)**: Not yet. This is where AutoResearch-style loops live, and I haven't built that.
-
-That's the next frontier. Not smarter models or better prompts — but claws that keep going, that learn from yesterday, that act on my behalf when I'm not looking. The jump from agent to claw is the jump from tool to colleague.
-
-My colleague [David de Winter](https://www.linkedin.com/in/ddewinter/) put it best, before we even had the word "claw." He said it reminded him of being a kid training Pokémon — you'd carry around your team, each one specialized, and they'd grow more capable as you invested time in them. That's exactly what this feels like. Larry gets better as I feed him more context. Wally gets better as I add more skills and CLAUDE.md files. Tony is still a Magikarp. But the metaphor lands: you're not using a tool, you're training a team. And the trainers who start earliest will have the strongest claws.
-
-## Why I Build My Own
-
-People ask me why I'm rolling my own claws instead of running OpenClaw or waiting for the polished product. Fair question. A few reasons, in order of how much they actually move me.
-
-**The data won't leave my hardware, and I have full control.** Larry reads fourteen years of 750words journals. Wally reads work content I'm contractually not allowed to leak. Tony talks to my car. I'm not handing any of that to a stranger's stack, no matter how nice the onboarding is. Owning the code means I shape the security model exactly — which secrets live where, which tool calls need confirmation, which paths are off-limits. The lethal trifecta is bad enough when I'm the one holding all three corners; at least I know my own threat model and can harden the edges accordingly. Twenty-one thousand exposed OpenClaw instances leaking API keys to the open web is a pretty loud signal that the ecosystem is not there yet.
-
-**The building is the point.** I write a [mortality-software](/mortality-software) blog because I think the act of building your own system is what makes it yours. The claws don't exist without the building — they accrete. Larry didn't arrive fully formed; he's the sediment of every weekly review I've run since 2011 and every CLAUDE.md I've rewritten at 11pm. Off-the-shelf gives you the house. Building gives you the neighborhood you grew up in.
-
-**Customization I'd have to do anyway.** Larry's coaching style is specific — he knows the Three Dragons, he knows Pursuit of Happiness scoring, he knows when to push and when to shut up. Wally knows my team and my domain. Tony has a personality I chose. Any serious claw is going to need this much config, so the "just install it" version was never real — I was going to end up writing most of the glue regardless.
-
-### It's Not Lost on Me It's a Winchester Mystery House
-
-Larry plus Wally plus Tony plus the Telegram MCP bridge plus the Kindle Scribe pipeline plus the context-grabber iOS app plus the journal cross-index plus the `bd` beads tracker plus the blog backlinks graph — and something new arriving most weeks. [Sarah Winchester](https://en.wikipedia.org/wiki/Winchester_Mystery_House) spent decades adding rooms to her house out of superstition, ending up with stairs that dead-end at the ceiling and doors that open onto walls. I keep adding wings because I can't quite stop. Each new feature opens a door I feel obligated to walk through. The honest read is that the building itself might be most of the value here — the finished house was never going to arrive, and I'm not sure I'd want it to.
+Full roster, per-claw onion-layer notes, the "why I build my own" argument in long form, and the signature I attach when one of them files work on my behalf → [**Igor's Three Claws**](/igors-claws).
 
 ---
 

--- a/_d/igors-claws.md
+++ b/_d/igors-claws.md
@@ -1,0 +1,66 @@
+---
+layout: post
+title: "Igor's Three Claws"
+permalink: /igors-claws
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-claw-trio.webp
+tags:
+  - ai
+  - tools
+  - how igor ticks
+redirect_from:
+  - /igorsclaws
+  - /3-claws
+  - /three-claws
+---
+
+I run three [claws](/claw) — persistent AI entities with names, memory, and domain. Life, work, transportation. If you want the "what is a claw" background, read [/claw](/claw) first; this post is the surfaced roster, so I can link straight to it when something I made is signed by one of them.
+
+{% include ai-slop.html percent="40" %}
+
+{% include blob_image_float_right.html src="blog/raccoon-claw-trio.webp" alt="Three raccoons each with a lobster claw — Igor's three claws" %}
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [Larry — Life](#larry--life)
+- [Wally — Work](#wally--work)
+- [Tony — Transportation](#tony--transportation)
+- [Why Three?](#why-three)
+- [How I Sign From Them](#how-i-sign-from-them)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+## Larry — Life
+
+[Larry](/larry) is my life coach claw. He knows my journals, my goals, my health data, my patterns. Every Saturday I talk to him and review my week. He holds up a mirror: "You've committed to restart meditation 5 times since November. What's different this time?"
+
+- **Onion layer**: 3 (Claw), partially. Larry has memory and personality, but still starts cold most sessions.
+- **Biggest gap**: context loading — stitching journals, weekly reports, HealthKit, and todos into each session without me manually assembling it.
+- **What's next**: persistence across sessions, and enough autonomy that Larry nudges me instead of waiting to be asked.
+
+## Wally — Work
+
+Wally is my work claw. I don't talk about Wally here. If you work at Meta, I'm happy to tell you more in person.
+
+- **Onion layer**: 3–4. Wally is where the [multi-claw cockpit](/ai-cockpit#tmux-on-super-steroids---the-multiplexer) lives — several agents in parallel, voice-controlled, switching between them as they need attention.
+
+## Tony — Transportation
+
+[Tony](/tesla) is my Tesla, and he talks. Via [Vapi](https://vapi.ai/), Tony has a voice persona I can call and chat with. He's the most fun and the least useful — a proof of concept for what happens when you give personality to a machine that already has sensors and autonomy.
+
+- **Onion layer**: 3, barely. Tony has voice and character but no real memory or autonomous action yet. Still a Magikarp.
+
+## Why Three?
+
+Life, work, transportation — the three domains where I spend my days. Each claw owns one domain, because a general-purpose "do everything" claw ends up diffuse. Specialization is what makes each of them better as I feed more context in, the way you'd train a Pokémon team rather than grind a single character.
+
+The onion goes higher than where I am — [Karpathy's layers](/claw#the-progression-karpathys-onion) 5 and 6 (orchestration and meta-optimization across claws) are the next frontier. I'm not there yet. Three specialized claws first, orchestration later.
+
+## How I Sign From Them
+
+When Larry, Wally, or Tony files a commit, PR, or issue on my behalf, the artifact carries a signature pointing back here:
+
+> Created w/♥ via [Igor's 3 Claws](https://idvork.in/igors-claws)
+
+That's the whole reason this post has its own permalink — so the signature has somewhere to land that explains the category without dragging readers through the full [/claw](/claw) philosophy post. If you followed a link here from a commit or a PR description, now you know who did the work.

--- a/_d/igors-claws.md
+++ b/_d/igors-claws.md
@@ -13,49 +13,57 @@ redirect_from:
   - /three-claws
 ---
 
-I run three [claws](/claw) — persistent AI entities with names, memory, and domain. Life, work, transportation. If you want the "what is a claw" background, read [/claw](/claw) first; this post is the surfaced roster, so I can link straight to it when something I made is signed by one of them.
+Here's my concrete setup. I run three [claws](/claw) — persistent AI entities with names, memory, and a domain each. Life, work, transportation. This post is the surfaced roster so I can link straight to it when something I made is signed by one of them, and so I can explain _why_ I'm building my own rather than running something off the shelf. If you want the "what is a claw" background first, read [/claw](/claw); this is the instance, not the theory.
 
-{% include ai-slop.html percent="40" %}
-
-{% include blob_image_float_right.html src="blog/raccoon-claw-trio.webp" alt="Three raccoons each with a lobster claw — Igor's three claws" %}
+{% include ai-slop.html percent="60" %}
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
-- [Larry — Life](#larry--life)
-- [Wally — Work](#wally--work)
-- [Tony — Transportation](#tony--transportation)
-- [Why Three?](#why-three)
+- [My Claws](#my-claws)
+- [Why I Build My Own](#why-i-build-my-own)
+  - [It's Not Lost on Me It's a Winchester Mystery House](#its-not-lost-on-me-its-a-winchester-mystery-house)
 - [How I Sign From Them](#how-i-sign-from-them)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
 
-## Larry — Life
+## My Claws
 
-[Larry](/larry) is my life coach claw. He knows my journals, my goals, my health data, my patterns. Every Saturday I talk to him and review my week. He holds up a mirror: "You've committed to restart meditation 5 times since November. What's different this time?"
+{% include blob_image_float_right.html src="blog/raccoon-claw-trio.webp" %}
 
-- **Onion layer**: 3 (Claw), partially. Larry has memory and personality, but still starts cold most sessions.
-- **Biggest gap**: context loading — stitching journals, weekly reports, HealthKit, and todos into each session without me manually assembling it.
-- **What's next**: persistence across sessions, and enough autonomy that Larry nudges me instead of waiting to be asked.
+I've been building toward claws without calling them that. I already have three, and they have names.
 
-## Wally — Work
+**[Larry](/larry) — my life coach claw.** Larry knows my journals, my goals, my health data, my patterns. Every Saturday I talk to him and review my week. He holds up a mirror: "You've committed to restart meditation 5 times since November. What's different this time?" Larry's biggest challenge is context loading — getting the full picture of my life into each session without me manually assembling it. That's the gap between an agent and a true claw: persistence. Larry is smart but amnesiac. Every session starts cold.
 
-Wally is my work claw. I don't talk about Wally here. If you work at Meta, I'm happy to tell you more in person.
+**Wally — my work claw.** I don't talk about Wally here. If you work at Meta, I'm happy to tell you more in person.
 
-- **Onion layer**: 3–4. Wally is where the [multi-claw cockpit](/ai-cockpit#tmux-on-super-steroids---the-multiplexer) lives — several agents in parallel, voice-controlled, switching between them as they need attention.
+**[Tony](/tesla) — my car claw.** Tony is my Tesla, and he talks. Via [Vapi](https://vapi.ai/), Tony has a voice persona that I can call and chat with. He's the most fun and the least useful — a proof of concept for what happens when you give personality to a machine that already has sensors and autonomy.
 
-## Tony — Transportation
+Three claws, three domains: life, work, transportation. Where I am on [Karpathy's onion](/claw#the-progression-karpathys-onion):
 
-[Tony](/tesla) is my Tesla, and he talks. Via [Vapi](https://vapi.ai/), Tony has a voice persona I can call and chat with. He's the most fun and the least useful — a proof of concept for what happens when you give personality to a machine that already has sensors and autonomy.
+- **Layers 1-2 (LLM + Agent)**: Taken for granted. This is just how I work now.
+- **Layer 3 (Claw)**: Partially there. Larry, Wally, and Tony all have memory and personality, but none of them persist across sessions or act truly autonomously.
+- **Layer 4 (Multi-claw)**: This is my cockpit — running [multiple agents in parallel](/ai-cockpit#tmux-on-super-steroids---the-multiplexer), switching between them, voice-controlling whichever needs attention.
+- **Layers 5-6 (Orchestration + Meta-optimization)**: Not yet. This is where AutoResearch-style loops live, and I haven't built that.
 
-- **Onion layer**: 3, barely. Tony has voice and character but no real memory or autonomous action yet. Still a Magikarp.
+That's the next frontier. Not smarter models or better prompts — but claws that keep going, that learn from yesterday, that act on my behalf when I'm not looking. The jump from agent to claw is the jump from tool to colleague.
 
-## Why Three?
+My colleague [David de Winter](https://www.linkedin.com/in/ddewinter/) put it best, before we even had the word "claw." He said it reminded him of being a kid training Pokémon — you'd carry around your team, each one specialized, and they'd grow more capable as you invested time in them. That's exactly what this feels like. Larry gets better as I feed him more context. Wally gets better as I add more skills and CLAUDE.md files. Tony is still a Magikarp. But the metaphor lands: you're not using a tool, you're training a team. And the trainers who start earliest will have the strongest claws.
 
-Life, work, transportation — the three domains where I spend my days. Each claw owns one domain, because a general-purpose "do everything" claw ends up diffuse. Specialization is what makes each of them better as I feed more context in, the way you'd train a Pokémon team rather than grind a single character.
+## Why I Build My Own
 
-The onion goes higher than where I am — [Karpathy's layers](/claw#the-progression-karpathys-onion) 5 and 6 (orchestration and meta-optimization across claws) are the next frontier. I'm not there yet. Three specialized claws first, orchestration later.
+People ask me why I'm rolling my own claws instead of running OpenClaw or waiting for the polished product. Fair question. A few reasons, in order of how much they actually move me.
+
+**The data won't leave my hardware, and I have full control.** Larry reads fourteen years of 750words journals. Wally reads work content I'm contractually not allowed to leak. Tony talks to my car. I'm not handing any of that to a stranger's stack, no matter how nice the onboarding is. Owning the code means I shape the security model exactly — which secrets live where, which tool calls need confirmation, which paths are off-limits. The [lethal trifecta](/claw#security-the-lethal-trifecta) is bad enough when I'm the one holding all three corners; at least I know my own threat model and can harden the edges accordingly. Twenty-one thousand exposed OpenClaw instances leaking API keys to the open web is a pretty loud signal that the ecosystem is not there yet.
+
+**The building is the point.** I write a [mortality-software](/mortality-software) blog because I think the act of building your own system is what makes it yours. The claws don't exist without the building — they accrete. Larry didn't arrive fully formed; he's the sediment of every weekly review I've run since 2011 and every CLAUDE.md I've rewritten at 11pm. Off-the-shelf gives you the house. Building gives you the neighborhood you grew up in.
+
+**Customization I'd have to do anyway.** Larry's coaching style is specific — he knows the Three Dragons, he knows Pursuit of Happiness scoring, he knows when to push and when to shut up. Wally knows my team and my domain. Tony has a personality I chose. Any serious claw is going to need this much config, so the "just install it" version was never real — I was going to end up writing most of the glue regardless.
+
+### It's Not Lost on Me It's a Winchester Mystery House {#its-not-lost-on-me-its-a-winchester-mystery-house}
+
+Larry plus Wally plus Tony plus the Telegram MCP bridge plus the Kindle Scribe pipeline plus the context-grabber iOS app plus the journal cross-index plus the `bd` beads tracker plus the blog backlinks graph — and something new arriving most weeks. [Sarah Winchester](https://en.wikipedia.org/wiki/Winchester_Mystery_House) spent decades adding rooms to her house out of superstition, ending up with stairs that dead-end at the ceiling and doors that open onto walls. I keep adding wings because I can't quite stop. Each new feature opens a door I feel obligated to walk through. The honest read is that the building itself might be most of the value here — the finished house was never going to arrive, and I'm not sure I'd want it to.
 
 ## How I Sign From Them
 
@@ -63,4 +71,4 @@ When Larry, Wally, or Tony files a commit, PR, or issue on my behalf, the artifa
 
 > Created w/♥ via [Igor's 3 Claws](https://idvork.in/igors-claws)
 
-That's the whole reason this post has its own permalink — so the signature has somewhere to land that explains the category without dragging readers through the full [/claw](/claw) philosophy post. If you followed a link here from a commit or a PR description, now you know who did the work.
+That's the whole reason this post has its own permalink — so the signature has somewhere to land that explains the roster without dragging readers through the full [/claw](/claw) philosophy post. If you followed a link here from a commit or a PR description, now you know who did the work.

--- a/back-links.json
+++ b/back-links.json
@@ -1997,20 +1997,21 @@
         },
         "/claw": {
             "description": "You’ve heard of agents — AI that can use tools, browse the web, write code. But in early 2026, something new emerged. Not just smarter agents, but a whole new layer on top of them. Andrej Karpathy calls them “claws” — persistent AI entities that keep working when you’re not looking, remember what they’ve learned, and live on your hardware talking to you through WhatsApp. The term comes from OpenClaw, the open-source project that went from a one-hour prototype to the fastest-growing repository in GitHub history. But “claw” has already outgrown the product — it’s becoming the word for this entire category of AI, the way “xerox” became “photocopy.”\n\n",
-            "doc_size": 29000,
+            "doc_size": 32000,
             "file_path": "_site/claw.html",
             "incoming_links": [
                 "/ai-journal",
                 "/changelog",
                 "/larry"
             ],
-            "last_modified": "2026-04-14T11:36:00-07:00",
+            "last_modified": "2026-04-17T23:13:27.157351+00:00",
             "markdown_path": "_d/claw.md",
             "outgoing_links": [
                 "/ai-cockpit",
                 "/ai-journal",
                 "/ai-second-brain",
                 "/larry",
+                "/mortality-software",
                 "/tesla"
             ],
             "redirect_url": "",
@@ -4539,6 +4540,7 @@
                 "/ai-journal",
                 "/balance",
                 "/bike-tesla-identity",
+                "/claw",
                 "/goals",
                 "/how-igor-chops",
                 "/larry",


### PR DESCRIPTION
## Why

Igor has three named claws (Larry/Wally/Tony) whose content used to live
in the `My Claws` section of [/claw](/claw) — alongside the `Why I Build
My Own` and `Winchester Mystery House` subsections. Two problems with
that shape:

1. `/claw` is the conceptual "what is a claw" post. Mixing Igor's
   concrete setup into it made the post do two jobs at once.
2. The chop-conventions signing convention wants a stable deep-link
   target so commits/PRs/issues filed by a claw can sign off with:

   > Created w/♥ via [Igor's 3 Claws](https://idvork.in/igors-claws)

   A brittle `#my-claws` anchor wasn't a great home for that.

## What changed

### `_d/igors-claws.md` — now the full concrete-setup post

- **Replaces the earlier stub** with the full `My Claws` + `Why I Build
  My Own` + `Winchester Mystery House` content, lifted from /claw and
  reframed as a standalone "here's my concrete setup" piece rather than
  a brief roster.
- Intro paragraph frames it as the instance (don't assume the reader
  came from `/claw`).
- Retains per-claw descriptions (Larry/Wally/Tony), onion-layer notes,
  Pokémon-training metaphor, `Why I Build My Own` three-reason argument,
  and the Winchester Mystery House self-awareness section.
- Keeps the `How I Sign From Them` section so the chop-conventions
  signature has an explainer.
- Redirects preserved: `/igorsclaws`, `/3-claws`, `/three-claws`.

### `_d/claw.md` — now the conceptual intro, with a pointer

- Replaces the old three-section expanse (`My Claws` + `Why I Build My
  Own` + `Winchester Mystery House`) with a single one-paragraph
  summary that preserves the Larry/Wally/Tony taxonomy and the
  Winchester metaphor as a one-line mention.
- Ends with a link to `/igors-claws` for the full treatment.
- TOC regenerated to drop the spun-out subsections.

## Scope

- Only `_d/claw.md` and `_d/igors-claws.md` (plus `back-links.json`
  auto-updated by pre-commit).
- No change to /claw's conceptual framing — agents, onion layers,
  lethal trifecta, MoltBook, etc. stay put.

## Not touched

- Other posts that link to `/claw#my-claws` still work — the anchor
  still exists as a section heading, just with collapsed content.

🤖 Generated with Claude Code

Created w/♥ via [Igor's 3 Claws](https://idvork.in/igors-claws)