### PR TITLE
backlinks: exclude changelog as an aggregator source

### DIFF
--- a/build_back_links.py
+++ b/build_back_links.py
@@ -382,6 +382,15 @@ class LinkBuilder:
 
         assert "should never get here"
 
+    # Pages whose outgoing links should NOT populate other pages' backlinks.
+    # These are aggregator/index pages that link to nearly everything, so
+    # treating them as a backlink source pollutes every post's "Referenced by"
+    # section with noise. The pages themselves still appear in self.pages
+    # (searchable, reachable), they just don't contribute incoming_links.
+    EXCLUDED_BACKLINK_SOURCES = frozenset({
+        "changelog.html",
+    })
+
     def update(self, path_back: FileType):
         if "debug-something-wonky" in path_back:
             pudb.set_trace()
@@ -394,11 +403,12 @@ class LinkBuilder:
             self.redirects[page.url] = page.redirect_url
             return
 
-        for link in page.outgoing_links:
-            # when a link has an anchor eg foo.html#bar
-            # the incoming_link is foo.html, so strip the anchor
-            clean_link = link.split("#")[0]
-            self.incoming_links[clean_link].append(page.url)
+        if os.path.basename(path_back) not in self.EXCLUDED_BACKLINK_SOURCES:
+            for link in page.outgoing_links:
+                # when a link has an anchor eg foo.html#bar
+                # the incoming_link is foo.html, so strip the anchor
+                clean_link = link.split("#")[0]
+                self.incoming_links[clean_link].append(page.url)
 
         self.pages[page.url] = page
 


### PR DESCRIPTION
## Summary

`changelog.md` is an auto-generated weekly index that links to nearly every post. Before this change, every one of those outbound links populated `incoming_links` for the linked page, so every post's "Referenced by" section accumulated changelog references every week — cumulative noise with zero navigational value.

## Fix

Add `EXCLUDED_BACKLINK_SOURCES = frozenset({"changelog.html"})` on `LinkBuilder`, checked by `os.path.basename(path_back)` in `update()`. Pages in the set are still parsed and registered in `self.pages` (searchable/reachable, still crawled), but their outgoing links do NOT contribute to other pages' `incoming_links`.

```diff
- for link in page.outgoing_links:
-     clean_link = link.split("#")[0]
-     self.incoming_links[clean_link].append(page.url)
+ if os.path.basename(path_back) not in self.EXCLUDED_BACKLINK_SOURCES:
+     for link in page.outgoing_links:
+         clean_link = link.split("#")[0]
+         self.incoming_links[clean_link].append(page.url)
```

## Extensibility

If another aggregator-style page shows up (sitemap, roadmap, an index page), add it to `EXCLUDED_BACKLINK_SOURCES` — same behavior, one-line addition.

## Followup

`back-links.json` will need a regenerate run (`python3 build_back_links.py build`) to take effect. The existing cache still has the old noisy entries until then. Post-merge regeneration via the normal build pipeline should handle it.

Co-Authored-By: Claude <noreply@anthropic.com>