### PR TITLE
fix(backlinks): atomic write to avoid concurrency corruption

### DIFF
--- a/build_back_links.py
+++ b/build_back_links.py
@@ -23,6 +23,7 @@ from typing import NewType, List, Dict
 from typing_extensions import Annotated
 import os
 import json
+import tempfile
 from dataclasses import dataclass
 import copy
 import typer
@@ -550,16 +551,19 @@ class LinkBuilder:
                 }
             return obj
 
-        # Write directly to the file instead of printing to stdout
-        with open(output_file, "w", encoding="utf-8") as f:
-            json.dump(
-                out,
-                f,
-                default=page_encoder,
-                ensure_ascii=False,
-                indent=4,
-                sort_keys=True,
-            )
+        # Atomic write: truncation+write of the target file isn't safe when
+        # multiple pre-commit hook workers run in parallel on different
+        # markdown files — one writer can truncate mid-write of another,
+        # producing a corrupted suffix. Write to a tempfile in the same
+        # directory, then os.replace() into place (atomic on POSIX).
+        _atomic_write_json(
+            out,
+            output_file,
+            default=page_encoder,
+            ensure_ascii=False,
+            indent=4,
+            sort_keys=True,
+        )
 
         # Print a message to stdout for logging
         console.print(f"[green]Successfully wrote backlinks data to {output_file}[/]")
@@ -1392,10 +1396,42 @@ def rebuild_incoming_links(data):
 
 
 def write_updated_data(data, output_file):
-    """Write updated data to the output file."""
-    with open(output_file, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=4, sort_keys=True)
-        console.print(f"[green]Successfully wrote {output_file}[/]")
+    """Write updated data to the output file, atomically."""
+    _atomic_write_json(data, output_file, ensure_ascii=False, indent=4, sort_keys=True)
+    console.print(f"[green]Successfully wrote {output_file}[/]")
+
+
+def _atomic_write_json(data, output_file, **dumps_kwargs):
+    """Atomically write JSON to `output_file`.
+
+    Writes to a uniquely-named tempfile in the same directory, fsyncs,
+    then os.replace()s onto the target path. On POSIX, os.replace is
+    atomic at the inode level, so concurrent pre-commit hook workers
+    (one per changed markdown file) can't truncate each other's in-flight
+    writes — the worst case is that one worker's view wins and the
+    other's update is lost, rather than a corrupt JSON document on disk.
+
+    The tempfile is created in the same directory as the target so the
+    rename is same-filesystem (guaranteed atomic); TMPDIR could be on a
+    different fs and break the guarantee.
+    """
+    output_dir = os.path.dirname(os.path.abspath(output_file)) or "."
+    base = os.path.basename(output_file)
+    fd, tmp_path = tempfile.mkstemp(prefix=f".{base}.", suffix=".tmp", dir=output_dir)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, **dumps_kwargs)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, output_file)
+    except Exception:
+        # If anything went wrong, remove the tempfile so we don't leave
+        # stale `.back-links.json.*.tmp` droppings in the repo root.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def print_delta_summary(


### PR DESCRIPTION
## Summary

`build_back_links.py` had two call sites (`print_json`, `write_updated_data`) that wrote `back-links.json` via plain `open("w")`. Under `prek run --files A.md B.md …` (or any scenario with multiple parallel hook workers), two writers could truncate mid-write or race on the final close, leaving a corrupt JSON document on disk — valid body followed by a duplicate suffix fragment like `…"/y26"}}}e": "Igor's plan for 2026"…`. Every subsequent hook run (and `check-internal-links`) then failed with `JSONDecodeError: Extra data`.

## Fix

New helper `_atomic_write_json()` that uses `tempfile.mkstemp` in the same directory → `json.dump` → `flush` + `fsync` → `os.replace` onto the target. Both call sites now route through it. Tempfile is unlinked on exception so no stray `.back-links.json.*.tmp` droppings accumulate in the repo root.

`os.replace` is atomic at the inode level on POSIX when source and target are on the same filesystem, which is why the tempfile goes next to the target rather than in `$TMPDIR` — `$TMPDIR` could be on a different fs and break the guarantee.

## Verification

```bash
# 4x parallel delta against different markdown files
(uv run build_back_links.py delta _d/ai-testing.md > /tmp/d1.log 2>&1) &
(uv run build_back_links.py delta _d/ai-coder.md > /tmp/d2.log 2>&1) &
(uv run build_back_links.py delta _d/ai-developer.md > /tmp/d3.log 2>&1) &
(uv run build_back_links.py delta _d/ai-operator.md > /tmp/d4.log 2>&1) &
wait
python3 -c "import json; json.load(open('back-links.json'))"
# -> JSON VALID, no stale .tmp files in repo root
```

Before this change the same invocation would intermittently leave the JSON corrupted. After, it stays valid across repeated runs.

Trade-off: concurrent writers still "win or lose" semantically (the later writer's content survives — one worker's delta update can be dropped if two land simultaneously). That's acceptable because the hook runs with `pass_filenames: true` and the dropped update is recoverable by re-running the hook. The important invariant — the file on disk is always a parseable JSON document — is preserved.

## Test plan

- [ ] Trigger the hook via `prek run --files` with several markdown files; confirm `back-links.json` remains valid JSON
- [ ] Full rebuild via `uv run build_back_links.py build` writes a valid file
- [ ] No `.back-links.json.*.tmp` files left in the repo root after any run

🤖 Generated with [Claude Code](https://claude.com/claude-code)