### PR TITLE
feat(skills/changelog): scan_repos.py + changed_files.py — parallel cross-repo scan & ranked file changes

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -32,13 +32,15 @@ git log --since="2026-01-25" --until="2026-02-01" --oneline upstream/main
 
 ### 2. Identify Changed Content Files
 
-Find the most-modified content files:
+Use the `changed_files.py` helper that ships alongside this skill — emits JSON, keeps the count-and-rank logic in pure-function Python (unit-tested, deterministic tie-breaking):
 
 ```bash
-git log --since="$START_DATE" --name-only --pretty=format: upstream/main \
-  | grep -E "^_d/|^_posts/" \
-  | sort | uniq -c | sort -rn | head -20
+.claude/skills/changelog/changed_files.py --since "$START_DATE" --limit 20
 ```
+
+Output shape: `[{"path": "_d/ai-journal.md", "change_count": 8}, ...]`, sorted by count descending with alphabetical tie-break. Defaults to `_d/` and `_posts/` prefixes; pass `--prefixes _d/,_posts/,_includes/` to widen. Pass `--branch main` for a local-only repo.
+
+Tests: `cd .claude/skills/changelog && python3 -m unittest test_changed_files`.
 
 ### 3. Read Actual Content Diffs (NOT commit messages!)
 
@@ -55,6 +57,7 @@ git show COMMIT_HASH -- _d/filename.md
 ```
 
 **What to extract from diffs:**
+
 - New section headers (what topics were added?)
 - Key concepts, frameworks, or models introduced
 - Specific examples or case studies
@@ -62,9 +65,11 @@ git show COMMIT_HASH -- _d/filename.md
 - Tables, lists, or structured content
 
 **Example - BAD (from commit message):**
+
 > "Add spiritual health content"
 
 **Example - GOOD (from actual diff):**
+
 > "Vanaprastha framework: 4-stage Hindu life model (Brahmacharya→Grihastha→Vanaprastha→Sannyasa). Three obstacles: 'None' identity trap, Santa in the Church, Tyranny of Time."
 
 For other repos, get diff summaries:
@@ -91,7 +96,7 @@ Description of changes in this theme:
 - **Item title** - Description ([blog](/permalink#section)) ([github](https://github.com/idvorkin/idvorkin.github.io/commit/SHORTHASH))
 ```
 
-**Important — unique section names**: Every `###` heading must be unique across the *entire* file, not just the current week. Duplicate headings produce duplicate Markdown TOC anchors (`#other-projects`, `#other-projects-1`, …) which are confusing and break deep links.
+**Important — unique section names**: Every `###` heading must be unique across the _entire_ file, not just the current week. Duplicate headings produce duplicate Markdown TOC anchors (`#other-projects`, `#other-projects-1`, …) which are confusing and break deep links.
 
 - For "Other Projects" sections, always append the week date: `### Other Projects (YYYY-MM-DD)` (e.g. `### Other Projects (2026-04-12)`). Never use month names like `(April)` since they repeat across weeks.
 - If you use any other recurring theme name (e.g. "Infrastructure"), append the week date too if that name already appears earlier in the file: `### Infrastructure (YYYY-MM-DD)`.
@@ -104,7 +109,7 @@ Always include both blog and GitHub links where applicable:
 - **Blog link**: `([blog](/permalink))` or `([blog](/permalink#section-anchor))`
 - **GitHub icon link**: `[<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/SHORTHASH)`
 
-Use short commit hashes (first 9 chars) for readability. The GitHub icon (`<i class="fa fa-github"></i>`) renders as a clickable  icon.
+Use short commit hashes (first 9 chars) for readability. The GitHub icon (`<i class="fa fa-github"></i>`) renders as a clickable icon.
 
 ### 5. Finding Section Anchors
 
@@ -116,18 +121,21 @@ grep "^#" _d/filename.md | head -20
 ```
 
 Section anchors are slugified headers:
+
 - `### My Section Title` → `#my-section-title`
 - `### AI & Machine Learning` → `#ai--machine-learning`
 
 ## Example Output
 
 **BAD - based on commit messages (vague, unhelpful):**
+
 ```markdown
 - **Software Survival 3.0** - Added Steve Yegge's framework
 - **Code as Costly Signal** - Discussed what code signals
 ```
 
 **GOOD - based on actual content diffs (specific, informative):**
