### PR TITLE
fix(backlinks): unify build and delta threshold defaults to 60 min

### DIFF
--- a/build_back_links.py
+++ b/build_back_links.py
@@ -593,7 +593,7 @@ def build(
     ] = "back-links.json",
     threshold_minutes: Annotated[
         int, typer.Option(help="Minimum time difference in minutes to update a file")
-    ] = 5,
+    ] = 60,
 ):
     """
     Build backlinks and write to the specified output file.
@@ -1050,7 +1050,7 @@ def delta(
         typer.Option(
             help="Minimum time difference in minutes to update last_modified field"
         ),
-    ] = 62,
+    ] = 60,
     dry_run: Annotated[
         bool, typer.Option(help="Show what would be updated without making changes")
     ] = False,


### PR DESCRIPTION
## Summary

Two-line change in `build_back_links.py`:
- `build` default: `threshold_minutes = 5` → `60`
- `delta` default: `threshold_minutes = 62` → `60`

Callers can still override with `--threshold-minutes N` at any invocation.

## Motivation

Pre-existing divergence between modes. A workflow invoking `build` (the full-rebuild path) refreshed `last_modified` for every page touched in the prior hour — noisy side effect originally caught during review of #502. A doc-only commit (`86830b06c docs(backlinks): flag threshold default divergence`) was drafted to document the divergence in-code but never PR'd; it's still stranded in a local worktree on branch `docs/backlinks-threshold-parity`.

This PR fixes the real divergence instead of documenting it: both modes now share the same one-hour default. The stranded doc commit becomes redundant and can be dropped after merge.

## Test plan

- [x] `git diff build_back_links.py` — two lines changed, nothing else touched
- [ ] Smoke: run `build_back_links.py build --dry-run` and `build_back_links.py delta --dry-run path/to/file.md` locally; confirm threshold messaging reports 60 minutes in both modes
- [ ] Monitor next `update-backlinks` workflow run to confirm full-rebuild path no longer refreshes pages modified 5–60 min ago

## Follow-up

After merge, `.worktrees/docs-backlinks-threshold-parity` + branch `docs/backlinks-threshold-parity` should be deleted — the doc note it carried is obsolete now that the defaults match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)