### PR TITLE
content(ai-operator): add learnings-live, prompt-leak, skill-kit sections

### DIFF
--- a/_d/ai-cockpit.md
+++ b/_d/ai-cockpit.md
@@ -84,7 +84,7 @@ So I built a [hand-written Rust picker](https://github.com/idvorkin/settings/tre
 
 {% include image_float_right.html src="https://raw.githubusercontent.com/idvorkin/ipaste/main/20260417_111056.webp" %}
 
-Pick an item and the URL lands on the Mac's clipboard. An Alfred hotkey — wired through yabai to bring the browser window forward — reads the clipboard and opens the page. One pick in the picker, one hotkey on the Mac, and I'm on the URL. (Eventually this moves onto the [Agent Dashboard](#agent-dashboard---the-radar-screen) as a clickable row; then even the hotkey goes away.)
+Pick an item and the URL lands on the Mac's clipboard. An Alfred hotkey — wired through [`y.py`](https://github.com/idvorkin/settings/blob/main/py/y.py), my yabai helper, to bring the browser window forward — reads the clipboard and opens the page. One pick in the picker, one hotkey on the Mac, and I'm on the URL. (Eventually this moves onto the [Agent Dashboard](#agent-dashboard---the-radar-screen) as a clickable row; then even the hotkey goes away.)
 
 Full story: [Rust tmux_helper - 10x speedup from Python](/ai-journal#rust-tmux_helper-10x-speedup-from-python)
 

--- a/_d/ai-cockpit.md
+++ b/_d/ai-cockpit.md
@@ -28,6 +28,7 @@ Agents are slow. Not slow like "wait a second," slow like "go make coffee and co
   - [Tmux on Super Steroids - The Multiplexer](#tmux-on-super-steroids---the-multiplexer)
   - [Alfred - The Session Switcher](#alfred---the-session-switcher)
   - [Agent Dashboard - The Radar Screen](#agent-dashboard---the-radar-screen)
+  - [GitHub Views - The Triage Queue](#github-views---the-triage-queue)
   - [Stream Deck - The Physical Buttons](#stream-deck---the-physical-buttons)
   - [Tailscale - The Network](#tailscale---the-network)
 - [How the Pieces Fit Together](#how-the-pieces-fit-together)
@@ -115,6 +116,15 @@ The [Agent Dashboard](https://github.com/idvorkin-ai-tools/agent-dashboard) is t
 I didn't build this. I gave the requirements and Claude built it itself. The irony of AI building its own monitoring tool isn't lost on me.
 
 **Why it matters for the cockpit:** Without this, you're blind. You don't know which agent finished, which one is stuck, which PR needs review. With it, one glance tells you where to focus attention.
+
+### GitHub Views - The Triage Queue
+
+The Agent Dashboard knows what my agents are _doing_ right now. GitHub knows what they've already _filed_. Different instruments, same cockpit. I keep two saved searches pinned in the browser — everything `idvorkin-ai-tools` touched in the last four weeks, sorted by recent activity:
+
+- [Open PRs involving idvorkin-ai-tools](https://github.com/pulls/2294839?q=+%28involves%3Aidvorkin-ai-tools%29+++++state%3Aopen+archived%3Afalse+sort%3Aupdated-desc+created%3A%3E%40today-4w+)
+- [Open issues & PRs involving idvorkin-ai-tools](https://github.com/issues/SSC_kgDOACMG4Q?q=%28involves%3Aidvorkin-ai-tools%29%20state%3Aopen%20archived%3Afalse%20sort%3Aupdated-desc%20created%3A%3E%40today-4w%20is%3Aissue%20is%3Apr)
+
+One tab, one glance, full triage queue. Before I had these, agent PRs on stale branches just vanished from my attention; now the staleness is the sort key.
 
 ### Stream Deck - The Physical Buttons
 

--- a/_d/ai-cockpit.md
+++ b/_d/ai-cockpit.md
@@ -84,7 +84,7 @@ So I built a [hand-written Rust picker](https://github.com/idvorkin/settings/tre
 
 {% include image_float_right.html src="https://raw.githubusercontent.com/idvorkin/ipaste/main/20260417_111056.webp" %}
 
-Pick an item and it lands on your clipboard. _You_ paste it into the browser — tmux on the dev VM can't launch a browser directly (yet), so the human is still completing the last step. It's ~2 seconds and your eyes are already on the URL bar, so it's cheap — but it's not invisible. (Eventually this moves onto the [Agent Dashboard](#agent-dashboard---the-radar-screen) as a clickable row; the scrollback scan and the human paste both go away.)
+Pick an item and the URL lands on the Mac's clipboard. An Alfred hotkey — wired through yabai to bring the browser window forward — reads the clipboard and opens the page. One pick in the picker, one hotkey on the Mac, and I'm on the URL. (Eventually this moves onto the [Agent Dashboard](#agent-dashboard---the-radar-screen) as a clickable row; then even the hotkey goes away.)
 
 Full story: [Rust tmux_helper - 10x speedup from Python](/ai-journal#rust-tmux_helper-10x-speedup-from-python)
 

--- a/_d/ai-cockpit.md
+++ b/_d/ai-cockpit.md
@@ -29,6 +29,7 @@ Agents are slow. Not slow like "wait a second," slow like "go make coffee and co
   - [Alfred - The Session Switcher](#alfred---the-session-switcher)
   - [Agent Dashboard - The Radar Screen](#agent-dashboard---the-radar-screen)
   - [Stream Deck - The Physical Buttons](#stream-deck---the-physical-buttons)
+  - [Tailscale - The Network](#tailscale---the-network)
 - [How the Pieces Fit Together](#how-the-pieces-fit-together)
 - [What I'm Still Building](#what-im-still-building)
 - [The Meta-Question](#the-meta-question)
@@ -79,6 +80,8 @@ So I built a [hand-written Rust picker](https://github.com/idvorkin/settings/tre
 
 **Why it matters for the cockpit:** This is the "stick" that steers. One keystroke opens the picker. Another keystroke lands you in the right agent session. No thinking, no typing paths, no remembering which container is which.
 
+**Scrollback as clipboard.** The same helper has a `pick-links` mode that scans the current pane's scrollback and pulls out every GitHub URL, running server address, and IP. Agent just opened a PR? Hit the hotkey, pick it, you're in the browser. Agent just launched a Jekyll preview? Pick the URL, one tap, the page opens. No mouse-dragging across terminal text, no squinting at a wrapped URL to find the end. Links become first-class objects in the cockpit.
+
 Full story: [Rust tmux_helper - 10x speedup from Python](/ai-journal#rust-tmux_helper-10x-speedup-from-python)
 
 ### Alfred - The Session Switcher
@@ -122,6 +125,14 @@ The [Stream Deck plugin](https://github.com/idvorkin/streamdeck-igor-vibe) gives
 Physical buttons matter because they don't require visual attention. I can hit "next agent" by feel while reading code on screen. It's the same reason cars have physical knobs for volume instead of touchscreen sliders - you don't want to look away from the road.
 
 Built the plugin in 30 minutes with AI. See the [journal entry](/ai-journal#stream-deck-plugin-in-30-minutes).
+
+### Tailscale - The Network
+
+Every agent runs on a Linux dev VM in my closet. Tailscale puts that VM on a private network that follows me across devices — same hostname, same URLs, from the couch or the treadmill or a coffee shop.
+
+What this buys in the cockpit: every server an agent launches is reachable from wherever I am. Agent runs `jekyll serve` on the dev VM, the preview is at `http://c-5001:4000` from my phone browser. The [link picker](#tmux-on-super-steroids---the-multiplexer) catches server URLs out of the agent's stdout; one tap and the rendered page is on whatever device I have out. No port-forwarding. No ngrok tunnel. No SSH gymnastics.
+
+Without Tailscale, every agent-launched server is a negotiation. With it, servers are just URLs.
 
 ## How the Pieces Fit Together
 

--- a/_d/ai-cockpit.md
+++ b/_d/ai-cockpit.md
@@ -80,7 +80,11 @@ So I built a [hand-written Rust picker](https://github.com/idvorkin/settings/tre
 
 **Why it matters for the cockpit:** This is the "stick" that steers. One keystroke opens the picker. Another keystroke lands you in the right agent session. No thinking, no typing paths, no remembering which container is which.
 
-**Scrollback as clipboard.** The same helper has a `pick-links` mode that scans the current pane's scrollback and pulls out every GitHub URL, running server address, and IP. Agent just opened a PR? Hit the hotkey, pick it, you're in the browser. Agent just launched a Jekyll preview? Pick the URL, one tap, the page opens. No mouse-dragging across terminal text, no squinting at a wrapped URL to find the end. Links become first-class objects in the cockpit.
+**`pick-links` — pulling URLs out of scrollback.** `rmux_helper pick-links` scans the current pane's scrollback and surfaces every PR URL, running server address, and IP as a TUI picker.
+
+{% include image_float_right.html src="https://raw.githubusercontent.com/idvorkin/ipaste/main/20260417_111056.webp" %}
+
+Pick an item and it lands on your clipboard. _You_ paste it into the browser — tmux on the dev VM can't launch a browser directly (yet), so the human is still completing the last step. It's ~2 seconds and your eyes are already on the URL bar, so it's cheap — but it's not invisible. (Eventually this moves onto the [Agent Dashboard](#agent-dashboard---the-radar-screen) as a clickable row; the scrollback scan and the human paste both go away.)
 
 Full story: [Rust tmux_helper - 10x speedup from Python](/ai-journal#rust-tmux_helper-10x-speedup-from-python)
 

--- a/_d/ai-operator.md
+++ b/_d/ai-operator.md
@@ -109,7 +109,13 @@ _Skills: [`hill-climbing`](/hill-climbing)_
 
 Perfect is the baseline's enemy. You can't hill-climb from nothing — you need a bad version, scored, before there's a hill to walk up. Every minute you spend polishing before that baseline exists is a minute not climbing.
 
-This is [Eat That Frog](/frog) in a new uniform. The hard task never gets easier by delay; procrastination just shrinks the working window. Now it's worse — agents run while you stall, so the perfectionist isn't just delaying their own work, they're idling the agent. Eat the frog. Ship ugly. Let the raccoon climb.
+The trap: perfectionism _feels_ like work, but it functions like procrastination. The output is the same — hours disappear, no frog gets eaten, the deadline stays where it was. [Eat That Frog](/frog) is the playbook, same strategies:
+
+- **Slice and dice.** Ship v1 ugly. Then v2. Then v3. The agent only climbs between concrete versions — a ship every iteration beats one perfect release.
+- **One oil barrel at a time.** "Done" isn't the finish line. "Done" is the next baseline the agent can score. Aim for the next milestone, not the summit.
+- **Single-handle the task.** Don't fork your attention between drafting and polishing. Draft. Ship. Polish gets its own pass after the baseline exists.
+
+Agents make procrastination worse, not better. They run while you stall — so the perfectionist isn't just delaying their own work, they're idling the agent. Eat the frog. Ship ugly. Let the raccoon climb.
 
 ## You're a Compound Engineer
 

--- a/_d/ai-operator.md
+++ b/_d/ai-operator.md
@@ -23,6 +23,7 @@ The operators who get better aren't the ones who just practice. They're the ones
 - [You Need to Get On the Loop](#you-need-to-get-on-the-loop)
 - [You Need to Use Voice](#you-need-to-use-voice)
 - [You Can Throw It Away](#you-can-throw-it-away)
+- [You Ship Good Enough, Then Hill-Climb](#you-ship-good-enough-then-hill-climb)
 - [You're a Compound Engineer](#youre-a-compound-engineer)
 - [Where Learnings Live](#where-learnings-live)
 - [Writing Prompts That Don't Leak Thinking](#writing-prompts-that-dont-leak-thinking)
@@ -101,6 +102,14 @@ In AI land, the economics flipped. The code is cheap; the thinking is expensive.
 Worse, rescuing a bad generation is a trap: it pulls you line-by-line back into the loop, burning thinking tokens you can't afford on code the AI could regenerate for free.
 
 Watch for the sunk cost reflex. When you catch yourself trying to rescue a bad generation instead of re-running it, that's the old economics talking. Throw it away. It's free.
+
+## You Ship Good Enough, Then Hill-Climb
+
+_Skills: [`hill-climbing`](/hill-climbing)_
+
+Perfect is the baseline's enemy. You can't hill-climb from nothing — you need a bad version, scored, before there's a hill to walk up. Every minute you spend polishing before that baseline exists is a minute not climbing.
+
+This is [Eat That Frog](/frog) in a new uniform. The hard task never gets easier by delay; procrastination just shrinks the working window. Now it's worse — agents run while you stall, so the perfectionist isn't just delaying their own work, they're idling the agent. Eat the frog. Ship ugly. Let the raccoon climb.
 
 ## You're a Compound Engineer
 

--- a/_d/ai-operator.md
+++ b/_d/ai-operator.md
@@ -24,6 +24,9 @@ The operators who get better aren't the ones who just practice. They're the ones
 - [You Need to Use Voice](#you-need-to-use-voice)
 - [You Can Throw It Away](#you-can-throw-it-away)
 - [You're a Compound Engineer](#youre-a-compound-engineer)
+- [Where Learnings Live](#where-learnings-live)
+- [Writing Prompts That Don't Leak Thinking](#writing-prompts-that-dont-leak-thinking)
+- [The Skills I Use](#the-skills-i-use)
 - [A Note on Companion AIs](#a-note-on-companion-ais)
 
 <!-- vim-markdown-toc-end -->
@@ -31,7 +34,7 @@ The operators who get better aren't the ones who just practice. They're the ones
 
 {% include blob_image_float_right.html src="blog/raccoon-operator.webp" %}
 
-{% include ai-slop.html percent="80" %}
+{% include ai-slop.html percent="85" %}
 
 ## You Have a Finite Number of Thinking Tokens
 
@@ -116,6 +119,91 @@ This is compound engineering. You're not just shipping the task in front of you;
 The operator skill: treat every in-the-loop moment as a signal, not a setback. The place you got stuck today is the place you're about to automate away tomorrow — and _that_ is how you climb out of the loop for good.
 
 The same compounding logic applies to algorithms, not just operator skills. [Eval-driven hill climbing](/hill-climbing) lets an agent climb on top of its own previous best run after run; the winning recipe then becomes infrastructure, and the eval becomes a regression guard on every future output. You do the compounding; the agent does the climbing.
+
+## Where Learnings Live
+
+_Skills: [`learn-from-session`](https://github.com/idvorkin/chop-conventions/blob/main/skills/learn-from-session/SKILL.md)_
+
+Every learning belongs in one of three places. Getting the routing right is half the value — a rule filed as memory never fires, a skill filed as a rule is a wall of text the model skims past.
+
+- **Memory** (`~/.claude/projects/<repo>/memory/`) — facts about you, feedback you've already given, project state, pointers to external systems. Things that should color the next conversation but don't need to fire as a rule. "Igor prefers single quotes in this include." "The bd database lives here." Reference material, not instructions.
+- **CLAUDE.md** — rules that fire on every session. `global.md` for things true on every machine ("don't use `claude-agent-sdk` for batch extraction — 17× the cost"). Project `CLAUDE.md` for repo-specific rules ("always use permalinks, not redirect URLs"). One-liners. If it has steps, it's not a rule — it's a skill.
+- **Skills** (`~/.claude/skills/` for personal, `chop-conventions/skills/` for shared) — executable recipes with steps, scripts, flags. The thing that would take three bash commands and two judgment calls. The [`toc`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/toc/SKILL.md) skill regenerates a TOC matching my nvim plugin's slug rules. A rule can't do that. A recipe can.
+
+Don't trust yourself to remember. The [`learn-from-session`](https://github.com/idvorkin/chop-conventions/blob/main/skills/learn-from-session/SKILL.md) skill reads the transcript at the end of a session, classifies what's worth keeping, and asks permission before writing.
+
+## Writing Prompts That Don't Leak Thinking
+
+_Skills: [`delegate-to-other-repo`](https://github.com/idvorkin/chop-conventions/blob/main/skills/delegate-to-other-repo/SKILL.md) · [`bulk`](https://github.com/idvorkin/chop-conventions/blob/main/skills/bulk/SKILL.md)_
+
+When you dispatch an agent, the prompt should prove _you_ understood the problem. If it doesn't, you're pushing the synthesis onto the agent and hoping its summary matches reality. Two common failure modes:
+
+- **"Based on your findings, fix the bug."** You haven't read the findings. The agent's summary describes what it _intended_ to do, not what it did.
+- **"Implement the plan."** You haven't internalized the plan. The agent is about to execute a design you can't defend.
+
+The fix is specifics. File paths, line numbers, what to change, how you'll know it worked. If you can't write those, you haven't understood the problem yet — don't dispatch.
+
+Bad:
+
+```
+Fix the caching bug we talked about.
+```
+
+Good:
+
+```
+In src/cache.ts:42, the TTL check uses `Date.now() - stored`
+instead of `stored + ttl < Date.now()`. Fix the comparison and
+add a test case for a stored timestamp within the TTL window.
+```
+
+The subagent starts with none of your context. Brief it like a smart colleague who just walked into the room.
+
+## The Skills I Use
+
+_Skills: the whole kit, grouped below_
+
+Operators like to compare models and IDEs. The real leverage is the kit of named recipes you reach for every day. Here's mine this quarter, grouped by when I use them.
+
+**Every session (bookends):**
+
+- [`/up-to-date`](https://github.com/idvorkin/chop-conventions/blob/main/skills/up-to-date/SKILL.md) — sync the repo with upstream before I start. Avoids stale-branch merge pain.
+- [`learn-from-session`](https://github.com/idvorkin/chop-conventions/blob/main/skills/learn-from-session/SKILL.md) — at the end, extract durable lessons and route them to the right CLAUDE.md or skill.
+- [`/changelog`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/changelog/SKILL.md) — weekly rollup across repos with deep links.
+
+**In-session movement:**
+
+- [`/content`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/content/SKILL.md) and [`/ai-content`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/ai-content/SKILL.md) — load blog writing guidelines and wire up the branch and server.
+- `side-edit` — open a file in a side nvim pane so I can watch the agent edit without leaving the conversation.
+- [`delegate-to-other-repo`](https://github.com/idvorkin/chop-conventions/blob/main/skills/delegate-to-other-repo/SKILL.md) — hand off work in another repo without dragging its context into this session.
+- [`bulk`](https://github.com/idvorkin/chop-conventions/blob/main/skills/bulk/SKILL.md) — fan out N similar CLI calls (gh, bd, git) as one parallel step instead of N sequential turns.
+
+**Verification:**
+
+- [`walk-the-store`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/walk-the-store/SKILL.md) — visual walkthrough of the blog to catch regressions.
+- [`show-your-work`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/show-your-work/SKILL.md) — screenshot the changed pages and host them on a gist for the PR body.
+- [`architect-review`](https://github.com/idvorkin/chop-conventions/blob/main/skills/architect-review/SKILL.md) — iterate a design spec until the review passes stabilize.
+- `verification-before-completion` — one last pass before I claim something is done. Evidence before assertions.
+
+**Generation:**
+
+- [`gen-image`](https://github.com/idvorkin/chop-conventions/blob/main/skills/gen-image/SKILL.md) — illustrations via Gemini image API.
+- [`gen-tts`](https://github.com/idvorkin/chop-conventions/blob/main/skills/gen-tts/SKILL.md) and [`gen-stt`](https://github.com/idvorkin/chop-conventions/blob/main/skills/gen-stt/SKILL.md) — speech synthesis and transcription for voice-in / voice-out loops.
+- [`image-explore`](https://github.com/idvorkin/chop-conventions/blob/main/skills/image-explore/SKILL.md) — brainstorm several visual directions in parallel and compare.
+- [`explainers`](https://github.com/idvorkin/chop-conventions/blob/main/skills/explainers/SKILL.md) — scaffold a standalone interactive explainer page for a concept.
+
+**Debugging:**
+
+- [`machine-doctor`](https://github.com/idvorkin/chop-conventions/blob/main/skills/machine-doctor/SKILL.md) — diagnose rogue processes, runaway agents, stale dev servers.
+- [`docs`](https://github.com/idvorkin/chop-conventions/blob/main/skills/docs/SKILL.md) — fetch fresh library docs via Context7 instead of guessing from stale training data.
+- `systematic-debugging` — the discipline of forming a hypothesis before I change a line.
+
+**One-shot specialists:**
+
+- [`toc`](https://github.com/idvorkin/idvorkin.github.io/blob/main/.claude/skills/toc/SKILL.md) — regenerate or validate a TOC using the same slug rules as my nvim plugin.
+- [Hill climbing](/hill-climbing) — the pattern, not a skill. Let an agent climb on top of its own previous best, with an eval as the regression guard.
+
+None of these existed a year ago. In a year, half will be gone and the rest will be better. The kit is a living thing — that's the point.
 
 ## A Note on Companion AIs
 

--- a/back-links.json
+++ b/back-links.json
@@ -1075,13 +1075,13 @@
         },
         "/ai-operator": {
             "description": "Using AI well is a skill, like driving a car or operating heavy machinery. Nobody hands you the keys to a forklift and says “figure it out.” There’s a license, training, and hard-won intuition about what the machine can and can’t do. AI is the same — except most of us skipped the training, there is no manual, and we’re writing the rules as we go.\n\n",
-            "doc_size": 29000,
+            "doc_size": 28000,
             "file_path": "_site/ai-operator.html",
             "incoming_links": [
                 "/changelog",
                 "/how-igor-chops"
             ],
-            "last_modified": "2026-04-17T02:35:05.677827+00:00",
+            "last_modified": "2026-04-17T17:34:49.736635+00:00",
             "markdown_path": "_d/ai-operator.md",
             "outgoing_links": [
                 "/ai-cockpit",

--- a/back-links.json
+++ b/back-links.json
@@ -857,7 +857,7 @@
         },
         "/ai-cockpit": {
             "description": "Agents are slow. Not slow like “wait a second,” slow like “go make coffee and come back.” So you run several in parallel. But now you’ve got a different problem: you’re an air traffic controller with no radar. You need a cockpit - a physical and software control surface that gives you visibility into what your agents are doing and lets you switch between them instantly.\n\n",
-            "doc_size": 25000,
+            "doc_size": 27000,
             "file_path": "_site/ai-cockpit.html",
             "incoming_links": [
                 "/ai-feed",
@@ -868,7 +868,7 @@
                 "/claw",
                 "/how-igor-chops"
             ],
-            "last_modified": "2026-04-11T07:40:34-07:00",
+            "last_modified": "2026-04-17T18:06:10.793477+00:00",
             "markdown_path": "_d/ai-cockpit.md",
             "outgoing_links": [
                 "/ai-journal",
@@ -1081,13 +1081,14 @@
                 "/changelog",
                 "/how-igor-chops"
             ],
-            "last_modified": "2026-04-17T17:34:49.736635+00:00",
+            "last_modified": "2026-04-17T18:06:10.793477+00:00",
             "markdown_path": "_d/ai-operator.md",
             "outgoing_links": [
                 "/ai-cockpit",
                 "/ai-relationships",
                 "/balloon",
                 "/four-healths",
+                "/frog",
                 "/hill-climbing",
                 "/larry"
             ],
@@ -3118,6 +3119,7 @@
             "doc_size": 24000,
             "file_path": "_site/frog.html",
             "incoming_links": [
+                "/ai-operator",
                 "/anxiety-management",
                 "/be-proactive",
                 "/d/resistance",


### PR DESCRIPTION
## Summary

Three new sections in `/ai-operator`, extending the umbrella "how to operate AI" post:

- **Where Learnings Live** — the three-layer routing: memory / CLAUDE.md / skills. Explains why each one exists and what shape belongs where.
- **Writing Prompts That Don't Leak Thinking** — when dispatching a subagent, specifics in the prompt prove you understood. Don't punt synthesis with "based on your findings, fix the bug."
- **The Skills I Use** — the kit I actually reach for, grouped by role (bookends, in-session movement, verification, generation, debugging, one-shot). Closes with "none of these existed a year ago."

Placed between "You're a Compound Engineer" and "A Note on Companion AIs" so the Companion AIs section stays the closer. AI-slop bumped from 80 → 85.

TOC regenerated with `:Mtoc update`. `prek` passed after a `bundle exec jekyll build --incremental` to resolve a phantom-anchor flag (project CLAUDE.md documents this — jekyll's livereload doesn't write `_site` to disk).

## Test plan

- [ ] Rendered sections look right in-browser (section order, anchor links, skill-reference italics line at top of each section)
- [ ] Links to chop-conventions skills resolve (they point at `github.com/idvorkin/chop-conventions/blob/main/skills/<name>/SKILL.md`)
- [ ] No regression to existing sections above or below the insertion point

🤖 Generated with [Claude Code](https://claude.com/claude-code)