### PR TITLE
docs(CLAUDE.md): session learnings — TOC regen + HTML-commented Claude instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,16 +179,43 @@ Blog posts use a TOC block between HTML fence markers. Igor's convention comes f
 
 **Important:** Do NOT use the `vim-markdown-toc GFM` / `vim-markdown-toc` markers (from the unrelated `mzlogin/vim-markdown-toc` plugin) — Igor's setup won't update those, and there is no Jekyll-side hook that regenerates TOCs. The only working path is the `-start` / `-end` markers.
 
-**To generate or refresh the TOC**, run this from the repo root (works headlessly, doesn't disturb Igor's live nvim session as long as you clean the swap file first):
+**Any `_d/*.md` edit → regen the TOC via `.claude/skills/toc/toc.py` BEFORE commit.** Default levels are 2..3; use `--max 4` for journal-style posts with `#### Entry Title` subsections (ai-journal, life-journal). Never leave `:Mtoc update` as a task for the human — the skill is headless and byte-identical to the nvim plugin.
+
+```bash
+# Default (levels 2..3) — most posts
+.claude/skills/toc/toc.py regenerate _d/FILENAME.md
+
+# Journal-style posts with #### entry subsections
+.claude/skills/toc/toc.py regenerate _d/life-journal.md --max 4
+```
+
+**Fallback (nvim headless)** — only if `toc.py` is unavailable; works but requires clearing the swap file first so it doesn't fight Igor's live nvim session:
 
 ```bash
 rm -f ~/.local/state/nvim/swap/%home%developer%gits%blog4%_d%FILENAME.md.swp
 nvim --headless -n _d/FILENAME.md -c 'Mtoc update' -c 'w' -c 'qa'
 ```
 
-The `:Mtoc update` subcommand (from `idvorkin/markdown-toc.nvim`) finds the fenced block, deletes whatever is between the markers, and regenerates the full TOC from the current headings. Anchors use kramdown-compatible slugs (lowercase, punctuation stripped, spaces → hyphens, em-dashes preserved as double hyphens).
+Both paths emit identical output — kramdown-compatible slugs (lowercase, punctuation stripped, spaces → hyphens, em-dashes preserved as double hyphens). Other `:Mtoc` subcommands if needed: `:Mtoc insert` (create a new fenced block at cursor), `:Mtoc remove` (strip the TOC entirely).
 
-Other subcommands if needed: `:Mtoc insert` (create a new fenced block at cursor), `:Mtoc remove` (strip the TOC entirely).
+## Claude-Facing Instructions in Blog Posts
+
+**Instructions for Claude inside a blog post go in HTML comments, not visible H2 sections.** Pattern: `<!-- INSTRUCTIONS FOR CLAUDE — ... -->` placed between the frontmatter and the first visible section. Jekyll renders nothing; agents parsing the markdown source still find them. **Never leave an `## Instructions for Claude` visible heading in a published post** — it ships to the public page.
+
+```markdown
+---
+layout: post
+title: My Post
+---
+
+<!--
+INSTRUCTIONS FOR CLAUDE — do not render
+- Rule 1 about how to edit this file
+- Rule 2 about cross-linking
+-->
+
+First visible paragraph that becomes the excerpt...
+```
 
 ## AI Journal Entries
 


### PR DESCRIPTION
## Summary

Two blog-local rules codified into \`CLAUDE.md\` so the drift doesn't repeat:

- **Any \`_d/*.md\` edit → regen the TOC via \`.claude/skills/toc/toc.py\` BEFORE commit.** Default levels 2..3; \`--max 4\` for journal-style posts with \`#### Entry Title\` subsections (ai-journal, life-journal). Never leave \`:Mtoc update\` as a task for the human. Merged into the existing "Generating Tables of Contents" section and promoted \`toc.py\` to the primary path; headless nvim \`:Mtoc update\` stays documented as the fallback.
- **Claude-facing instructions inside blog posts belong in HTML comments**, not visible H2 sections. Pattern: \`<!-- INSTRUCTIONS FOR CLAUDE — ... -->\` between frontmatter and the first visible section. Jekyll renders nothing; agents parsing the markdown source still find them.

## Why

Both lessons come from real session drift this week:

- \`fa9b4e916 docs(life-journal): regen TOC via toc.py\` — a post-hoc fix for a commit that had shipped with a stale TOC.
- \`214ae2c00 blog(life-journal): hero image + hide Claude instructions + TOC max=4\` + PR #540 — \`_d/life-journal.md\` shipped with a visible \`## Instructions for Claude\` H2 that rendered on the public page.

The \`toc\` skill already exists at \`.claude/skills/toc/toc.py\` — CLAUDE.md now points at what's already in the repo.

## Test plan

- [ ] Visual diff review — CLAUDE.md-only change, no \`_d/*.md\` touched
- [ ] Pre-commit hooks ran clean on commit (prettier, typos, backlinks, lychee, anchor-checker)
- [ ] Next time an agent edits a \`_d/*.md\` post, it regens the TOC via \`toc.py\` before committing

Generated with [Claude Code](https://claude.com/claude-code)