+
 ```markdown
 ## Week of 2026-01-25
 
@@ -142,6 +150,7 @@ Five new entries on AI-era software development ([blog](/ai-journal#2026-01-31))
 ```
 
 Notice how the GOOD version includes:
+
 - Actual formulas/frameworks from the content
 - Specific quotes
 - Key concepts explained
@@ -149,13 +158,13 @@ Notice how the GOOD version includes:
 
 ## Common Themes to Look For
 
-| Theme | Files to Check | Keywords |
-|-------|---------------|----------|
-| AI/Tech | `ai-*.md`, `how-igor-chops.md` | AI, coding, CHOP |
-| Health | `*-pain.md`, `physical-*.md` | pain, exercise, health |
-| Spiritual | `spiritual-*.md`, `religion.md`, `meditation.md` | spiritual, meditation |
-| Life Planning | `gap-year.md`, `y20*.md`, `retire.md` | goals, planning |
-| Infrastructure | `.claude/`, `scripts/`, `_plugins/` | fix, improve, add command |
+| Theme          | Files to Check                                   | Keywords                  |
+| -------------- | ------------------------------------------------ | ------------------------- |
+| AI/Tech        | `ai-*.md`, `how-igor-chops.md`                   | AI, coding, CHOP          |
+| Health         | `*-pain.md`, `physical-*.md`                     | pain, exercise, health    |
+| Spiritual      | `spiritual-*.md`, `religion.md`, `meditation.md` | spiritual, meditation     |
+| Life Planning  | `gap-year.md`, `y20*.md`, `retire.md`            | goals, planning           |
+| Infrastructure | `.claude/`, `scripts/`, `_plugins/`              | fix, improve, add command |
 
 ## Update TOC
 
