### PR TITLE
feat(skills/changelog): partial_week.py tool — merge mid-week partial entries

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -18,16 +18,77 @@ Generate weekly changelog entries for the blog and other GitHub repos with deep 
 
 ## Workflow
 
-### 1. Determine Time Range
+### 0. Merge Partial Weeks (pre-execution, mid-week runs only)
 
-Default to the last 7 days, or use user-specified range:
+**Purpose:** keep the changelog at one entry per ISO week. Multiple mid-week runs would otherwise fragment the same week into several partial entries (e.g., a Mon-anchored entry from Tuesday's run + a trailing-date entry from Thursday's run, both covering the same week). Before generating new content, detect and merge any partial-week entry for the _current_ ISO week.
+
+**Skip this step entirely if today is Monday** — Monday runs produce the canonical fresh weekly entry, no merging needed.
+
+**Detection logic** — a partial-week entry exists when the date of the top-most `## Week of YYYY-MM-DD` heading falls within this week's ISO range (Mon through Sun containing today). This catches both shapes:
+
+- **Mon-anchored partial** — entry dated 2026-04-13 (Monday), today is 2026-04-16 (Thursday). Entry covers Mon–Tue only; we need Mon–Thu.
+- **Trailing-date partial** — entry dated 2026-04-15 (Wednesday, from a Wed run), today is 2026-04-17 (Friday). Entry covers Mon–Wed; we need Mon–Fri.
+
+Use the `partial_week.py` tool that ships alongside this skill — stdlib-only Python with unit-tested classification logic:
 
 ```bash
-# Get commits from last 7 days
+# 1. Check — emits JSON report, no mutations
+.claude/skills/changelog/partial_week.py check
+
+# 2. Act — if the report has "should_merge": true, delete the partial in place
+.claude/skills/changelog/partial_week.py delete
+
+# Safety flag: preview without writing
+.claude/skills/changelog/partial_week.py delete --dry-run
+```
+
+The `check` output shape:
+
+```json
+{
+  "today": "2026-04-16",
+  "weekday": 4,
+  "is_monday": false,
+  "this_monday": "2026-04-13",
+  "this_sunday": "2026-04-19",
+  "most_recent_entry": "2026-04-13",
+  "should_merge": true,
+  "start_date": "2026-04-13",
+  "reason": "Entry 2026-04-13 falls within this ISO week"
+}
+```
+
+When `should_merge` is true, use the returned `start_date` as `START_DATE` for Step 1. `delete` removes both the `## Week of YYYY-MM-DD` section body _and_ its indented TOC entries in one shot, then the rest of the workflow regenerates a coherent entry.
+
+Tests live at `.claude/skills/changelog/test_partial_week.py` (stdlib `unittest`, 16 cases covering Monday skip, Mon-anchored partial, trailing-date partial, previous/future weeks, missing/empty changelog, TOC+section deletion, dry-run). Run with:
+
+```bash
+cd .claude/skills/changelog && python3 -m unittest test_partial_week
+```
+
+**Merge steps** (when a partial-week entry is detected):
+
+1. **Delete the section body** — from the `## Week of YYYY-MM-DD` heading through (but not including) the next `## Week of` heading, or EOF if it's the only one.
+2. **Delete the TOC entries** — the matching `- [Week of YYYY-MM-DD](#week-of-...)` line _and_ every indented `  - [...]` sub-bullet under it in the TOC block at the top of the file.
+3. **Use `$THIS_MONDAY` as `START_DATE`** when you proceed to Step 1 — the regenerated entry will be dated from this Monday and cover all commits Mon → today in one coherent block.
+
+**Why not preserve old content?** Step 2 (Identify Changed Content Files) and Step 3 (Read Actual Content Diffs) regenerate everything from git history. Anything in the old partial entry will be rediscovered from commits. Regenerating fresh is simpler and more coherent than patching an existing entry.
+
+**Example** — today is Thu 2026-04-16, changelog starts with `## Week of 2026-04-13`. 04-13 ≤ 04-13 ≤ 04-19 → partial detected. Delete `## Week of 2026-04-13` section + its TOC lines. Set `START_DATE=2026-04-13`. Regenerate.
+
+### 1. Determine Time Range
+
+If Step 0 set `START_DATE` from a merged partial week, use that. Otherwise default to the last 7 days, or use user-specified range:
+
+```bash
+# Get commits from last 7 days (default)
 git log --since="$(date -d '7 days ago' +%Y-%m-%d)" --oneline upstream/main | wc -l
 
 # Or specific date range
 git log --since="2026-01-25" --until="2026-02-01" --oneline upstream/main
+
+# Or from Step 0's merged-partial week start through today
+git log --since="$START_DATE" --oneline upstream/main
 ```
 
 ### 2. Identify Changed Content Files
