### PR TITLE
CLAUDE.md: add 'Distill, Don't Accrete' editorial rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,16 @@ Your compelling first paragraph that serves as the excerpt...
 Rest of post content...
 ```
 
+## Distill, Don't Accrete
+
+When adding content to an existing post, first think about how to distill and integrate — not append. Before writing new paragraphs, ask:
+
+- Can overlapping prose already in the post be replaced with a tighter version of both?
+- Can an existing paragraph absorb this idea?
+- Does this really want a new section, or a single sharpened sentence?
+
+Long-and-loose is the default drift. Short-and-tight is the move. A post that grows should mostly grow sharper, not fatter. Every addition earns its place.
+
 ## Internal Link Guidelines
 
 **Always use permalinks**, not redirect URLs:


### PR DESCRIPTION
## Summary

Codifies editorial directive from Igor (Telegram msg 2334, 2026-04-18): when adding content to an existing post, **first think about how to distill and integrate, not append**. Long-and-loose is the default drift; short-and-tight is the move.

Adds a new \`## Distill, Don't Accrete\` section to \`CLAUDE.md\` between AI Slop Label and Internal Link Guidelines — content-quality rules cluster.

Mirrored in \`igor2/CLAUDE.md\` under Gotchas (separate change, private repo).

## Why

We were about to grow \`/larry\` with a new 374-word "Chief of Staff" section (PR #562). Igor's redirect was: that belongs in \`/ai-operator\`'s existing "On the Loop" section — and when we do the move, integrate don't accrete. This rule makes that directive durable for future edits.

## Test plan

- [ ] No content pages change — rule lives in repo-level CLAUDE.md only
- [ ] Section renders correctly when viewing CLAUDE.md on GitHub
- [ ] Future PRs touching existing \`_d/\` posts can be reviewed against this rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)