@@ -167,69 +176,87 @@ After adding a new week, update the TOC at the top of the changelog:
 - [Week of 2026-01-25](#week-of-2026-01-25)
   - [AI Journal Updates](#ai-journal-updates)
   - [Theme 2](#theme-2)
-<!-- vim-markdown-toc-end -->
+  <!-- vim-markdown-toc-end -->
 ```
 
 ## Cross-Repo Changelog
 
-### List Active Repos
+### Scan Active Repos + Their Commits (one call)
 
-Scan BOTH `idvorkin` and `idvorkin-ai-tools` orgs. Use `--visibility public` to skip private repos.
-
-```bash
-for org in idvorkin idvorkin-ai-tools; do
-  echo "=== $org ==="
-  gh repo list $org --limit 100 --visibility public --json name,pushedAt \
-    --jq '.[] | select(.pushedAt > "DATE") | .name'
-done
-```
-
-### Get Commits from All Active Repos
+Use the `scan_repos.py` helper that ships alongside this skill — one command replaces the nested bash loop, with parallel `gh api` fetches and unit-tested active-repo classification:
 
 ```bash
-for org in idvorkin idvorkin-ai-tools; do
-  gh repo list $org --limit 100 --visibility public --json name,pushedAt \
-    --jq '.[] | select(.pushedAt > "DATE") | .name' | while read repo; do
-    echo "=== $org/$repo ==="
-    gh api repos/$org/$repo/commits \
-      --jq '.[0:10] | .[] | "\(.sha[0:9]) \(.commit.message | split("\n")[0])"' 2>/dev/null
-    echo ""
-  done
-done
+# Default: both orgs (idvorkin + idvorkin-ai-tools), parallel fetches
+.claude/skills/changelog/scan_repos.py --since "$START_DATE"
+
+# Narrow orgs or widen the fetch
+.claude/skills/changelog/scan_repos.py --since "$START_DATE" \
+  --orgs idvorkin \
+  --max-workers 16 \
+  --commit-limit 20
 ```
+
+Output shape (JSON, sorted by `(org, name)` for deterministic diffing):
+
+```json
+[
+  {
+    "org": "idvorkin",
+    "name": "idvorkin.github.io",
+    "pushed_at": "2026-04-16T14:42:00Z",
+    "commits": [
+      {
+        "sha": "049000327",
+        "message": "content: ...",
+        "date": "2026-04-16T14:40:00Z"
+      }
+    ]
+  }
+]
+```
+
+**Why parallel matters:** the previous bash loop issued ~30-50 serial `gh api commits` calls, each round-tripping to GitHub. `scan_repos.py` fans these out across a thread pool (default 8 workers), so a typical scan drops from tens of seconds to a few.
+
+**Safety:** a failed fetch for one repo returns `"commits": []` rather than aborting the full scan — one broken/private/archived repo can't poison a cross-repo sweep.
+
+Tests: `cd .claude/skills/changelog && python3 -m unittest test_scan_repos`.
 
 Don't be lazy — use GitHub deep links whenever possible: commit links, file links, section anchors.
 
 ### Key Repos to Track
 
-| Repo | Purpose | What to Look For |
-|------|---------|------------------|
-| `idvorkin.github.io` | Blog | Content changes, new posts |
-| `Settings` | Dotfiles/tools | New commands, config changes |
-| `nlp` | AI/NLP tools | New models, features |
-| `chop-conventions` | CHOP docs | Workflow improvements |
-| `tony_tesla` | Voice AI | Tony/Vapi updates |
-| `*-explainer` | Visualizations | New explainers |
+| Repo                 | Purpose        | What to Look For             |
+| -------------------- | -------------- | ---------------------------- |
+| `idvorkin.github.io` | Blog           | Content changes, new posts   |
+| `Settings`           | Dotfiles/tools | New commands, config changes |
+| `nlp`                | AI/NLP tools   | New models, features         |
+| `chop-conventions`   | CHOP docs      | Workflow improvements        |
+| `tony_tesla`         | Voice AI       | Tony/Vapi updates            |
+| `*-explainer`        | Visualizations | New explainers               |
 
 ### Cross-Repo Entry Format
 
 **For regular repos** (link repo name to GitHub):
+
 ```markdown
 **[Settings](https://github.com/idvorkin/Settings)** (dotfiles & tools)
+
 - Added terminal tab switching command [<i class="fa fa-github"></i>](https://github.com/idvorkin/Settings/commit/HASH)
 ```
 
 **For explainers/apps with deployments** (link name to deployment, icon to repo):
+
 ```markdown
 **[monitor-explainer](https://monitor-explorer.surge.sh)** (visualization) [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer)
+
 - Added comprehensive content [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer/commit/HASH)
 ```
 
 ### Link Patterns
 
-| Type | Name Links To | GitHub Icon |
-|------|---------------|-------------|
-| Regular repo | GitHub repo | Commit link |
+| Type          | Name Links To   | GitHub Icon                              |
+| ------------- | --------------- | ---------------------------------------- |
+| Regular repo  | GitHub repo     | Commit link                              |
 | Explainer/app | Live deployment | Repo link (header) + Commit link (items) |
 
 ### GitHub Icon Link Format

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -223,16 +223,19 @@ Tests: `cd .claude/skills/changelog && python3 -m unittest test_scan_repos`.
 
 Don't be lazy — use GitHub deep links whenever possible: commit links, file links, section anchors.
 
-### Key Repos to Track
+### Scope: all public repos under both orgs
 
-| Repo                 | Purpose        | What to Look For             |
-| -------------------- | -------------- | ---------------------------- |
-| `idvorkin.github.io` | Blog           | Content changes, new posts   |
-| `Settings`           | Dotfiles/tools | New commands, config changes |
-| `nlp`                | AI/NLP tools   | New models, features         |
-| `chop-conventions`   | CHOP docs      | Workflow improvements        |
-| `tony_tesla`         | Voice AI       | Tony/Vapi updates            |
-| `*-explainer`        | Visualizations | New explainers               |
+**Include every public repo under `idvorkin` and `idvorkin-ai-tools`** — do not filter to a curated list. `scan_repos.py` already enumerates everything via `gh repo list --visibility public`; the active-repo filter then drops repos with no commits in the window. The only other automatic filter is per-repo fetch failure, which skips archived/moved/rate-limited repos silently.
+
+Common categories encountered in practice (for shape, not a whitelist):
+
+| Example repos                         | Typical surface area                |
+| ------------------------------------- | ----------------------------------- |
+| `idvorkin.github.io`                  | Blog content, new posts             |
+| `Settings`, `chop-conventions`        | Dotfiles, tooling, workflow docs    |
+| `nlp`, `tony_tesla`, `tony_assistant` | AI/NLP/voice experiments            |
+| `*-explainer`                         | Visualization apps with deployments |
+| `idvorkin-ai-tools/*`                 | AI-written tools, forks, PR bots    |
 
 ### Cross-Repo Entry Format
 

--- a/.claude/skills/changelog/changed_files.py
+++ b/.claude/skills/changelog/changed_files.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Rank blog content files by change frequency since a date.
+
+Replaces the 6-stage shell pipeline:
+
+    git log --since="$START_DATE" --name-only --pretty=format: upstream/main \\
+      | grep -E "^_d/|^_posts/" \\
+      | sort | uniq -c | sort -rn | head -20
+
+with a stdlib Python helper that keeps the counting + ranking logic as
+a pure function (testable without subprocess). The only subprocess call
+is `git log`; everything else is in-memory.
+
+Usage:
+
+  changed_files.py --since 2026-04-13
+  changed_files.py --since 2026-04-13 --branch main --limit 10
+  changed_files.py --since 2026-04-13 --prefixes _d/,_posts/,_includes/
+
+Output: JSON array of {path, change_count}, sorted by count descending
+with ties broken alphabetically for deterministic diffing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass
+
+DEFAULT_PREFIXES = ("_d/", "_posts/")
+DEFAULT_BRANCH = "upstream/main"
+DEFAULT_LIMIT = 20
+
+
+@dataclass
+class FileChange:
+    path: str
+    change_count: int
+
+
+def run_git_log(since: dt.date, branch: str = DEFAULT_BRANCH) -> list[str]:
+    """Return the raw `git log --name-only --pretty=format:` lines."""
+    result = subprocess.run(
+        [
+            "git",
+            "log",
+            f"--since={since.isoformat()}",
+            "--name-only",
+            "--pretty=format:",
+            branch,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.splitlines()
+
+
+def rank_files(
+    lines: list[str],
+    prefixes: tuple[str, ...] = DEFAULT_PREFIXES,
+    limit: int = DEFAULT_LIMIT,
+) -> list[FileChange]:
+    """Count file occurrences, filter by content-path prefix, return top N.
+
+    Pure function — ties are broken alphabetically so output is stable.
+    """
+    matching = [
+        line
+        for line in lines
+        if line and any(line.startswith(prefix) for prefix in prefixes)
+    ]
+    counts = Counter(matching)
+    ordered = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    return [
+        FileChange(path=path, change_count=count) for path, count in ordered[:limit]
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--since", type=dt.date.fromisoformat, required=True)
+    parser.add_argument("--branch", default=DEFAULT_BRANCH)
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    parser.add_argument(
+        "--prefixes",
+        default=",".join(DEFAULT_PREFIXES),
+        help="Comma-separated content-path prefixes to keep.",
+    )
+    args = parser.parse_args()
+
+    prefixes = tuple(p.strip() for p in args.prefixes.split(",") if p.strip())
+    lines = run_git_log(args.since, args.branch)
+    ranked = rank_files(lines, prefixes, args.limit)
+    print(json.dumps([asdict(r) for r in ranked], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/changelog/scan_repos.py
+++ b/.claude/skills/changelog/scan_repos.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Scan GitHub orgs for active repos + recent commits, in parallel.
+
+Replaces the serial nested bash loop:
+
+    for org in idvorkin idvorkin-ai-tools; do
+      gh repo list $org --limit 100 --visibility public ...
+      while read repo; do
+        gh api repos/$org/$repo/commits ...
+      done
+    done
+
+with a parallel implementation that (a) fans `gh api commits` calls out
+across a thread pool, and (b) keeps the classification logic (active-repo
+detection by `pushedAt`) as a pure function that unit tests can exercise
+without mocking subprocess.
+
+Usage:
+
+  scan_repos.py --since 2026-04-13
+  scan_repos.py --since 2026-04-13 --orgs idvorkin,idvorkin-ai-tools
+  scan_repos.py --since 2026-04-13 --max-workers 16 --commit-limit 20
+
+Output: JSON array of {org, name, pushed_at, commits: [{sha, message, date}]}
+sorted by (org, name) for deterministic diffing. Failed commit fetches
+return an empty `commits` list rather than aborting the whole scan.
+
+Stdlib-only. Cross-platform. Requires `gh` on PATH.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import datetime as dt
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import Callable
+
+DEFAULT_ORGS = "idvorkin,idvorkin-ai-tools"
+DEFAULT_REPO_LIMIT = 100
+DEFAULT_COMMIT_LIMIT = 30
+DEFAULT_MAX_WORKERS = 8
+
+
+@dataclass
+class RepoActivity:
+    org: str
+    name: str
+    pushed_at: str
+    commits: list[dict] = field(default_factory=list)
+
+
+def run_gh(args: list[str]) -> str:
+    """Run `gh <args>`, return stdout. Raises CalledProcessError on failure."""
+    result = subprocess.run(["gh", *args], check=True, capture_output=True, text=True)
+    return result.stdout
+
+
+def list_org_repos(org: str, limit: int = DEFAULT_REPO_LIMIT) -> list[dict]:
+    """Return [{name, pushedAt}, ...] for public repos in the org."""
+    raw = run_gh(
+        [
+            "repo",
+            "list",
+            org,
+            "--limit",
+            str(limit),
+            "--visibility",
+            "public",
+            "--json",
+            "name,pushedAt",
+        ]
+    )
+    return json.loads(raw)
+
+
+def filter_active(repos: list[dict], since: dt.date) -> list[dict]:
+    """Keep repos whose `pushedAt` is on or after `since` (pure function)."""
+    cutoff = f"{since.isoformat()}T00:00:00Z"
+    return [r for r in repos if r.get("pushedAt", "") >= cutoff]
+
+
+def fetch_repo_commits(
+    org: str, name: str, since: dt.date, limit: int = DEFAULT_COMMIT_LIMIT
+) -> list[dict]:
+    """Fetch up to `limit` commits since `since` for one repo.
+
+    Best-effort: returns `[]` on error rather than propagating, so one broken
+    repo can't abort the whole cross-repo scan.
+    """
+    jq = (
+        f'[.[] | select(.commit.committer.date >= "{since.isoformat()}") '
+        f"| {{sha: .sha[0:9], "
+        f'message: (.commit.message | split("\\n")[0]), '
+        f"date: .commit.committer.date}}] "
+        f"| .[0:{limit}]"
+    )
+    try:
+        raw = run_gh(["api", f"repos/{org}/{name}/commits", "-q", jq])
+    except subprocess.CalledProcessError:
+        return []
+    return json.loads(raw) if raw.strip() else []
+
+
+def scan(
+    orgs: list[str],
+    since: dt.date,
+    max_workers: int = DEFAULT_MAX_WORKERS,
+    commit_limit: int = DEFAULT_COMMIT_LIMIT,
+    repo_limit: int = DEFAULT_REPO_LIMIT,
+    _list_org_repos: Callable[[str, int], list[dict]] = list_org_repos,
+    _fetch_repo_commits: Callable[
+        [str, str, dt.date, int], list[dict]
+    ] = fetch_repo_commits,
+) -> list[RepoActivity]:
+    """Run the full scan. The two `_*` injected callables let tests stub gh."""
+    active: list[tuple[str, dict]] = []
+    for org in orgs:
+        for repo in filter_active(_list_org_repos(org, repo_limit), since):
+            active.append((org, repo))
+
+    results: list[RepoActivity] = []
+    if not active:
+        return results
+
+    with cf.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        future_map = {
+            pool.submit(_fetch_repo_commits, org, repo["name"], since, commit_limit): (
+                org,
+                repo,
+            )
+            for org, repo in active
+        }
+        for fut in cf.as_completed(future_map):
+            org, repo = future_map[fut]
+            results.append(
+                RepoActivity(
+                    org=org,
+                    name=repo["name"],
+                    pushed_at=repo["pushedAt"],
+                    commits=fut.result(),
+                )
+            )
+
+    results.sort(key=lambda r: (r.org, r.name))
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--since", type=dt.date.fromisoformat, required=True)
+    parser.add_argument("--orgs", default=DEFAULT_ORGS)
+    parser.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
+    parser.add_argument("--commit-limit", type=int, default=DEFAULT_COMMIT_LIMIT)
+    parser.add_argument("--repo-limit", type=int, default=DEFAULT_REPO_LIMIT)
+    args = parser.parse_args()
+
+    orgs = [o.strip() for o in args.orgs.split(",") if o.strip()]
+    results = scan(
+        orgs=orgs,
+        since=args.since,
+        max_workers=args.max_workers,
+        commit_limit=args.commit_limit,
+        repo_limit=args.repo_limit,
+    )
+    print(json.dumps([asdict(r) for r in results], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/changelog/test_changed_files.py
+++ b/.claude/skills/changelog/test_changed_files.py
@@ -1,0 +1,65 @@
+"""Unit tests for changed_files.py. Stdlib-only. Run with `python3 -m unittest`."""
+
+from __future__ import annotations
+
+import unittest
+
+from changed_files import FileChange, rank_files
+
+
+class RankFilesTest(unittest.TestCase):
+    def test_counts_and_filters_by_prefix(self):
+        lines = [
+            "_d/ai-journal.md",
+            "_d/ai-journal.md",
+            "_posts/2026-04-15-hello.md",
+            "_plugins/foo.rb",  # not a content file
+            "README.md",  # not a content file
+            "",  # blank separator from git log --pretty=format:
+            "_d/religion.md",
+        ]
+        result = rank_files(lines)
+        self.assertEqual(
+            result,
+            [
+                FileChange(path="_d/ai-journal.md", change_count=2),
+                FileChange(path="_d/religion.md", change_count=1),
+                FileChange(path="_posts/2026-04-15-hello.md", change_count=1),
+            ],
+        )
+
+    def test_ties_broken_alphabetically(self):
+        lines = ["_d/zeta.md", "_d/alpha.md", "_d/beta.md"]
+        result = rank_files(lines)
+        paths = [r.path for r in result]
+        self.assertEqual(paths, ["_d/alpha.md", "_d/beta.md", "_d/zeta.md"])
+
+    def test_limit_honored(self):
+        lines = [f"_d/{c}.md" for c in "abcdefg"]
+        result = rank_files(lines, limit=3)
+        self.assertEqual(len(result), 3)
+
+    def test_empty_input_yields_empty(self):
+        self.assertEqual(rank_files([]), [])
+
+    def test_all_blank_lines_yields_empty(self):
+        self.assertEqual(rank_files(["", "", ""]), [])
+
+    def test_custom_prefixes(self):
+        lines = ["docs/intro.md", "_d/ai.md", "_includes/header.html"]
+        result = rank_files(lines, prefixes=("_d/", "_includes/"))
+        paths = {r.path for r in result}
+        self.assertEqual(paths, {"_d/ai.md", "_includes/header.html"})
+        self.assertNotIn("docs/intro.md", paths)
+
+    def test_sort_is_stable_across_runs(self):
+        lines = ["_d/a.md", "_d/b.md", "_d/b.md", "_d/a.md"]
+        r1 = rank_files(lines)
+        r2 = rank_files(lines)
+        self.assertEqual(r1, r2)
+        # Highest count first; ties alphabetical
+        self.assertEqual([r.path for r in r1], ["_d/a.md", "_d/b.md"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/changelog/test_scan_repos.py
+++ b/.claude/skills/changelog/test_scan_repos.py
@@ -1,0 +1,120 @@
+"""Unit tests for scan_repos.py. Stdlib-only. Run with `python3 -m unittest`."""
+
+from __future__ import annotations
+
+import datetime as dt
+import unittest
+
+from scan_repos import RepoActivity, filter_active, scan
+
+
+class FilterActiveTest(unittest.TestCase):
+    def test_keeps_repos_pushed_after_cutoff(self):
+        repos = [
+            {"name": "a", "pushedAt": "2026-04-13T10:00:00Z"},
+            {"name": "b", "pushedAt": "2026-04-10T10:00:00Z"},
+            {"name": "c", "pushedAt": "2026-04-20T10:00:00Z"},
+        ]
+        result = filter_active(repos, dt.date(2026, 4, 13))
+        names = [r["name"] for r in result]
+        self.assertEqual(names, ["a", "c"])
+
+    def test_empty_list_yields_empty(self):
+        self.assertEqual(filter_active([], dt.date(2026, 4, 13)), [])
+
+    def test_missing_pushedAt_excluded(self):
+        repos = [{"name": "a"}]
+        self.assertEqual(filter_active(repos, dt.date(2026, 4, 13)), [])
+
+    def test_same_day_included(self):
+        repos = [{"name": "a", "pushedAt": "2026-04-13T00:00:00Z"}]
+        self.assertEqual(filter_active(repos, dt.date(2026, 4, 13)), repos)
+
+
+class ScanTest(unittest.TestCase):
+    """Test the full scan pipeline with injected stubs — no real gh calls."""
+
+    def test_end_to_end_with_stubs(self):
+        def fake_list_repos(org: str, _limit: int) -> list[dict]:
+            return {
+                "idvorkin": [
+                    {"name": "active", "pushedAt": "2026-04-15T00:00:00Z"},
+                    {"name": "stale", "pushedAt": "2026-01-01T00:00:00Z"},
+                ],
+                "idvorkin-ai-tools": [
+                    {"name": "tools", "pushedAt": "2026-04-14T00:00:00Z"},
+                ],
+            }[org]
+
+        calls: list[tuple[str, str]] = []
+
+        def fake_fetch(org: str, name: str, _since: dt.date, _limit: int) -> list[dict]:
+            calls.append((org, name))
+            return [
+                {
+                    "sha": f"{name[:3]}1234567",
+                    "message": f"commit in {name}",
+                    "date": "2026-04-15T10:00:00Z",
+                }
+            ]
+
+        result = scan(
+            orgs=["idvorkin", "idvorkin-ai-tools"],
+            since=dt.date(2026, 4, 13),
+            _list_org_repos=fake_list_repos,
+            _fetch_repo_commits=fake_fetch,
+        )
+
+        self.assertEqual(len(result), 2)  # stale excluded
+        self.assertEqual(
+            [(r.org, r.name) for r in result],
+            [("idvorkin", "active"), ("idvorkin-ai-tools", "tools")],
+        )
+        self.assertCountEqual(
+            calls, [("idvorkin", "active"), ("idvorkin-ai-tools", "tools")]
+        )
+        self.assertEqual(result[0].commits[0]["message"], "commit in active")
+
+    def test_no_active_repos_returns_empty(self):
+        def fake_list(_org: str, _limit: int) -> list[dict]:
+            return [{"name": "stale", "pushedAt": "2026-01-01T00:00:00Z"}]
+
+        def fake_fetch(*args, **kwargs):
+            raise AssertionError("fetch should not be called when nothing is active")
+
+        result = scan(
+            orgs=["idvorkin"],
+            since=dt.date(2026, 4, 13),
+            _list_org_repos=fake_list,
+            _fetch_repo_commits=fake_fetch,
+        )
+        self.assertEqual(result, [])
+
+    def test_sorted_deterministically(self):
+        def fake_list(org: str, _limit: int) -> list[dict]:
+            if org == "alpha":
+                return [{"name": "zeta", "pushedAt": "2026-04-15T00:00:00Z"}]
+            return [{"name": "apple", "pushedAt": "2026-04-15T00:00:00Z"}]
+
+        def fake_fetch(*_args, **_kwargs) -> list[dict]:
+            return []
+
+        result = scan(
+            orgs=["beta", "alpha"],
+            since=dt.date(2026, 4, 13),
+            _list_org_repos=fake_list,
+            _fetch_repo_commits=fake_fetch,
+        )
+        self.assertEqual(
+            [(r.org, r.name) for r in result], [("alpha", "zeta"), ("beta", "apple")]
+        )
+
+
+class RepoActivityTest(unittest.TestCase):
+    def test_default_commits_is_empty_list(self):
+        r = RepoActivity(org="foo", name="bar", pushed_at="2026-04-15T00:00:00Z")
+        self.assertEqual(r.commits, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #522. Migrates the two remaining heavy bash blocks in the changelog skill to Python helpers, per [chop-conventions](https://github.com/idvorkin/chop-conventions/blob/main/CLAUDE.md) ("default to Python for non-trivial scripts").

## What changes

### \`scan_repos.py\` — parallel cross-repo scanner

**Before** (serial nested bash loop in SKILL.md):

\`\`\`bash
for org in idvorkin idvorkin-ai-tools; do
  gh repo list \$org --limit 100 --visibility public --json name,pushedAt \
    --jq '.[] | select(.pushedAt > \"DATE\") | .name' | while read repo; do
    gh api repos/\$org/\$repo/commits --jq '...'
  done
done
\`\`\`

~30-50 sequential \`gh api commits\` calls, one at a time.

**After**:

\`\`\`bash
.claude/skills/changelog/scan_repos.py --since 2026-04-13
\`\`\`

- Thread pool (default 8 workers) fans \`gh api commits\` fetches in parallel
- \`filter_active(repos, since)\` is a pure function, unit-tested
- \`scan()\` takes injected \`_list_org_repos\` / \`_fetch_repo_commits\` callables so tests drive the pipeline without mocking subprocess
- Failed fetches for one repo return \`[]\` rather than aborting the full scan (one broken/archived/private repo can't poison a sweep)
- JSON output sorted by \`(org, name)\` for deterministic diffing

### \`changed_files.py\` — ranked file-change frequency

**Before** (6-stage shell pipeline):

\`\`\`bash
git log --since=\"\$START_DATE\" --name-only --pretty=format: upstream/main \\
  | grep -E \"^_d/|^_posts/\" \\
  | sort | uniq -c | sort -rn | head -20
\`\`\`

Non-deterministic on ties (\`sort -rn\` isn't stable), pipeline of 5 processes.

**After**:

\`\`\`bash
.claude/skills/changelog/changed_files.py --since 2026-04-13 --limit 20
\`\`\`

- One \`git log\` call + in-memory counting + **alphabetical tie-breaking**
- \`rank_files(lines, prefixes, limit)\` pure function, testable without subprocess
- Configurable prefixes (\`--prefixes _d/,_posts/,_includes/\`) and branch (\`--branch main\`)
- JSON output

## Why Python

Per chop-conventions: *\"Default to Python for any non-trivial script, not shell. Helpers earn their place when they (a) parallelize subprocess calls AND (b) need unit-tested classification logic.\"*

- \`scan_repos.py\` hits **both** criteria (parallelizes + classifies active repos)
- \`changed_files.py\` needs deterministic classification logic (the bash \`sort -rn\` tie-break was non-deterministic)

Modeled on \`skills/up-to-date/diagnose.py\` (the reference implementation cited in chop-conventions).

## Verification

**15/15 unit tests pass** (stdlib \`unittest\`, no mocks — pipe-style stub injection):

\`\`\`
test_counts_and_filters_by_prefix ... ok
test_ties_broken_alphabetically ... ok
test_limit_honored ... ok
test_empty_input_yields_empty ... ok
test_all_blank_lines_yields_empty ... ok
test_custom_prefixes ... ok
test_sort_is_stable_across_runs ... ok
test_keeps_repos_pushed_after_cutoff ... ok
test_empty_list_yields_empty ... ok
test_missing_pushedAt_excluded ... ok
test_same_day_included ... ok
test_end_to_end_with_stubs ... ok
test_no_active_repos_returns_empty ... ok
test_sorted_deterministically ... ok
test_default_commits_is_empty_list ... ok
\`\`\`

**CLI smoke-test** — \`changed_files.py --since 2026-04-13 --limit 5\` against the live repo correctly ranks the files edited during this week's AI-relationships PR work:

\`\`\`json
[
  {\"path\": \"_d/ai-relationships.md\", \"change_count\": 8},
  {\"path\": \"_d/act.md\", \"change_count\": 5},
  {\"path\": \"_d/larry.md\", \"change_count\": 4},
  {\"path\": \"_d/ai-operator.md\", \"change_count\": 3},
  {\"path\": \"_d/ai-journal.md\", \"change_count\": 1}
]
\`\`\`

## Files

- \`.claude/skills/changelog/scan_repos.py\` (~180 lines) + \`test_scan_repos.py\` (7 tests)
- \`.claude/skills/changelog/changed_files.py\` (~90 lines) + \`test_changed_files.py\` (7 tests)
- \`.claude/skills/changelog/SKILL.md\` — Step 2 calls \`changed_files.py\`; Cross-Repo section consolidated into one \`scan_repos.py\` invocation

## Test plan

- [x] \`python3 -m unittest test_scan_repos test_changed_files\` — 15/15 pass
- [x] \`changed_files.py --since 2026-04-13\` against live repo — output correct
- [x] Ruff + Prettier pre-commit hooks pass
- [ ] Next full changelog run exercises both tools end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)