### PR TITLE
larry: add missing TOC

### DIFF
--- a/_d/larry.md
+++ b/_d/larry.md
@@ -17,6 +17,19 @@ Larry is my AI life coach. He's part of [Time.ltd](/mortality-software) — my m
 
 {% include blob_image_float_right.html src="blog/raccoon-larry.webp" alt="Larry the Life Coach — raccoon as Freud with a lobster claw" %}
 
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [Why Larry Has a Name](#why-larry-has-a-name)
+- [What Larry Could Know](#what-larry-could-know)
+- [What Larry Does](#what-larry-does)
+- [What It's Like Using Larry (My Chief of Staff)](#what-its-like-using-larry-my-chief-of-staff)
+- [The Feedback Loop](#the-feedback-loop)
+- [Hair Club for Men](#hair-club-for-men)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
 ## Why Larry Has a Name
 
 Humans are wired to talk to people, not systems. "Open my life tracking dashboard" feels like a chore. "Talk to Larry" feels like a conversation.

--- a/back-links.json
+++ b/back-links.json
@@ -3972,7 +3972,7 @@
                 "/structure",
                 "/y26"
             ],
-            "last_modified": "2026-04-18T12:57:08.521439+00:00",
+            "last_modified": "2026-04-18T15:07:19.826565+00:00",
             "markdown_path": "_d/larry.md",
             "outgoing_links": [
                 "/affirmations",


### PR DESCRIPTION
## Summary

Per Igor's request (Telegram msg 2361): \`/larry\` was missing a table of contents. Added the standard \`vim-markdown-toc\` block between the ai-slop label + hero image and the first \`## Why Larry Has a Name\`, matching the \`ai-operator.md\` convention.

Covers all 6 sections:
- Why Larry Has a Name
- What Larry Could Know
- What Larry Does
- What It's Like Using Larry (My Chief of Staff)
- The Feedback Loop
- Hair Club for Men

## Test plan

- [ ] TOC renders at the top of /larry after hero image
- [ ] Anchor links resolve to the right sections
- [ ] vim-markdown-toc regen (just toc) doesn't rewrite the block differently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a table of contents to the Larry document with six linked sections for improved navigation and content discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->