@@ -55,6 +116,7 @@ git show COMMIT_HASH -- _d/filename.md
 ```
 
 **What to extract from diffs:**
+
 - New section headers (what topics were added?)
 - Key concepts, frameworks, or models introduced
 - Specific examples or case studies
@@ -62,9 +124,11 @@ git show COMMIT_HASH -- _d/filename.md
 - Tables, lists, or structured content
 
 **Example - BAD (from commit message):**
+
 > "Add spiritual health content"
 
 **Example - GOOD (from actual diff):**
+
 > "Vanaprastha framework: 4-stage Hindu life model (Brahmacharya→Grihastha→Vanaprastha→Sannyasa). Three obstacles: 'None' identity trap, Santa in the Church, Tyranny of Time."
 
 For other repos, get diff summaries:
@@ -91,7 +155,7 @@ Description of changes in this theme:
 - **Item title** - Description ([blog](/permalink#section)) ([github](https://github.com/idvorkin/idvorkin.github.io/commit/SHORTHASH))
 ```
 
-**Important — unique section names**: Every `###` heading must be unique across the *entire* file, not just the current week. Duplicate headings produce duplicate Markdown TOC anchors (`#other-projects`, `#other-projects-1`, …) which are confusing and break deep links.
+**Important — unique section names**: Every `###` heading must be unique across the _entire_ file, not just the current week. Duplicate headings produce duplicate Markdown TOC anchors (`#other-projects`, `#other-projects-1`, …) which are confusing and break deep links.
 
 - For "Other Projects" sections, always append the week date: `### Other Projects (YYYY-MM-DD)` (e.g. `### Other Projects (2026-04-12)`). Never use month names like `(April)` since they repeat across weeks.
 - If you use any other recurring theme name (e.g. "Infrastructure"), append the week date too if that name already appears earlier in the file: `### Infrastructure (YYYY-MM-DD)`.
@@ -104,7 +168,7 @@ Always include both blog and GitHub links where applicable:
 - **Blog link**: `([blog](/permalink))` or `([blog](/permalink#section-anchor))`
 - **GitHub icon link**: `[<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/SHORTHASH)`
 
-Use short commit hashes (first 9 chars) for readability. The GitHub icon (`<i class="fa fa-github"></i>`) renders as a clickable  icon.
+Use short commit hashes (first 9 chars) for readability. The GitHub icon (`<i class="fa fa-github"></i>`) renders as a clickable icon.
 
 ### 5. Finding Section Anchors
 
@@ -116,18 +180,21 @@ grep "^#" _d/filename.md | head -20
 ```
 
 Section anchors are slugified headers:
+
 - `### My Section Title` → `#my-section-title`
 - `### AI & Machine Learning` → `#ai--machine-learning`
 
 ## Example Output
 
 **BAD - based on commit messages (vague, unhelpful):**
+
 ```markdown
 - **Software Survival 3.0** - Added Steve Yegge's framework
 - **Code as Costly Signal** - Discussed what code signals
 ```
 
 **GOOD - based on actual content diffs (specific, informative):**
+
 ```markdown
 ## Week of 2026-01-25
 
@@ -142,6 +209,7 @@ Five new entries on AI-era software development ([blog](/ai-journal#2026-01-31))
 ```
 
 Notice how the GOOD version includes:
