### PR TITLE
images: add repo_image include + allow both repo-local and blob-hosted

### DIFF
--- a/_d/life-journal.md
+++ b/_d/life-journal.md
@@ -33,6 +33,7 @@ When adding a new entry:
 4. **Voice**: Plain and direct. Self-aware is fine; preachy isn't. Specific details over abstraction.
 5. **Update TOC**: Regenerate the TOC with `:Mtoc update` (Igor will handle this if you skip it).
 6. **Images**: Maximum one image per entry. If the entry wants more visuals, it probably wants to be its own post.
+7. **Image source**: Two options. For one-off illustrations tied to a single entry, drop the file in `images/` and use `{% include repo_image.html src="<filename>.webp" %}`. For images hosted in the `idvorkin/blob` repo — the raccoon mascot set, reused art, or anything you'd rather keep out of the blog's git history — use `{% include blob_image.html src="blog/<filename>.webp" %}` (upload to blob first; two-PR dance). Default to `repo_image` for one-offs.
 
 ## Upcoming
 

--- a/_includes/repo_image.html
+++ b/_includes/repo_image.html
@@ -1,0 +1,1 @@
+![](/images/{{include.src}})

--- a/_includes/repo_image_float_right.html
+++ b/_includes/repo_image_float_right.html
@@ -1,0 +1,2 @@
+{%- capture full_url %}/images/{{include.src}}{%- endcapture -%} {% include
+image_float_right.html src=full_url alt=include.alt %}

--- a/back-links.json
+++ b/back-links.json
@@ -4071,12 +4071,12 @@
         },
         "/life-journal": {
             "description": "A journal of random life observations. Keeping track of them so I don’t forget what the world did today.\n\n",
-            "doc_size": 20000,
+            "doc_size": 22000,
             "file_path": "_site/life-journal.html",
             "incoming_links": [
                 "/ai-operator"
             ],
-            "last_modified": "2026-04-17T19:07:34.959080+00:00",
+            "last_modified": "2026-04-17T23:11:45.422800+00:00",
             "markdown_path": "_d/life-journal.md",
             "outgoing_links": [
                 "/ai-operator"


### PR DESCRIPTION
## Summary

Reverses the blob-only rule from #553. Igor's call (msg 2282): repo-local images are fine for one-off illustrations tied to a single post; the blob dance is only warranted for reused art or assets we want out of the blog's git history.

Three edits:

1. **`_d/life-journal.md`** — rewrite rule #7 in the INSTRUCTIONS block to document both options. `repo_image` is the default for one-offs; `blob_image` for the raccoon mascot set and other re-used art.
2. **`_includes/repo_image.html`** — new sibling of `blob_image.html`, renders `![](/images/<src>)`.
3. **`_includes/repo_image_float_right.html`** — sibling of `blob_image_float_right.html`, wraps `image_float_right` with a `/images/` src.

The `back-links.json` diff is the auto-generated output of the `update-backlinks-last-modified` pre-commit hook triggered by the `_d/life-journal.md` edit.

## .gitignore status

**No change needed.** `images/` is not in `.gitignore` — files under it commit normally (confirmed via `git check-ignore`). The convention I was asked to mirror from "blob-include PRs" turned out to be a no-op on that side too — #553 makes no `.gitignore` changes.

## Context

Replaces rule #7 from #553 (still open). The raccoon-handoff image deletion in #553 was correct in its own right; only the rule about never using local paths is being reversed here. Once this PR merges Igor can either re-land #553's image swap separately or close it as superseded — that's his call.

## Test plan

- [ ] Jekyll renders a `{% include repo_image.html src=\"foo.webp\" %}` as a standard `<img>` with `src=\"/images/foo.webp\"`
- [ ] `{% include repo_image_float_right.html src=\"foo.webp\" %}` renders with the `float-right-img` class
- [ ] Rule #7 in `/life-journal` documents both options (note: hidden in HTML comments per #540)

Co-Authored-By: Claude <noreply@anthropic.com>