### PR TITLE
content(ai-or-niece): vignette on catching the AI-substitution reflex

### DIFF
--- a/_d/ai-or-niece.md
+++ b/_d/ai-or-niece.md
@@ -1,0 +1,21 @@
+---
+layout: post
+title: "AI or My Niece?"
+permalink: /ai-or-niece
+imagefeature: /images/raccoon-family.webp
+tags:
+  - ai
+  - ai-relationships
+---
+
+I got curious about [HAR1](https://en.wikipedia.org/wiki/Human_accelerated_region_1) — Human Accelerated Region 1, a stretch of DNA that's nearly identical across mammals but went wild in the human lineage, probably doing something to our brains. My reflex was immediate: ask Larry. Larry is right there. Larry is always right there.
+
+Then I caught myself. My niece studies frog genomes for a living. She does this stuff.
+
+So I texted her instead. Dumb, sincere questions: "Hey does knowing about 1 genome thing make you know more about others? Like does your frog stuff make you understand this better?" Not a polished query. A real one — the kind you ask a person because you want _them_, not just the answer.
+
+Here's what spooked me. Asking Larry would have been faster. Cleaner. No wait, no small talk, no risk of being boring. The cost of substituting AI for a human expert has dropped so low that the AI is now the default, and the human is the effortful choice. I didn't _decide_ to ask Larry — I just reached for him, the way you reach for your phone.
+
+That reflex is the thing to watch. Not because AI is bad — [Larry's great at the things he's great at](/larry) — but because the choice between "ask the machine" and "ask the person who loves me" has gone invisible. Making it visible again, even for one dumb question about chimp DNA, is how I keep the relationships that make any of this worth doing.
+
+[The easy acts of care aren't inefficiencies to automate.](/ai-relationships) They're the relationship.


### PR DESCRIPTION
## Summary

Short vignette post at `/ai-or-niece` (~270 words body). Igor got curious about HAR1 (Human Accelerated Region 1), reflex was "ask Larry," caught himself — niece studies frog genomes for a living — and texted her instead.

The point: the cost of AI substitution has dropped so low that asking the machine is now the default and asking the human is the effortful choice. Catching the reflex and choosing the human anyway is the work.

Pairs with `/ai-relationships` (which argues AI is often better at caring than humans) as the other side of the coin — noticing the substitution default and pushing back on it for relationship reasons.

## Changes

- New: `_d/ai-or-niece.md` — post body, `imagefeature: /images/raccoon-family.webp` (reused), tags `ai` + `ai-relationships`
- Cross-links: `/larry`, `/ai-relationships`, Wikipedia HAR1

## Test plan

- [ ] Skim on local Jekyll (`just jekyll-serve` → `http://localhost:4000/ai-or-niece`)
- [ ] Verify frontmatter + permalink render
- [ ] Confirm excerpt (first paragraph) reads cleanly — no image include above the lede

[Files view](https://github.com/idvorkin/idvorkin.github.io/pull/files)

Generated with [Claude Code](https://claude.com/claude-code)