+
 - Actual formulas/frameworks from the content
 - Specific quotes
 - Key concepts explained
@@ -149,13 +217,13 @@ Notice how the GOOD version includes:
 
 ## Common Themes to Look For
 
-| Theme | Files to Check | Keywords |
-|-------|---------------|----------|
-| AI/Tech | `ai-*.md`, `how-igor-chops.md` | AI, coding, CHOP |
-| Health | `*-pain.md`, `physical-*.md` | pain, exercise, health |
-| Spiritual | `spiritual-*.md`, `religion.md`, `meditation.md` | spiritual, meditation |
-| Life Planning | `gap-year.md`, `y20*.md`, `retire.md` | goals, planning |
-| Infrastructure | `.claude/`, `scripts/`, `_plugins/` | fix, improve, add command |
+| Theme          | Files to Check                                   | Keywords                  |
+| -------------- | ------------------------------------------------ | ------------------------- |
+| AI/Tech        | `ai-*.md`, `how-igor-chops.md`                   | AI, coding, CHOP          |
+| Health         | `*-pain.md`, `physical-*.md`                     | pain, exercise, health    |
+| Spiritual      | `spiritual-*.md`, `religion.md`, `meditation.md` | spiritual, meditation     |
+| Life Planning  | `gap-year.md`, `y20*.md`, `retire.md`            | goals, planning           |
+| Infrastructure | `.claude/`, `scripts/`, `_plugins/`              | fix, improve, add command |
 
 ## Update TOC
 
