### PR TITLE
ai-native-manager: add founder-side hiring field note (Shivani Poddar)

### DIFF
--- a/_d/ai-native-manager.md
+++ b/_d/ai-native-manager.md
@@ -348,4 +348,12 @@ What changed is "Gets Shit Done" got a fancy new word — [Agency](/agency). But
 
 The real question isn't _what_ to hire for — it's _how_ to assess it when AI changes what the work looks like. That's a whole separate rabbit hole.
 
+**Field note from the founder side.** Shivani Poddar (ex-Google / Deepmind / Meta, now Founder Stealth) recently shared what she looks for in her founding team:
+
+1. **Excellence in _something_** — "could be athletics, competitive programming, anything. This shows me you have it in you to learn and be the bestest and greatest at something."
+2. **Founder energy** — "that fire in the belly and never-say-never attitude."
+3. **AI-pilled** — "you know how to exponentiate yourself, your stack, your product, and people around you with AI."
+
+She noted her former colleagues from Google, Meta, and Deepmind resonate with these as much as the new crop of graduates and founding engineers do. That tracks with the argument above: AI didn't invent agency, it just made the signal louder. The founder-stage variant of "Smart, GSD, Not an Asshole" looks a lot like its big-tech cousin — the bar didn't move, the noise floor dropped.
+
 {% include summarize-page.html src="/ai-hiring" %}

--- a/back-links.json
+++ b/back-links.json
@@ -1061,7 +1061,7 @@
                 "/pet-projects",
                 "/raccoon-history"
             ],
-            "last_modified": "2026-04-17T02:35:08.162475+00:00",
+            "last_modified": "2026-04-20T14:53:51.987129+00:00",
             "markdown_path": "_d/ai-native-manager.md",
             "outgoing_links": [
                 "/agency",
@@ -1072,7 +1072,6 @@
                 "/chop",
                 "/coaching",
                 "/explainers",
-                "/hill-climbing",
                 "/manager-book",
                 "/software-leadership-roles"
             ],
@@ -3529,7 +3528,6 @@
             "file_path": "_site/hill-climbing.html",
             "incoming_links": [
                 "/ai-developer",
-                "/ai-native-manager",
                 "/ai-testing",
                 "/changelog",
                 "/chop",


### PR DESCRIPTION
## Summary

Adds a concrete founder-side example to the "How Should Hiring Change?" section in `_d/ai-native-manager.md`. Shivani Poddar (ex-Google / Deepmind / Meta, now Founder Stealth) recently shared what she looks for in a founding team — excellence in something, founder energy, AI-pilled. The note closes by connecting her framing back to the post's existing thesis: the big-tech "Smart, GSD, Not an Asshole" formula and the founder-stage formula look a lot alike, because AI didn't move the bar, it dropped the noise floor.

## Changes

- `_d/ai-native-manager.md` — one paragraph + numbered list added right before the `ai-hiring` summarize-page include; no restructuring of surrounding prose.
- `back-links.json` — regenerated by the `update-backlinks-last-modified` pre-commit hook.

## Closing note

First of two related PRs. Companion PR adds an **AI Pilled** entry in the "New Words for a New World" section of the same post.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AI-Native Manager article with a new founder perspective section highlighting key team traits and their relevance to modern hiring practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->