### PR TITLE
algolia: exclude _ig66/* (family journal) from search index

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,6 +53,7 @@ algolia:
     - "_d/changelog.md"
     - "_d/positive-mitzvahs.md"
     - "_d/negative-mitzvahs.md"
+    - "_ig66/*"
     - "debug.html"
     - "edit.html"
     - "edit"


### PR DESCRIPTION
## Summary

- Add `_ig66/*` to `algolia.files_to_exclude` in `_config.yml`
- Drops the family-journal collection (89 files, ~6500 lines) from the Algolia index — estimated ~1500-2000 records reclaimed

## Context

The Algolia app was blocked (HTTP 403 — quota exceeded) on the most recent index rebuild. `jekyll-algolia` emits one record per heading/paragraph/list-item, so line-count is the right proxy for quota pressure. The `_ig66/` family journal is the single biggest record-eater outside already-excluded files.

This keeps personal/family archive entries out of public search, matching the intent behind prior commit `0aad61a8d` ("Add support for showing/hiding Family Journal from Search Results").

## Test plan

- [ ] Next `bundle exec jekyll algolia` rebuild completes without quota block
- [ ] `/ig66/*` pages no longer appear in site search results
- [ ] Non-ig66 search hits unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search indexing configuration to exclude certain content directories from search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->