@@ -167,7 +235,7 @@ After adding a new week, update the TOC at the top of the changelog:
 - [Week of 2026-01-25](#week-of-2026-01-25)
   - [AI Journal Updates](#ai-journal-updates)
   - [Theme 2](#theme-2)
-<!-- vim-markdown-toc-end -->
+  <!-- vim-markdown-toc-end -->
 ```
 
 ## Cross-Repo Changelog
@@ -202,34 +270,38 @@ Don't be lazy — use GitHub deep links whenever possible: commit links, file li
 
 ### Key Repos to Track
 
-| Repo | Purpose | What to Look For |
-|------|---------|------------------|
-| `idvorkin.github.io` | Blog | Content changes, new posts |
-| `Settings` | Dotfiles/tools | New commands, config changes |
-| `nlp` | AI/NLP tools | New models, features |
-| `chop-conventions` | CHOP docs | Workflow improvements |
-| `tony_tesla` | Voice AI | Tony/Vapi updates |
-| `*-explainer` | Visualizations | New explainers |
+| Repo                 | Purpose        | What to Look For             |
+| -------------------- | -------------- | ---------------------------- |
+| `idvorkin.github.io` | Blog           | Content changes, new posts   |
+| `Settings`           | Dotfiles/tools | New commands, config changes |
+| `nlp`                | AI/NLP tools   | New models, features         |
+| `chop-conventions`   | CHOP docs      | Workflow improvements        |
+| `tony_tesla`         | Voice AI       | Tony/Vapi updates            |
+| `*-explainer`        | Visualizations | New explainers               |
 
 ### Cross-Repo Entry Format
 
 **For regular repos** (link repo name to GitHub):
+
 ```markdown
 **[Settings](https://github.com/idvorkin/Settings)** (dotfiles & tools)
+
 - Added terminal tab switching command [<i class="fa fa-github"></i>](https://github.com/idvorkin/Settings/commit/HASH)
 ```
 
 **For explainers/apps with deployments** (link name to deployment, icon to repo):
+
 ```markdown
 **[monitor-explainer](https://monitor-explorer.surge.sh)** (visualization) [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer)
+
 - Added comprehensive content [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer/commit/HASH)
 ```
 
 ### Link Patterns
 
-| Type | Name Links To | GitHub Icon |
-|------|---------------|-------------|
-| Regular repo | GitHub repo | Commit link |
+| Type          | Name Links To   | GitHub Icon                              |
+| ------------- | --------------- | ---------------------------------------- |
+| Regular repo  | GitHub repo     | Commit link                              |
 | Explainer/app | Live deployment | Repo link (header) + Commit link (items) |
 
 ### GitHub Icon Link Format

--- a/.claude/skills/changelog/partial_week.py
+++ b/.claude/skills/changelog/partial_week.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Detect and remove partial-week entries in the blog changelog.
+
+Before running the changelog skill mid-week, check whether the top-most
+`## Week of YYYY-MM-DD` entry falls within the current ISO week. If so,
+it is a partial snapshot left by an earlier run — the next run should
+merge it, which is easiest by deleting the old entry and regenerating
+fresh from git history.
+
+Commands:
+
+  partial_week.py check                      # JSON report to stdout
+  partial_week.py check --today 2026-04-16   # override today (testing)
+  partial_week.py delete                     # remove detected partial in place
+  partial_week.py delete --dry-run           # show what would change
+
+Stdlib-only. Cross-platform (no GNU `date -d` dependency).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+CHANGELOG_DEFAULT = Path("_d/changelog.md")
+
+
+@dataclass
+class Report:
+    today: str
+    weekday: int
+    is_monday: bool
+    this_monday: str
+    this_sunday: str
+    most_recent_entry: str | None
+    should_merge: bool
+    start_date: str | None
+    reason: str
+
+
+def parse_recent_entry(text: str) -> dt.date | None:
+    match = re.search(r"^## Week of (\d{4}-\d{2}-\d{2})", text, re.MULTILINE)
+    return dt.date.fromisoformat(match.group(1)) if match else None
+
+
+def analyze(changelog_path: Path, today: dt.date) -> Report:
+    weekday = today.isoweekday()
+    this_monday = today - dt.timedelta(days=weekday - 1)
+    this_sunday = this_monday + dt.timedelta(days=6)
+
+    def build(
+        most_recent_entry: str | None,
+        should_merge: bool,
+        start_date: str | None,
+        reason: str,
+    ) -> Report:
+        return Report(
+            today=str(today),
+            weekday=weekday,
+            is_monday=weekday == 1,
+            this_monday=str(this_monday),
+            this_sunday=str(this_sunday),
+            most_recent_entry=most_recent_entry,
+            should_merge=should_merge,
+            start_date=start_date,
+            reason=reason,
+        )
+
+    if weekday == 1:
+        return build(None, False, None, "Monday — skip partial merge")
+
+    if not changelog_path.exists():
+        return build(None, False, None, f"Changelog not found: {changelog_path}")
+
+    recent = parse_recent_entry(changelog_path.read_text())
+    if recent is None:
+        return build(None, False, None, "No existing week entries")
+
+    if this_monday <= recent <= this_sunday:
+        return build(
+            str(recent),
+            True,
+            str(this_monday),
+            f"Entry {recent} falls within this ISO week",
+        )
+
+    return build(
+        str(recent),
+        False,
+        None,
+        f"Entry {recent} is outside this week ({this_monday} → {this_sunday})",
+    )
+
+
+def delete_partial(
+    changelog_path: Path, entry_date: str, dry_run: bool = False
+) -> dict:
+    """Remove the `## Week of {entry_date}` section body and its TOC entries.
+
+    Returns a summary of what was (or would be) removed.
+    """
+    text = changelog_path.read_text()
+
+    toc_pattern = (
+        rf"^- \[Week of {re.escape(entry_date)}\]\([^)]+\)\n"
+        rf"(?:  - \[[^\]]+\]\([^)]+\)\n)*"
+    )
+    stripped, toc_subs = re.subn(toc_pattern, "", text, count=1, flags=re.MULTILINE)
+
+    section_pattern = (
+        rf"^## Week of {re.escape(entry_date)}\n"
+        rf".*?"
+        rf"(?=^## Week of \d{{4}}-\d{{2}}-\d{{2}}\n|\Z)"
+    )
+    stripped, sec_subs = re.subn(
+        section_pattern, "", stripped, count=1, flags=re.MULTILINE | re.DOTALL
+    )
+
+    summary = {
+        "toc_entries_removed": toc_subs,
+        "section_removed": sec_subs,
+        "dry_run": dry_run,
+    }
+    if not dry_run and (toc_subs or sec_subs):
+        changelog_path.write_text(stripped)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    for name in ("check", "delete"):
+        sp = sub.add_parser(name, help=f"{name} partial-week entry")
+        sp.add_argument("--changelog", type=Path, default=CHANGELOG_DEFAULT)
+        sp.add_argument("--today", type=dt.date.fromisoformat, default=None)
+        if name == "delete":
+            sp.add_argument("--dry-run", action="store_true")
+
+    args = parser.parse_args()
+    today = args.today or dt.date.today()
+
+    report = analyze(args.changelog, today)
+
+    if args.cmd == "check":
+        print(json.dumps(asdict(report), indent=2))
+        return 0
+
+    if not report.should_merge:
+        print(json.dumps({**asdict(report), "action": "no-op"}, indent=2))
+        return 0
+
+    assert report.most_recent_entry is not None  # guaranteed by should_merge
+    summary = delete_partial(args.changelog, report.most_recent_entry, args.dry_run)
+    print(json.dumps({**asdict(report), "action": summary}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/changelog/test_partial_week.py
+++ b/.claude/skills/changelog/test_partial_week.py
@@ -1,0 +1,175 @@
+"""Unit tests for partial_week.py. Stdlib-only. Run with `python3 -m unittest`."""
+
+from __future__ import annotations
+
+import datetime as dt
+import tempfile
+import unittest
+from pathlib import Path
+
+from partial_week import analyze, delete_partial, parse_recent_entry
+
+
+class AnalyzeTest(unittest.TestCase):
+    def _write(self, text: str) -> Path:
+        fd, path = tempfile.mkstemp(suffix=".md")
+        import os
+
+        os.close(fd)
+        Path(path).write_text(text)
+        return Path(path)
+
+    def test_monday_skips_merge(self):
+        path = self._write("## Week of 2026-04-13\n")
+        r = analyze(path, dt.date(2026, 4, 13))
+        self.assertTrue(r.is_monday)
+        self.assertFalse(r.should_merge)
+        self.assertIn("Monday", r.reason)
+
+    def test_thursday_with_mon_anchored_partial(self):
+        path = self._write("## Week of 2026-04-13\n\nsome content\n")
+        r = analyze(path, dt.date(2026, 4, 16))
+        self.assertTrue(r.should_merge)
+        self.assertEqual(r.most_recent_entry, "2026-04-13")
+        self.assertEqual(r.start_date, "2026-04-13")
+
+    def test_friday_with_trailing_wed_partial(self):
+        path = self._write("## Week of 2026-04-15\n\ncontent\n")
+        r = analyze(path, dt.date(2026, 4, 17))
+        self.assertTrue(r.should_merge)
+        self.assertEqual(r.most_recent_entry, "2026-04-15")
+        self.assertEqual(r.start_date, "2026-04-13")
+
+    def test_sunday_with_trailing_partial(self):
+        path = self._write("## Week of 2026-04-16\n\ncontent\n")
+        r = analyze(path, dt.date(2026, 4, 19))
+        self.assertTrue(r.should_merge)
+
+    def test_previous_week_entry_no_merge(self):
+        path = self._write("## Week of 2026-04-06\n\ncontent\n")
+        r = analyze(path, dt.date(2026, 4, 16))
+        self.assertFalse(r.should_merge)
+        self.assertEqual(r.most_recent_entry, "2026-04-06")
+        self.assertIn("outside this week", r.reason)
+
+    def test_future_entry_no_merge(self):
+        path = self._write("## Week of 2026-05-04\n\ncontent\n")
+        r = analyze(path, dt.date(2026, 4, 16))
+        self.assertFalse(r.should_merge)
+
+    def test_empty_changelog_no_merge(self):
+        path = self._write("no week entries yet\n")
+        r = analyze(path, dt.date(2026, 4, 16))
+        self.assertFalse(r.should_merge)
+        self.assertIsNone(r.most_recent_entry)
+
+    def test_missing_changelog_no_merge(self):
+        r = analyze(Path("/nonexistent/changelog.md"), dt.date(2026, 4, 16))
+        self.assertFalse(r.should_merge)
+        self.assertIn("not found", r.reason)
+
+    def test_picks_first_entry_when_multiple_weeks(self):
+        text = "## Week of 2026-04-13\n\nrecent\n\n## Week of 2026-04-06\n\nolder\n"
+        path = self._write(text)
+        r = analyze(path, dt.date(2026, 4, 16))
+        self.assertEqual(r.most_recent_entry, "2026-04-13")
+
+
+class ParseRecentEntryTest(unittest.TestCase):
+    def test_returns_first_occurrence(self):
+        self.assertEqual(
+            parse_recent_entry("## Week of 2026-04-13\nstuff\n## Week of 2026-04-06\n"),
+            dt.date(2026, 4, 13),
+        )
+
+    def test_returns_none_when_missing(self):
+        self.assertIsNone(parse_recent_entry("no entries here"))
+
+    def test_ignores_non_anchored_match(self):
+        self.assertIsNone(parse_recent_entry("see ## Week of 2026-04-13 inline"))
+
+
+class DeletePartialTest(unittest.TestCase):
+    SAMPLE = """\
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [Week of 2026-04-13](#week-of-2026-04-13)
+  - [Theme A](#theme-a)
+  - [Theme B](#theme-b)
+- [Week of 2026-04-06](#week-of-2026-04-06)
+  - [Older theme](#older-theme)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+## Week of 2026-04-13
+
+_3 commits this week_
+
+### Theme A
+
+Content A.
+
+### Theme B
+
+Content B.
+
+## Week of 2026-04-06
+
+_5 commits this week_
+
+### Older theme
+
+Older content.
+"""
+
+    def _write(self, text: str) -> Path:
+        fd, path = tempfile.mkstemp(suffix=".md")
+        import os
+
+        os.close(fd)
+        Path(path).write_text(text)
+        return Path(path)
+
+    def test_removes_section_and_toc(self):
+        path = self._write(self.SAMPLE)
+        summary = delete_partial(path, "2026-04-13")
+        self.assertEqual(summary["toc_entries_removed"], 1)
+        self.assertEqual(summary["section_removed"], 1)
+        new = path.read_text()
+        self.assertNotIn("Week of 2026-04-13", new)
+        self.assertNotIn("Theme A", new)
+        self.assertIn("## Week of 2026-04-06", new)
+        self.assertIn("### Older theme", new)
+
+    def test_dry_run_does_not_write(self):
+        path = self._write(self.SAMPLE)
+        before = path.read_text()
+        summary = delete_partial(path, "2026-04-13", dry_run=True)
+        self.assertTrue(summary["dry_run"])
+        self.assertEqual(path.read_text(), before)
+
+    def test_nonmatching_date_noop(self):
+        path = self._write(self.SAMPLE)
+        before = path.read_text()
+        summary = delete_partial(path, "2026-03-01")
+        self.assertEqual(summary["toc_entries_removed"], 0)
+        self.assertEqual(summary["section_removed"], 0)
+        self.assertEqual(path.read_text(), before)
+
+    def test_removes_last_section_at_eof(self):
+        text = (
+            "- [Week of 2026-04-13](#week-of-2026-04-13)\n"
+            "  - [Only](#only)\n\n"
+            "## Week of 2026-04-13\n\n_1 commit_\n\n### Only\n\nThe end.\n"
+        )
+        path = self._write(text)
+        summary = delete_partial(path, "2026-04-13")
+        self.assertEqual(summary["toc_entries_removed"], 1)
+        self.assertEqual(summary["section_removed"], 1)
+        self.assertNotIn("Week of 2026-04-13", path.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a standalone Python tool (`partial_week.py`) that the changelog skill invokes before generating new content, to prevent fragmented partial-week entries when the skill is run mid-week.

## Problem

When the changelog skill runs mid-week (e.g., Wednesday), it creates a partial \`## Week of YYYY-MM-DD\` entry covering Mon-Wed only. A second mid-week run (or the canonical Monday run the following week) creates a *second* entry for the same ISO week — fragmenting the changelog.

## Solution

A standalone, unit-tested Python CLI that:

- **\`partial_week.py check\`** — emits JSON report: is today Monday? Is the top-most \`## Week of YYYY-MM-DD\` heading within this ISO week (Mon–Sun containing today)? If yes, \`should_merge: true\` with \`start_date\` set to this week's Monday.
- **\`partial_week.py delete\`** — removes the section body *and* matching TOC entries in one shot. \`--dry-run\` previews without writing.

A single ISO-week containment check covers both shapes:
- **Mon-anchored partial** — entry dated Monday, today is Thursday → entry covers Mon-Tue only
- **Trailing-date partial** — entry dated Wednesday (from a Wed run), today is Friday → entry covers Mon-Wed only

## Why a separate Python tool

Per [chop-conventions](https://github.com/idvorkin/chop-conventions/blob/main/CLAUDE.md): *Default to Python for any non-trivial script, not shell. Anything with branching, data structures, or more than ~20 lines should be Python.*

Detection needs date arithmetic (GNU \`date -d\` breaks on macOS), file parsing, and classification logic — earns a tested Python helper over an inline bash heredoc. Modeled on \`skills/up-to-date/diagnose.py\`: stdlib-only, \`uv run --script\` shebang, classification logic behind testable functions.

## Files

- **\`partial_week.py\`** — 170 lines, stdlib-only, \`uv run --script\` shebang
- **\`test_partial_week.py\`** — 16 unit tests (\`unittest\`), no mocks needed
- **\`SKILL.md\`** — invokes the tool instead of the prior inline \`python3 - <<'PY'\` heredoc

## Verification

All 16 tests pass:

\`\`\`
test_empty_changelog_no_merge ... ok
test_friday_with_trailing_wed_partial ... ok
test_future_entry_no_merge ... ok
test_missing_changelog_no_merge ... ok
test_monday_skips_merge ... ok
test_picks_first_entry_when_multiple_weeks ... ok
test_previous_week_entry_no_merge ... ok
test_sunday_with_trailing_partial ... ok
test_thursday_with_mon_anchored_partial ... ok
test_dry_run_does_not_write ... ok
test_nonmatching_date_noop ... ok
test_removes_last_section_at_eof ... ok
test_removes_section_and_toc ... ok
test_ignores_non_anchored_match ... ok
test_returns_first_occurrence ... ok
test_returns_none_when_missing ... ok

Ran 16 tests in 0.016s — OK
\`\`\`

CLI smoke-test against the live \`_d/changelog.md\` correctly flags today's scenario:

\`\`\`json
{
  "today": "2026-04-16",
  "weekday": 4,
  "is_monday": false,
  "this_monday": "2026-04-13",
  "this_sunday": "2026-04-19",
  "most_recent_entry": "2026-04-13",
  "should_merge": true,
  "start_date": "2026-04-13",
  "reason": "Entry 2026-04-13 falls within this ISO week"
}
\`\`\`

## Test plan

- [x] \`python3 -m unittest test_partial_week\` — 16/16 pass
- [x] \`partial_week.py check\` against live changelog — JSON output matches expected
- [x] Ruff + Prettier pre-commit hooks pass
- [ ] Mental review: next mid-week changelog run should invoke \`check\` → \`delete\` → regenerate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated detection and merging of partial-week changelog entries for non-Monday runs
  * New check and delete commands for partial-week management with dry-run support

* **Tests**
  * Added comprehensive test coverage for partial-week detection and management workflows

* **Documentation**
  * Updated workflow documentation with new automatic partial-week handling step

<!-- end of auto-generated comment: release notes by coderabbit.ai -->