### PR TITLE
content(explainers): add dolt-explainer to the built-explainers tables

### DIFF
--- a/_d/explainers.md
+++ b/_d/explainers.md
@@ -87,11 +87,12 @@ In [CHOW](/chow) (Chat-Oriented Writing), the written artifact is a side effect 
 
 ## Explainers I've Built
 
-| Explainer                                                                    | What It Does                                                             | Instead Of                  |                                                                                         |
-| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------ | --------------------------- | --------------------------------------------------------------------------------------- |
-| [Monitor Explainer](https://monitor-explorer.surge.sh/)                      | Explains monitor dimensions, aspect ratios, and the "p" vs "K" confusion | Reading spec sheets         | [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer)           |
-| [How Long Since AI](https://idvorkin-how-long-since-ai.surge.sh/)            | Track time since AI milestones — ChatGPT, GPT-4, Claude, Gemini          | Searching for release dates | [<i class="fa fa-github"></i>](https://github.com/idvorkin/how-long-since-ai)           |
-| [Religion Evolution Explorer](https://religion-evolution-explorer.surge.sh/) | Interactive timeline of how religions evolved and influenced each other  | Reading history books       | [<i class="fa fa-github"></i>](https://github.com/idvorkin/religion-evolution-explorer) |
+| Explainer                                                                    | What It Does                                                                 | Instead Of                        |                                                                                         |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------- |
+| [Monitor Explainer](https://monitor-explorer.surge.sh/)                      | Explains monitor dimensions, aspect ratios, and the "p" vs "K" confusion     | Reading spec sheets               | [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer)           |
+| [How Long Since AI](https://idvorkin-how-long-since-ai.surge.sh/)            | Track time since AI milestones — ChatGPT, GPT-4, Claude, Gemini              | Searching for release dates       | [<i class="fa fa-github"></i>](https://github.com/idvorkin/how-long-since-ai)           |
+| [Religion Evolution Explorer](https://religion-evolution-explorer.surge.sh/) | Interactive timeline of how religions evolved and influenced each other      | Reading history books             | [<i class="fa fa-github"></i>](https://github.com/idvorkin/religion-evolution-explorer) |
+| [Dolt Explainer](https://idvorkin-ai-tools.github.io/dolt-explainer/)        | How beads task state and git code share one GitHub repo via `refs/dolt/data` | Staring at `git ls-remote` output | [<i class="fa fa-github"></i>](https://github.com/idvorkin-ai-tools/dolt-explainer)     |
 
 The pattern is the same every time: take something that's hard to grasp as text, ask AI to build an interactive version, and suddenly it makes sense. These aren't prettier presentations — they're fundamentally different experiences. You explore at your own pace, discover things the author didn't explicitly write, and actually retain what you learned.
 

--- a/_d/pet-projects.md
+++ b/_d/pet-projects.md
@@ -111,11 +111,12 @@ GitHub orgs to check:
 
 Interactive experiences that let you _do_ the thing, not just read about it — an antidote to [cognitive debt](/ai-native-manager#cognitive-debt). See the [full explainers page](/explainers) for great examples, the AI workflow, and why this matters.
 
-| Explainer                                                                    | What It Does                                                             | Instead Of                  |                                                                                         |
-| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------ | --------------------------- | --------------------------------------------------------------------------------------- |
-| [Monitor Explainer](https://monitor-explorer.surge.sh/)                      | Explains monitor dimensions, aspect ratios, and the "p" vs "K" confusion | Reading spec sheets         | [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer)           |
-| [How Long Since AI](https://idvorkin-how-long-since-ai.surge.sh/)            | Track time since AI milestones — ChatGPT, GPT-4, Claude, Gemini          | Searching for release dates | [<i class="fa fa-github"></i>](https://github.com/idvorkin/how-long-since-ai)           |
-| [Religion Evolution Explorer](https://religion-evolution-explorer.surge.sh/) | Interactive timeline of how religions evolved and influenced each other  | Reading history books       | [<i class="fa fa-github"></i>](https://github.com/idvorkin/religion-evolution-explorer) |
+| Explainer                                                                    | What It Does                                                                 | Instead Of                        |                                                                                         |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------- |
+| [Monitor Explainer](https://monitor-explorer.surge.sh/)                      | Explains monitor dimensions, aspect ratios, and the "p" vs "K" confusion     | Reading spec sheets               | [<i class="fa fa-github"></i>](https://github.com/idvorkin/monitor-explainer)           |
+| [How Long Since AI](https://idvorkin-how-long-since-ai.surge.sh/)            | Track time since AI milestones — ChatGPT, GPT-4, Claude, Gemini              | Searching for release dates       | [<i class="fa fa-github"></i>](https://github.com/idvorkin/how-long-since-ai)           |
+| [Religion Evolution Explorer](https://religion-evolution-explorer.surge.sh/) | Interactive timeline of how religions evolved and influenced each other      | Reading history books             | [<i class="fa fa-github"></i>](https://github.com/idvorkin/religion-evolution-explorer) |
+| [Dolt Explainer](https://idvorkin-ai-tools.github.io/dolt-explainer/)        | How beads task state and git code share one GitHub repo via `refs/dolt/data` | Staring at `git ls-remote` output | [<i class="fa fa-github"></i>](https://github.com/idvorkin-ai-tools/dolt-explainer)     |
 
 ## Fun & Experiments
 

--- a/back-links.json
+++ b/back-links.json
@@ -2945,7 +2945,7 @@
                 "/chow",
                 "/pet-projects"
             ],
-            "last_modified": "2026-03-16T19:40:55-07:00",
+            "last_modified": "2026-04-16T23:12:34.253724+00:00",
             "markdown_path": "_d/explainers.md",
             "outgoing_links": [
                 "/ai-native-manager",
@@ -3529,7 +3529,6 @@
                 "/ai-journal",
                 "/changelog",
                 "/chop",
-                "/pet-projects",
                 "/y25",
                 "/y26"
             ],
@@ -4777,17 +4776,17 @@
                 "/side-quests",
                 "/y25"
             ],
-            "last_modified": "2026-03-16T16:18:57.011958+00:00",
+            "last_modified": "2026-04-16T23:12:34.253724+00:00",
             "markdown_path": "_d/pet-projects.md",
             "outgoing_links": [
                 "/ai-native-manager",
                 "/bike-tesla-identity",
                 "/explainers",
-                "/how-igor-chops",
                 "/larry",
                 "/process-journal",
                 "/side-quests",
-                "/static/pet-projects.html"
+                "/static/pet-projects.html",
+                "/vibe"
             ],
             "redirect_url": "",
             "title": "Pet Projects",


### PR DESCRIPTION
## Summary

- Adds a row to both `/explainers` and `/pet-projects` tables pointing at https://idvorkin-ai-tools.github.io/dolt-explainer/
- The linked explainer covers how the beads task DB and the code repo share one GitHub fork via `refs/dolt/data` — seven reproducible shell scenarios, six PlantUML diagrams, a research doc

## Test plan
- [x] `bundle exec jekyll build --incremental` succeeds
- [x] Pre-commit anchor checker passes (after rebuilding `_site/`)
- [x] Live URL https://idvorkin-ai-tools.github.io/dolt-explainer/ is deployed and renders
- [x] Linked GitHub icon resolves to https://github.com/idvorkin-ai-tools/dolt-explainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)