### PR TITLE
_td/mosh: document Blink + Tailscale SSH on iOS

### DIFF
--- a/_td/mosh.md
+++ b/_td/mosh.md
@@ -159,12 +159,32 @@ I want to do remote development on linux, the best way to do this is mosh (inste
     1) Lower latency
     2) Reconnects to session.
 
-Setup on iOS
+### Blink + Tailscale SSH on iOS
 
-- Install Blink
-- Copy public key to clipboard, and mail it to yourself to install into the AMI @ ssh
+[Blink](https://blink.sh/) is a real iOS terminal — true SSH, true keyboard handling, scriptable. Pair it with [Tailscale SSH](https://tailscale.com/kb/1193/tailscale-ssh) and key management goes away entirely: `tailscaled` on the server authenticates the connection against your tailnet identity. No keys to copy, no `authorized_keys` to maintain.
 
-Setup on Server (AMI)
+Setup:
+
+1. Install the Tailscale iOS app and sign in with the same account as the server.
+2. On the server: `tailscale up --ssh`.
+3. In Blink: `ssh user@<magic-dns-name>` — no key, no password.
+
+Optional Mosh upgrade (resilient over network hops — useful when the iPhone jumps between Wi-Fi and cellular):
+
+```bash
+mosh --install-static user@host
+```
+
+Blink auto-installs `mosh-server` on the remote on first connect.
+
+**Gotcha — iOS notifications must be enabled for the Tailscale app.** If your tailnet ACL uses `check` mode, the iOS app gets a time-sensitive re-auth prompt at connection time. With notifications off, the prompt is silently dropped and the Blink SSH connection hangs with no error. Fix: enable notifications for the Tailscale iOS app, or tap "Reauthenticate" in the Tailscale app before connecting. See [tailscale/tailscale#4997](https://github.com/tailscale/tailscale/issues/4997).
+
+Sources:
+
+- [Blink docs — Tailscale + Mosh](https://docs.blink.sh/integrations/tailscale+mosh)
+- [tailscale/tailscale#4997](https://github.com/tailscale/tailscale/issues/4997) (the silent-hang gotcha)
+
+### Legacy Setup on Server (AMI)
 
 - sudo yum install mosh
 - In AWS console open UDP ports 60000-61000


### PR DESCRIPTION
## Summary

- Modernizes the iOS section of `/mosh` — replaces the stale Lightsail/AMI key-copy flow with the current Blink + Tailscale SSH workflow.
- Calls out the optional `mosh --install-static` upgrade for network-resilient sessions when the iPhone hops Wi-Fi to cellular.
- Documents the silent-hang gotcha: tailnets running ACL `check` mode require iOS notifications enabled for the Tailscale app, otherwise the time-sensitive re-auth prompt is dropped and the SSH connection just hangs. Linked to [tailscale/tailscale#4997](https://github.com/tailscale/tailscale/issues/4997) and the [Blink docs](https://docs.blink.sh/integrations/tailscale+mosh).

Companion issue with the actual iPhone-setup checklist will follow.

## Files

- `_td/mosh.md` — replaced "Setup on iOS" subsection, kept the legacy AMI / Lightsail / WSL content under a `### Legacy Setup on Server (AMI)` heading so old anchors still work.

## Test plan

- [x] `prek run --files _td/mosh.md` — all hooks pass (lychee, anchor-checker, prettier).
- [x] `bundle exec jekyll build --incremental` succeeds.
- [ ] Igor renders `/mosh` locally to confirm the new section reads cleanly.