### PR TITLE
feat(toc): validate also flags indented prettier-ignore fence markers

### DIFF
--- a/.claude/skills/toc/test_toc.py
+++ b/.claude/skills/toc/test_toc.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from toc import (
     find_duplicate_headings,
+    find_indented_fence_markers,
     parse_headings,
     regenerate_toc,
     render_toc,
@@ -269,6 +270,76 @@ class DuplicateHeadingsTest(unittest.TestCase):
         path = self._tmp("## Same\n### Same\n")
         self.assertEqual(find_duplicate_headings(path, 3), [])
         self.assertEqual(find_duplicate_headings(path, 2), [])
+
+
+class IndentedFenceMarkerTest(unittest.TestCase):
+    def _tmp(self, text: str) -> Path:
+        fd, path = tempfile.mkstemp(suffix=".md")
+        os.close(fd)
+        Path(path).write_text(text)
+        return Path(path)
+
+    def test_rejects_indented_prettier_ignore_start(self):
+        text = (
+            "intro\n"
+            "\n"
+            "    <!-- prettier-ignore-start -->\n"
+            "<!-- vim-markdown-toc-start -->\n"
+            "- [A](#a)\n"
+            "<!-- vim-markdown-toc-end -->\n"
+            "<!-- prettier-ignore-end -->\n"
+            "\n"
+            "## A\n"
+        )
+        path = self._tmp(text)
+        found = find_indented_fence_markers(path)
+        self.assertEqual(found, [(3, "prettier-ignore-start")])
+
+    def test_rejects_indented_prettier_ignore_end(self):
+        text = (
+            "intro\n"
+            "\n"
+            "<!-- prettier-ignore-start -->\n"
+            "<!-- vim-markdown-toc-start -->\n"
+            "- [A](#a)\n"
+            "<!-- vim-markdown-toc-end -->\n"
+            "\n"
+            "    <!-- prettier-ignore-end -->\n"
+            "\n"
+            "## A\n"
+        )
+        path = self._tmp(text)
+        found = find_indented_fence_markers(path)
+        self.assertEqual(found, [(8, "prettier-ignore-end")])
+
+    def test_accepts_flush_prettier_ignore_markers(self):
+        text = (
+            "intro\n"
+            "\n"
+            "<!-- prettier-ignore-start -->\n"
+            "<!-- vim-markdown-toc-start -->\n"
+            "- [A](#a)\n"
+            "<!-- vim-markdown-toc-end -->\n"
+            "<!-- prettier-ignore-end -->\n"
+            "\n"
+            "## A\n"
+        )
+        path = self._tmp(text)
+        self.assertEqual(find_indented_fence_markers(path), [])
+
+    def test_flags_both_markers_when_both_indented(self):
+        text = (
+            "    <!-- prettier-ignore-start -->\n"
+            "<!-- vim-markdown-toc-start -->\n"
+            "<!-- vim-markdown-toc-end -->\n"
+            "\t<!-- prettier-ignore-end -->\n"
+        )
+        path = self._tmp(text)
+        found = find_indented_fence_markers(path)
+        self.assertEqual(
+            found,
+            [(1, "prettier-ignore-start"), (4, "prettier-ignore-end")],
+        )
 
 
 if __name__ == "__main__":

--- a/.claude/skills/toc/toc.py
+++ b/.claude/skills/toc/toc.py
@@ -190,6 +190,27 @@ def find_duplicate_headings(file_path: Path, level: int) -> list[tuple[str, int]
     return sorted((k, v) for k, v in counts.items() if v > 1)
 
 
+FENCE_INDENT_RE = re.compile(
+    r"^[ \t]+<!-- prettier-ignore-(start|end) -->", re.MULTILINE
+)
+
+
+def find_indented_fence_markers(file_path: Path) -> list[tuple[int, str]]:
+    """Return [(line_number, marker_name), ...] for indented prettier-ignore markers.
+
+    A `<!-- prettier-ignore-start -->` or `-end -->` with 4+ leading spaces
+    after a blank line becomes a kramdown indented code block and renders
+    as literal HTML text in Jekyll output. Observed in _d/changelog.md
+    where a stray indent on the closing marker rendered the raw comment
+    above the first `## Week of ...` heading.
+    """
+    text = file_path.read_text(encoding="utf-8")
+    return [
+        (text[: m.start()].count("\n") + 1, f"prettier-ignore-{m.group(1)}")
+        for m in FENCE_INDENT_RE.finditer(text)
+    ]
+
+
 @app.command(help="Rewrite the TOC block in a markdown file")
 def regenerate(
     file: Annotated[Path, typer.Argument(help="Markdown file to update")],
@@ -213,24 +234,37 @@ def regenerate(
     stdout.print(f"TOC in [cyan]{file}[/] already in sync")
 
 
-@app.command(
-    help="Fail if any heading text at the given level repeats (broken anchors)"
-)
+@app.command(help="Fail on duplicate H3s or indented prettier-ignore fence markers")
 def validate(
     file: Annotated[Path, typer.Argument(help="Markdown file to check")],
     level: Annotated[int, typer.Option("--level", help="Heading level to check")] = 3,
 ) -> None:
-    """Exit 0 if clean, 1 if duplicates found."""
+    """Run all checks. Prints pass/fail per check, exits 1 if any fail."""
     duplicates = find_duplicate_headings(file, level)
-    if not duplicates:
+    fences = find_indented_fence_markers(file)
+
+    if duplicates:
+        stderr.print(f"[red]FAIL[/] — duplicate H{level} headings in [cyan]{file}[/]:")
+        for text, count in duplicates:
+            stderr.print(f"  [yellow]{count}×[/] '{text}'")
+    else:
         stdout.print(
             f"[green]OK[/] — no duplicate H{level} headings in [cyan]{file}[/]"
         )
-        return
-    stderr.print(f"[red]FAIL[/] — duplicate H{level} headings in [cyan]{file}[/]:")
-    for text, count in duplicates:
-        stderr.print(f"  [yellow]{count}×[/] '{text}'")
-    raise typer.Exit(code=1)
+
+    if fences:
+        stderr.print(
+            f"[red]FAIL[/] — indented prettier-ignore fence markers in [cyan]{file}[/]:"
+        )
+        for line_num, marker in fences:
+            stderr.print(f"  line [yellow]{line_num}[/]: {marker}")
+    else:
+        stdout.print(
+            f"[green]OK[/] — no indented prettier-ignore fence markers in [cyan]{file}[/]"
+        )
+
+    if duplicates or fences:
+        raise typer.Exit(code=1)
 
 
 @app.command(help="Print the GFM/mtoc slug for a heading (single-shot, no dedup)")


### PR DESCRIPTION
## Summary

Extends `.claude/skills/toc/toc.py`'s `validate` subcommand to flag any `<!-- prettier-ignore-start -->` or `<!-- prettier-ignore-end -->` marker with leading whitespace (4+ spaces or a tab). That indentation, after a blank line, turns the marker into a kramdown indented code block — the marker renders as literal HTML in production.

## Motivation

Bit `_d/changelog.md` this week: a stray 4-space indent on the closing fence rendered the literal `<!-- prettier-ignore-end -->` string above "Week of 2026-04-13" on the live `/changelog` page. PR #532 hand-fixed that file; this PR adds the linter so the class of bug is now caught by the same tool that rewrites TOCs.

## Dogfood

Running the enhanced validator on `main`'s `_d/changelog.md` correctly flags the pre-#532 indent:

```
$ .claude/skills/toc/toc.py validate _d/changelog.md
OK — no duplicate H3 headings in _d/changelog.md
FAIL — indented prettier-ignore fence markers in _d/changelog.md:
  line 69: prettier-ignore-end
exit=1
```

Once #532 lands, the output flips to clean on both checks.

## Behavior

- Both checks always run; both pass messages printed on clean runs; all failures reported before `Exit(1)`.
- Matches `^[ \t]+<!-- prettier-ignore-(start|end) -->` (leading spaces or tab, any amount — 1 space also triggers, since prettier's auto-formatter never emits that either).

## Test plan

- [x] `python3 -m unittest test_toc` → 35/35 pass (4 new tests + 31 existing)
- [x] Smoke: `validate` on clean file → exit 0, both OK messages
- [x] Smoke: `validate` on crafted broken file → exit 1, correct line numbers + markers
- [x] Smoke: `validate` on real `_d/changelog.md` — flags line 69 (PR #532 target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)