### PR TITLE
ai-native-manager: add AI Pilled to New Words for a New World

### DIFF
--- a/_d/ai-native-manager.md
+++ b/_d/ai-native-manager.md
@@ -41,6 +41,7 @@ What does it mean to be an engineering manager when AI is rewriting every assump
   - [Functional Collapse](#functional-collapse)
   - [Agency](#agency)
   - [AI Cockpit](#ai-cockpit)
+  - [AI Pilled](#ai-pilled)
   - [Cognitive Debt](#cognitive-debt)
   - [Deep Blue](#deep-blue)
   - [Heresies](#heresies)
@@ -51,9 +52,9 @@ What does it mean to be an engineering manager when AI is rewriting every assump
 - [Appendix: Hot Takes](#appendix-hot-takes)
   - [Should XFN Code?](#should-xfn-code)
 - [Appendix: Old Questions, New Answers](#appendix-old-questions-new-answers)
+  - [Should EMs Code?](#should-ems-code)
   - [Should I Become an EM?](#should-i-become-an-em)
   - [How Should Hiring Change?](#how-should-hiring-change)
-  - [Should EMs Code?](#should-ems-code)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
@@ -233,6 +234,12 @@ The fancy new word for "Gets Shit Done." It's not new — it's always been the t
 ### AI Cockpit
 
 {% include summarize-page.html src="/ai-cockpit" %}
+
+### AI Pilled
+
+A founder-era shorthand for the shift from "uses AI when it helps" to "instinctively reaches for AI first." Shivani Poddar (ex-Google / Deepmind / Meta, now Founder Stealth) lists it as one of three things she looks for in her founding team: "you know how to exponentiate yourself, your stack, your product and people around you with AI." The key word is _exponentiate_ — not "use AI for the task you happened to land on," but deliberately compounding across four layers: self, tools, output, and the humans around you.
+
+My take: AI-pilled is the habit form of what [Agency](#agency) is dispositionally. Agency is wanting to make things happen without being told. AI-pilled is what agency looks like in this era — the default tool reach is an AI. Someone with both shows up to every problem already five moves in. Someone with one without the other shows up late or shows up stuck. For hiring, [Shivani's three criteria](#how-should-hiring-change) are a tight test: excellence-in-something gives you the slope, founder energy gives you the fuel, AI-pilled gives you the transmission.
 
 ### Cognitive Debt
 

--- a/back-links.json
+++ b/back-links.json
@@ -1061,7 +1061,7 @@
                 "/pet-projects",
                 "/raccoon-history"
             ],
-            "last_modified": "2026-04-17T02:35:08.162475+00:00",
+            "last_modified": "2026-04-20T14:55:24.234310+00:00",
             "markdown_path": "_d/ai-native-manager.md",
             "outgoing_links": [
                 "/agency",
@@ -1072,7 +1072,6 @@
                 "/chop",
                 "/coaching",
                 "/explainers",
-                "/hill-climbing",
                 "/manager-book",
                 "/software-leadership-roles"
             ],
@@ -3529,7 +3528,6 @@
             "file_path": "_site/hill-climbing.html",
             "incoming_links": [
                 "/ai-developer",
-                "/ai-native-manager",
                 "/ai-testing",
                 "/changelog",
                 "/chop",


### PR DESCRIPTION
## Summary

Adds a new glossary entry `### AI Pilled` to the "Appendix: New Words for a New World" section of `/ai-native-manager`. Inserted alphabetically between `AI Cockpit` and `Cognitive Debt`.

The entry defines "AI-pilled" as the habit form of Agency in the AI era — the default tool reach is an AI — drawing on Shivani Poddar's three hiring criteria. Cross-links to `#agency` and `#how-should-hiring-change` within the same page.

Closing note: companion PR to the Shivani Poddar hiring field note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a new "AI Pilled" section defining the concept and connecting it to related ideas such as "Agency" and hiring criteria.
  * Updated documentation table of contents and section ordering for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->