### PR TITLE
share-link: signal 'not end of post' with '...' on short-complete snippets

### DIFF
--- a/src/__tests__/header-copy-link.test.ts
+++ b/src/__tests__/header-copy-link.test.ts
@@ -415,6 +415,139 @@ describe("Header Copy Link", () => {
       expect(previewPortion.length).toBeLessThanOrEqual(900); // includes "From: ..." breadcrumb + preview
     });
 
+    it("should append '...' when the extracted paragraph is short but more content follows (msg 2363)", async () => {
+      // When a section's first paragraph is short and fits well under the
+      // preview cap, we still need to signal to share recipients that the
+      // snippet is not the end of the post. Otherwise they read the clean
+      // first sentence and don't realize there are 3 more paragraphs to
+      // click through to.
+      const mockClipboard = vi.fn().mockResolvedValue(undefined);
+      (
+        globalThis as unknown as {
+          navigator: { clipboard: { writeText: typeof mockClipboard } };
+        }
+      ).navigator.clipboard.writeText = mockClipboard;
+
+      mockWindow.location.href = "http://localhost:4000/ai-operator#on-the-loop";
+
+      const makeP = (text: string): any => ({
+        tagName: "P",
+        textContent: text,
+      });
+
+      // Short first paragraph (well under 600 chars), followed by more
+      // non-empty paragraphs before the next header.
+      const firstPara = makeP(
+        "When you're on-the-loop, the AI does the checking and you do the review at a checkpoint.",
+      );
+      const secondPara = makeP(
+        "More content in this section that the reader would miss if we don't flag that this is a snippet.",
+      );
+      const thirdPara = makeP("Even more content — a third paragraph before the next header.");
+
+      firstPara.nextElementSibling = secondPara;
+      secondPara.nextElementSibling = thirdPara;
+      thirdPara.nextElementSibling = null;
+
+      const mockHeader: any = {
+        id: "on-the-loop",
+        textContent: "On the Loop",
+        tagName: "H2",
+        appendChild: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        querySelector: vi.fn(() => null),
+        getBoundingClientRect: vi.fn(() => ({ bottom: 0, left: 0, right: 0, top: 0, width: 0, height: 0 })),
+        nextElementSibling: firstPara,
+        childNodes: [{ nodeType: 3, textContent: "On the Loop" }],
+        previousElementSibling: null,
+      };
+
+      mockDocument.querySelectorAll.mockReturnValue([mockHeader]);
+      mockDocument.getElementById.mockImplementation((id: string) => (id === "on-the-loop" ? mockHeader : null));
+      mockDocument.querySelector.mockReturnValue(null);
+
+      initHeaderCopyLinks();
+
+      const copyIcon = mockHeader.appendChild.mock.calls[0][0];
+      const clickHandler = copyIcon.addEventListener.mock.calls.find((call: any[]) => call[0] === "click")?.[1];
+      expect(clickHandler).toBeDefined();
+
+      await clickHandler({ preventDefault: vi.fn(), stopPropagation: vi.fn() });
+
+      expect(mockClipboard).toHaveBeenCalled();
+      const clipboardText = mockClipboard.mock.calls[0][0] as string;
+
+      // Locate the extracted preview text (between the breadcrumb and the TinyURL).
+      const urlIdx = clipboardText.indexOf("https://tinyurl.com/");
+      const previewPortion = clipboardText.substring(0, urlIdx).trim();
+
+      // The preview must end with "..." to signal the snippet is not the end
+      // of the post. Without this, the reader thinks they have the whole
+      // section.
+      expect(previewPortion.endsWith("...")).toBe(true);
+
+      // And the first paragraph itself should be complete (not mid-sentence).
+      expect(previewPortion).toContain("When you're on-the-loop");
+      expect(previewPortion).toContain("review at a checkpoint");
+    });
+
+    it("should NOT append '...' when extracted paragraph is the only content in the section", async () => {
+      // Single-paragraph section with nothing else before the next header:
+      // the preview IS the whole section, so no trailing "..." is needed.
+      const mockClipboard = vi.fn().mockResolvedValue(undefined);
+      (
+        globalThis as unknown as {
+          navigator: { clipboard: { writeText: typeof mockClipboard } };
+        }
+      ).navigator.clipboard.writeText = mockClipboard;
+
+      mockWindow.location.href = "http://localhost:4000/some-post#last-section";
+
+      const onlyPara: any = {
+        tagName: "P",
+        textContent: "The only paragraph in this section, sitting right before the next header.",
+        nextElementSibling: null,
+      };
+      // Put an H2 right after — this is the natural end of the section.
+      const nextHeader: any = { tagName: "H2", textContent: "Next Section", nextElementSibling: null };
+      onlyPara.nextElementSibling = nextHeader;
+
+      const mockHeader: any = {
+        id: "last-section",
+        textContent: "Last Section",
+        tagName: "H2",
+        appendChild: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        querySelector: vi.fn(() => null),
+        getBoundingClientRect: vi.fn(() => ({ bottom: 0, left: 0, right: 0, top: 0, width: 0, height: 0 })),
+        nextElementSibling: onlyPara,
+        childNodes: [{ nodeType: 3, textContent: "Last Section" }],
+        previousElementSibling: null,
+      };
+
+      mockDocument.querySelectorAll.mockReturnValue([mockHeader]);
+      mockDocument.getElementById.mockImplementation((id: string) => (id === "last-section" ? mockHeader : null));
+      mockDocument.querySelector.mockReturnValue(null);
+
+      initHeaderCopyLinks();
+
+      const copyIcon = mockHeader.appendChild.mock.calls[0][0];
+      const clickHandler = copyIcon.addEventListener.mock.calls.find((call: any[]) => call[0] === "click")?.[1];
+      expect(clickHandler).toBeDefined();
+
+      await clickHandler({ preventDefault: vi.fn(), stopPropagation: vi.fn() });
+
+      const clipboardText = mockClipboard.mock.calls[0][0] as string;
+      const urlIdx = clipboardText.indexOf("https://tinyurl.com/");
+      const previewPortion = clipboardText.substring(0, urlIdx).trim();
+
+      // No more content in the section → no trailing "..."
+      expect(previewPortion.endsWith("...")).toBe(false);
+      expect(previewPortion).toContain("The only paragraph in this section");
+    });
+
     it("should handle clipboard API failure gracefully", async () => {
       // Mock clipboard API to fail
       const mockFailingClipboard = vi.fn().mockRejectedValue(new Error("Clipboard failed"));

--- a/src/header-copy-link.ts
+++ b/src/header-copy-link.ts
@@ -520,15 +520,51 @@ function getOrCreateHeaderId(header: HTMLElement): string {
 const PREVIEW_MAX_LENGTH = 600;
 
 /**
+ * Result of extracting a preview from the content after a header.
+ *
+ * `hasMore` is true when the section contains additional content beyond
+ * what `text` captured — either extra list items we skipped to keep the
+ * preview under cap, or additional paragraphs/lists before the next
+ * header. The caller uses this to append an ellipsis so recipients know
+ * the preview is a snippet, not the whole section.
+ */
+interface PreviewExtraction {
+  text: string;
+  hasMore: boolean;
+}
+
+/**
  * Gets the first non-empty paragraph of content after a header.
  *
- * Returns untruncated text — truncation is the caller's responsibility
- * (see `truncateText`). Previously this function pre-truncated at 500 chars,
- * then `getPreviewText` re-truncated at 400 chars, yielding double-truncation
- * that clipped bullet lists mid-sentence. See issue #487.
+ * Returns `{ text, hasMore }`. Truncation of oversized text is the caller's
+ * responsibility (see `truncateText`). Previously this function pre-truncated
+ * at 500 chars, then `getPreviewText` re-truncated at 400 chars, yielding
+ * double-truncation that clipped bullet lists mid-sentence. See issue #487.
+ *
+ * `hasMore` is set to true when further non-empty content exists in the
+ * same section (dropped bullets, or additional paragraphs/lists before
+ * the next header) so the caller can signal "snippet, not whole post"
+ * to the recipient. See share-link feedback 2026-04-18.
  */
-function getFirstParagraphAfterHeader(header: HTMLElement): string {
+function getFirstParagraphAfterHeader(header: HTMLElement): PreviewExtraction {
   let nextElement = header.nextElementSibling;
+
+  const hasMoreContentAfter = (startFrom: Element | null): boolean => {
+    let cursor: Element | null = startFrom;
+    while (cursor) {
+      if (cursor.tagName.match(/^H[1-6]$/)) {
+        return false;
+      }
+      if (cursor.tagName === "P" || cursor.tagName === "UL" || cursor.tagName === "OL") {
+        const content = (cursor.textContent || "").trim();
+        if (content.length > 0) {
+          return true;
+        }
+      }
+      cursor = cursor.nextElementSibling;
+    }
+    return false;
+  };
 
   // Look for the first non-empty content before the next header
   while (nextElement) {
@@ -541,7 +577,8 @@ function getFirstParagraphAfterHeader(header: HTMLElement): string {
     if (nextElement.tagName === "P") {
       const text = (nextElement.textContent || "").trim();
       if (text.length > 0) {
-        return text;
+        const hasMore = hasMoreContentAfter(nextElement.nextElementSibling);
+        return { text, hasMore };
       }
     }
 
@@ -555,6 +592,7 @@ function getFirstParagraphAfterHeader(header: HTMLElement): string {
       const listItems = nextElement.querySelectorAll("li");
       const itemTexts: string[] = [];
       let totalLength = 0;
+      let droppedItems = false;
 
       for (const li of Array.from(listItems)) {
         // Only get direct text content, not nested lists
@@ -577,6 +615,7 @@ function getFirstParagraphAfterHeader(header: HTMLElement): string {
         // blow the cap, stop here and let the outer truncator append an
         // ellipsis. This keeps bullet boundaries clean.
         if (itemTexts.length > 0 && totalLength + bulletLen + 1 > PREVIEW_MAX_LENGTH) {
+          droppedItems = true;
           break;
         }
 
@@ -585,15 +624,15 @@ function getFirstParagraphAfterHeader(header: HTMLElement): string {
       }
 
       if (itemTexts.length > 0) {
-        // Join with newlines for better formatting.
-        return itemTexts.join("\n");
+        const hasMore = droppedItems || hasMoreContentAfter(nextElement.nextElementSibling);
+        return { text: itemTexts.join("\n"), hasMore };
       }
     }
 
     nextElement = nextElement.nextElementSibling;
   }
 
-  return "";
+  return { text: "", hasMore: false };
 }
 
 /**
@@ -645,6 +684,19 @@ function truncateText(text: string, maxLength = PREVIEW_MAX_LENGTH): string {
 }
 
 /**
+ * Appends `...` to the preview text if it doesn't already end with one and
+ * there's more content in the post beyond the snippet. Signals "this is a
+ * snippet, not the whole section" to share recipients so they know to click
+ * through. `truncateText` already handles the mid-cut case; this handles
+ * the short-complete-paragraph-but-more-follows case.
+ */
+function withMoreIndicator(text: string, hasMore: boolean): string {
+  if (!hasMore) return text;
+  if (text.endsWith("...") || text.endsWith("…")) return text;
+  return `${text}...`;
+}
+
+/**
  * Extracts preview text from the page content, with anchor-aware logic
  */
 function getPreviewText(headerId?: string): string {
@@ -653,15 +705,16 @@ function getPreviewText(headerId?: string): string {
     const header = document.getElementById(headerId);
     if (header) {
       // Try to get text from the first paragraph after the header
-      const paragraphText = getFirstParagraphAfterHeader(header);
+      const { text: paragraphText, hasMore: paragraphHasMore } = getFirstParagraphAfterHeader(header);
       if (paragraphText) {
-        return truncateText(paragraphText);
+        return withMoreIndicator(truncateText(paragraphText), paragraphHasMore);
       }
 
       // Try to get text from any content elements after the header
       let nextElement = header.nextElementSibling;
       const textParts: string[] = [];
       let charCount = 0;
+      let moreAfter = false;
 
       while (nextElement && charCount < 400) {
         // Stop if we hit another header
@@ -686,8 +739,20 @@ function getPreviewText(headerId?: string): string {
         nextElement = nextElement.nextElementSibling;
       }
 
+      // If we stopped scanning early (hit 400 char cap) but there's still
+      // unscanned content before the next header, flag moreAfter.
+      let scan = nextElement;
+      while (scan && !moreAfter) {
+        if (scan.tagName.match(/^H[1-6]$/)) break;
+        if ((scan.textContent || "").trim().length > 0) {
+          moreAfter = true;
+          break;
+        }
+        scan = scan.nextElementSibling;
+      }
+
       if (textParts.length > 0) {
-        return truncateText(textParts.join(" "));
+        return withMoreIndicator(truncateText(textParts.join(" ")), moreAfter);
       }
     }
   }


### PR DESCRIPTION
## Summary

Per Igor's Telegram msg 2363 (2026-04-18): when the share-link feature extracts a snippet after a header, it should be clear to share recipients that the snippet is not the whole section. Previously \`truncateText\` only appended \`...\` when it actually truncated; short complete paragraphs (with more content after) arrived without any indicator — recipients read the clean first sentence and didn't realize there were 3 more paragraphs to click through.

## Changes

- \`getFirstParagraphAfterHeader\` now returns \`{ text, hasMore }\`. \`hasMore\` is \`true\` when either (a) the UL/OL loop dropped additional bullets to stay under cap, or (b) additional non-empty P/UL/OL elements exist before the next H1-H6.
- New \`withMoreIndicator(text, hasMore)\` helper appends \`...\` when the flag is set and the text doesn't already end with one.
- \`getPreviewText\` applies the helper in both the first-paragraph path and the mixed-element scan fallback (which also now tracks whether unscanned content remains before the next header).

## Tests

- **All 259 vitest tests pass** (19 files, 5 pre-existing skips).
- New: \`'should append "..." when the extracted paragraph is short but more content follows'\` — asserts trailing ellipsis on short-first-paragraph-plus-more.
- New: \`'should NOT append "..." when extracted paragraph is the only content in the section'\` — guards against false positives on single-paragraph sections.
- Existing \`#487\` bullet-preservation regression test still green.

## Why

Share recipients read the clean preview and assume it's the whole section. Adding \`...\` is the universal shorthand for "there's more here" — small signal, big improvement in click-through intent.

## Test plan

- [ ] Vitest: \`npx vitest run src/__tests__/header-copy-link.test.ts\` (all green)
- [ ] Manual: copy a link from a multi-paragraph section (e.g., \`/ai-operator#on-the-loop\`) and confirm preview ends with \`...\`
- [ ] Manual: copy from a single-paragraph section (if one exists) and confirm no trailing \`...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)