### PR TITLE
algolia: exclude changelog from search index

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,6 +50,7 @@ algolia:
     # https://community.algolia.com/jekyll-algolia/options.html#files-to-exclude
   files_to_exclude:
     - "*bak"
+    - "_d/changelog.md"
     - "_d/positive-mitzvahs.md"
     - "_d/negative-mitzvahs.md"
     - "debug.html"


### PR DESCRIPTION
## Summary

- Add `_d/changelog.md` to `algolia.files_to_exclude` in `_config.yml`
- The auto-generated changelog aggregator page was polluting Algolia search results; this excludes it from the next index build

## Change

```yaml
algolia:
  files_to_exclude:
    - "*bak"
    - "_d/changelog.md"   # <-- added
    - "_d/positive-mitzvahs.md"
    - "_d/negative-mitzvahs.md"
    ...
```

## Test plan

- [ ] Next `jekyll-algolia` index run skips `_d/changelog.md`
- [ ] Algolia search no longer returns changelog hits for generic queries

Co-Authored-By: Claude <noreply@anthropic.com>