### PR TITLE
feat(justfile): add worktree-init for fire-and-forget jekyll build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ The `anchor-checker` pre-commit hook reads `_site/*.html` to validate markdown a
 bundle exec jekyll build --incremental
 ```
 
+- **Background jekyll build on worktree creation**: after `git worktree add <path>`, cd in and run `just worktree-init`. Fires `bundle exec jekyll build` in the background (log: `/tmp/jekyll-worktree-<branch>.log`). By the time you're ready to commit, `_site/` is populated and the `anchor-checker` pre-commit hook resolves anchors correctly — no need for `SKIP=anchor-checker` unless there are genuinely-broken anchors in source.
+
 Same fix applies if you edit a heading mid-session and the live `jekyll serve` hasn't written it to disk yet — see the screenshot section below.
 
 ## PR Workflow

--- a/justfile
+++ b/justfile
@@ -234,10 +234,20 @@ jekyll-rebuild: jekyll-clean
 # is faster and sufficient.
 worktree-init:
     #!/usr/bin/env sh
-    BRANCH=$(git branch --show-current)
+    set -eu
+    # Sanitize branch name for filesystem (e.g. claude/foo -> claude-foo)
+    # Otherwise nohup writes to a non-existent parent dir and the build
+    # fails silently while we still print "Background build fired".
+    BRANCH=$(git branch --show-current | tr '/' '-')
     LOG="/tmp/jekyll-worktree-$BRANCH.log"
     echo "🔨 Starting bg jekyll build — log: $LOG"
-    nohup bundle exec jekyll build >"$LOG" 2>&1 & disown
+    # Match jekyll-rebuild: prefer homebrew Ruby on Darwin so we don't
+    # silently fall back to system Ruby and fail.
+    if [ "$(uname)" = "Darwin" ]; then
+        nohup ~/homebrew/opt/ruby/bin/bundle exec jekyll build >"$LOG" 2>&1 & disown
+    else
+        nohup bundle exec jekyll build >"$LOG" 2>&1 & disown
+    fi
     echo "✅ Background build fired. _site/ ready in ~60-90s; first commit should find it populated."
 
 jekyll-serve port="4000" livereload_port="35729":

--- a/justfile
+++ b/justfile
@@ -228,6 +228,18 @@ jekyll-rebuild: jekyll-clean
     fi
     echo "✅ Jekyll rebuild complete - site available in _site/"
 
+# Fire-and-forget background jekyll build for fresh worktrees.
+# Populates _site/ so the anchor-checker pre-commit hook passes by
+# the time the first commit lands. No clean step — incremental build
+# is faster and sufficient.
+worktree-init:
+    #!/usr/bin/env sh
+    BRANCH=$(git branch --show-current)
+    LOG="/tmp/jekyll-worktree-$BRANCH.log"
+    echo "🔨 Starting bg jekyll build — log: $LOG"
+    nohup bundle exec jekyll build >"$LOG" 2>&1 & disown
+    echo "✅ Background build fired. _site/ ready in ~60-90s; first commit should find it populated."
+
 jekyll-serve port="4000" livereload_port="35729":
     #!/usr/bin/env sh
     # Update git branch info for dev banner


### PR DESCRIPTION
## Summary

- New `just worktree-init` recipe: fires `bundle exec jekyll build` in the background (`nohup ... & disown`, log at `/tmp/jekyll-worktree-<branch>.log`) so fresh worktrees populate `_site/` without blocking the terminal.
- CLAUDE.md convention documented under the existing "First commit in a fresh worktree" section — points agents at `just worktree-init` right after `git worktree add`.

## Why

Fresh worktrees have no `_site/`, so the `anchor-checker` pre-commit hook fails with `Error: _site not found. Run 'jekyll build' first.` The existing workaround was to run `bundle exec jekyll build --incremental` synchronously (~60-90s blocking) OR commit with `SKIP=anchor-checker`. Firing the build in the background at worktree-creation time means `_site/` is populated by the time the first commit lands, so the hook resolves anchors correctly with no manual skip and no blocking wait.

## Test plan

- [x] `just --list | grep worktree-init` shows the new recipe
- [x] Diff is small (2 files, +14 lines)
- [ ] In a fresh worktree: `just worktree-init`, wait ~90s, make a trivial edit, commit without `SKIP=anchor-checker` — expect hook to pass against the freshly-built `_site/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for initializing new Git worktrees with pre-built site content.

* **New Features**
  * Added a new worktree initialization task that automatically prepares the build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->