### PR TITLE
docs(CLAUDE.md): hoist fresh-worktree jekyll build prereq

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,16 @@ Then read: `repo_tmp/chop-conventions/dev-inner-loop/a_readme_first.md`
 
 Use beads (`bd` commands) for task tracking. See the Beads Integration section below for details.
 
+## First commit in a fresh worktree
+
+The `anchor-checker` pre-commit hook reads `_site/*.html` to validate markdown anchors. A freshly cloned worktree has no `_site/` and the hook fails with `Error: _site not found. Run 'jekyll build' first.` Run once before your first commit:
+
+```bash
+bundle exec jekyll build --incremental
+```
+
+Same fix applies if you edit a heading mid-session and the live `jekyll serve` hasn't written it to disk yet — see the screenshot section below.
+
 ## PR Workflow
 
 Repo-mode distinctions (AI-Tools vs Human-Supervised) and the fork-push workflow live in `~/gits/chop-conventions/dev-inner-loop/repo-modes.md`.


### PR DESCRIPTION
## Summary

The `_site/`-required fix for the `anchor-checker` hook is already documented in the "PR Screenshots for Content Changes" subsection (around line 68), but markdown-only editors skip that section and re-discover the failure on every fresh worktree. Hoisting it to a top-level prereq section saves ~30s of hook-debugging per fresh clone.

Places a new `## First commit in a fresh worktree` section between `## Task Tracking` and `## PR Workflow` with a cross-reference back to the screenshot section for the mid-session heading-edit case.

## Context

Surfaced as a lesson during #543 (Blink + Tailscale SSH note) — fresh worktree hit exactly this failure. Filed as a separate PR since #543 merged before the hoist commit could ride along.

## Test plan

- [x] Pre-commit hooks pass (prettier, anchor-checker, lychee, typos)
- [x] New section renders correctly in preview
- [x] Cross-reference to screenshot section resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)