### PR TITLE
Promote addiction framing to 3-way trichotomy (Addiction/Passion/Hobby)

### DIFF
--- a/_d/addiction.md
+++ b/_d/addiction.md
@@ -51,36 +51,33 @@ Addiction is not about drugs or alcohol - it is about escape. Quoting "Do the Wo
 
 ## Is doing the thing you want to be doing an addiction?
 
-Here's a framework I've been working through: there's both addiction and there's opportunity cost, and they're different things.
+Here's the framework I've been working through. Two questions sort it: Am I compelled to do this? And is it negatively impacting my life?
 
-**Addiction:** You DON'T want to do the thing you're doing, but you feel compelled to inside. The rest of your life is suffering as a result.
+- **Addiction:** Compelled, AND it negatively impacts your life.
+- **Passion:** Compelled, but neutral or positive.
+- **Hobby:** Not compelled — you do it because you choose to.
 
-**Opportunity cost:** You DO want to do it, and the rest of your life is suffering because you're choosing this over other things.
-
-The key difference is compulsion versus choice. With addiction, you're running from something - escaping thoughts, avoiding feelings, numbing pain. With opportunity cost, you're running toward something you genuinely value, but you're paying a price in other areas of your life.
+The key axis is compulsion. Addiction and passion both have the "can't stand NOT doing it" pull; they only differ on whether the rest of your life is suffering because of it. Hobbies sit outside that pull entirely — you can put them down without feeling relief or loss.
 
 ### The logical approach
 
-Once you identify which one you're dealing with, you can respond appropriately:
+Once you've placed the activity, the response follows:
 
-- **If it's addiction:** The work is to address the underlying thing you're avoiding. What are you escaping from? What pain or fear are you numbing?
-- **If it's opportunity cost:** Weigh the costs logically. Is what you're gaining worth what you're losing? Are you making a conscious trade-off or just drifting into an imbalanced life?
+- **Addiction:** Address what you're escaping. What pain or fear is the compulsion numbing?
+- **Passion:** Weigh the [opportunity cost](/satisfaction). Compulsion plus net-positive is still a trade — what are you giving up, and is it worth it?
+- **Hobby:** Enjoy it. The absence of compulsion is the feature. (See [/hobby](/hobby) for what makes a great one.)
 
 ### Examples from my life
 
-The clearest distinction for me is **TikTok vs Vibe Coding**.
+**TikTok = Addiction.** I don't actually want to scroll. I'm not excited about strangers doing kettlebell lifts or giving retirement advice. But when I have a moment of quiet, or finish one thing before starting the next, I feel compelled to scroll. I'm escaping my thoughts — avoiding the discomfort of being present with my internal experience. I can't stand NOT scrolling in those moments. Compulsion plus my life worse for it.
 
-**TikTok = Addiction**
+**Vibe Coding = Passion.** When I'm in flow building something, solving a problem — I genuinely want to be doing it. I love it. I'm not escaping anything; I'm engaged. The compulsion is real, and there's an opportunity cost — I miss family time, skip workouts, stay up too late — but on balance my life is better with it in it, not worse.
 
-I don't actually want to scroll TikTok. I'm not excited about watching strangers do kettlebell lifts or give retirement advice. But when I have a moment of quiet, or finish one thing before starting the next, I feel compelled to scroll. I'm escaping my thoughts - avoiding the discomfort of being present with my internal experience. I can't stand NOT scrolling in those moments. That's addiction: running from something, not toward something.
+**Magic = Hobby.** I love performing magic, but I'm not compelled to practice it. If I skip a week, I don't feel a pull. I do it because it [reinforces who I am](/hobby) — a maker of smiles and wonder — not because I can't stand not doing it. That absence of compulsion is exactly what makes it a hobby and not a passion.
 
-**Vibe Coding = Opportunity Cost**
+The test: if I had to stop right now, which feels like relief, which feels like loss, and which feels like nothing in particular? TikTok = relief. Vibe coding = loss. Magic = nothing in particular — and that's fine.
 
-When I'm in flow writing code, building something, solving a problem - I genuinely want to be doing it. I love it. I'm not escaping anything; I'm engaged in something meaningful. But the rest of my life suffers - I miss family time, skip workouts, stay up too late. That's opportunity cost: I'm choosing this over other things, and I need to weigh whether the trade-off is worth it.
-
-The test is simple: If I had to stop right now, which one would feel like relief and which would feel like loss? TikTok would be relief. Vibe coding would be loss.
-
-**The question to ask:** Am I doing this because I genuinely want to, or because I can't stand NOT doing it?
+**The question to ask:** Am I doing this because I genuinely want to, or because I can't stand NOT doing it — and either way, is the rest of my life better or worse for it?
 
 ## Current Addictions
 
@@ -91,7 +88,6 @@ I recently became aware of something subtle: my urge to scroll TikTok isn't abou
 When I sit down and have a moment of quiet, or when I finish one thing and before I start the next, there's this pull to open TikTok. Not because I want to watch content, but because I don't want to sit with whatever's on my mind. The scrolling gives me something external to focus on so I don't have to be present with my internal experience.
 
 This is textbook addiction as escape. I'm not seeking pleasure - I'm avoiding discomfort. The thing I'm escaping from isn't even necessarily bad thoughts or painful feelings. Sometimes it's just... thoughts. The act of having an inner mental life feels uncomfortable, so I scroll.
-
 
 ## Hypo Addictions
 
@@ -165,7 +161,7 @@ This comes and goes depending on how well/poorly work is going. But I used to be
 
 ### Work Addiction and Success Addiction
 
-Workaholism is one of the trickiest addictions because it looks productive. People praise you for it, you get promoted, you build things. But using the [addiction vs opportunity cost framework](#is-doing-the-thing-you-want-to-be-doing-an-addiction) helps clarify what's really happening.
+Workaholism is one of the trickiest addictions because it looks productive. People praise you for it, you get promoted, you build things. But using the [addiction/passion/hobby trichotomy](#is-doing-the-thing-you-want-to-be-doing-an-addiction) helps clarify what's really happening.
 
 **Signs it's addiction (not just hard work):**
 
@@ -175,14 +171,14 @@ Workaholism is one of the trickiest addictions because it looks productive. Peop
 - The rest of your life is suffering - relationships, health, hobbies all deteriorating
 - You feel "out of control" - you can't stop even when you know you should
 
-**When it's opportunity cost (not addiction):**
+**When it's passion (not addiction):**
 
 - You DO want to work on the problem - it's genuinely interesting
 - You're making conscious trade-offs about where to spend your time
 - You could stop if you chose to, you're just choosing not to
 - You're aware of what you're sacrificing and weighing whether it's worth it
 
-The test: Can you stop? If you genuinely can't stop working even when you want to, even when you know it's hurting you - that's addiction. If you can stop but choose not to because the work matters to you more than the alternatives right now - that's opportunity cost.
+The test: Can you stop? If you genuinely can't stop working even when you want to, even when you know it's hurting you - that's addiction. If you can stop but choose not to because the work matters to you more than the alternatives right now - that's passion (with an opportunity cost attached).
 
 **Success Addiction**
 
@@ -219,16 +215,18 @@ Perhaps, boredom is the [pain](/mental-pain) of lack of connection, and addictio
 
 Being addicted to flow and production sounds like a perfect hack. After all, isn't that the goal? Being productive?
 
-Not quite. The [addiction vs opportunity cost framework](#is-doing-the-thing-you-want-to-be-doing-an-addiction) applies here too:
+Not quite. The [addiction/passion/hobby trichotomy](#is-doing-the-thing-you-want-to-be-doing-an-addiction) applies here too:
 
 **Productive work as addiction:**
+
 - You're using productivity to escape emotional discomfort
 - You can't stop working even when you want to
 - You're "skipping the thing you should be doing" (family time, rest, addressing underlying issues) to stay busy
 - The work feels compulsive, not joyful
 - You're running from something, not toward something
 
-**Productive work as opportunity cost:**
+**Productive work as passion:**
+
 - You genuinely love the flow state and the work itself
 - You're making conscious trade-offs about time allocation
 - You could stop if you chose to

--- a/_d/hobby.md
+++ b/_d/hobby.md
@@ -8,6 +8,8 @@ redirect_from:
 
 Some days thinking about work makes me stressed, thinking of my family makes me resentful, and I don't want to feel like a sloth feeding my addictions to TikTok, and doom scrolling. Those days, I'm grateful for my hobbies. This post gives you reasons to find a hobby and teaches you the attributes in an ideal hobby: Being accessible, Supporting mastery, Reinforcing your identity, and building relationships.
 
+A hobby isn't a [passion](/addiction#is-doing-the-thing-you-want-to-be-doing-an-addiction) and it isn't an [addiction](/addiction). The test is compulsion: with a passion or an addiction, you can't stand NOT doing it; with a hobby, you can put it down without feeling pulled back. That absence of compulsion is exactly the feature — your hobby stays a refuge instead of becoming another thing running you.
+
 <!--
 Who is the audience?
 * People struggling to find a new hobby

--- a/back-links.json
+++ b/back-links.json
@@ -667,13 +667,13 @@
                 "/timeoff",
                 "/walking-with-god"
             ],
-            "last_modified": "2026-02-01T06:29:23-08:00",
+            "last_modified": "2026-05-01T15:01:26.354807+00:00",
             "markdown_path": "_d/addiction.md",
             "outgoing_links": [
                 "/activation",
                 "/covid",
-                "/elder",
                 "/mental-pain",
+                "/midlife",
                 "/mind-at-work"
             ],
             "redirect_url": "",
@@ -2344,7 +2344,6 @@
                 "/d/resistance",
                 "/energy-abundance",
                 "/four-healths",
-                "/hobby",
                 "/idle",
                 "/life-as-business",
                 "/manager-book",
@@ -2665,7 +2664,6 @@
             "file_path": "_site/elder.html",
             "incoming_links": [
                 "/40yo",
-                "/addiction",
                 "/spiritual-health"
             ],
             "last_modified": "2026-01-25T16:42:46-08:00",
@@ -3559,11 +3557,11 @@
                 "/operating-manual",
                 "/retire"
             ],
-            "last_modified": "2025-12-07T03:09:30+00:00",
+            "last_modified": "2026-05-01T15:01:26.354807+00:00",
             "markdown_path": "_d/hobby.md",
             "outgoing_links": [
-                "/d/habits",
                 "/eulogy",
+                "/habits",
                 "/happy",
                 "/joy",
                 "/magic",


### PR DESCRIPTION
## Summary

Promote the existing 2-way framing in `/addiction` (Addiction vs Opportunity Cost) to a 3-way **trichotomy**:

- **Addiction** — compelled, AND it negatively impacts your life
- **Passion** — compelled, but neutral or positive
- **Hobby** — not compelled

Two questions sort an activity: am I compelled to do this, and is the rest of my life better or worse for it?

## What changed

**`_d/addiction.md`** — replaced the 2-way framing in place (distill, don't accrete). Re-anchored the existing examples and added a third:

- TikTok = **Addiction** (compulsion + negative)
- Vibe Coding = **Passion** (compulsion + positive — opportunity cost is now folded into "passion has a price tag")
- Magic = **Hobby** (no compulsion — and that's the feature)

Downstream references (Workaholism section, productivity section) now use "passion" instead of "opportunity cost" where appropriate, and the cross-link text reads "addiction/passion/hobby trichotomy".

**`_d/hobby.md`** — added a short framing block (3 sentences) right after the opening paragraph, distinguishing hobby from passion and addiction by the compulsion test, with a link back to `/addiction`. Absorbed into the existing flow rather than a new section.

## Source

Sourced via Telegram today (May 1, 2026) — Igor's framing.

## Test plan

- [x] `./anchor_checker.py _d/addiction.md _d/hobby.md` — "All links valid!"
- [x] All other pre-commit hooks (prettier, ruff, biome, lychee, fast tests) pass on the changed files
- [x] Cross-links round-trip: `/addiction#is-doing-the-thing-you-want-to-be-doing-an-addiction` resolves; `/hobby` resolves; `/satisfaction` resolves
- [ ] Visual sanity check on rendered pages

## Notes

The repo-wide anchor-checker reported 7 pre-existing broken anchors in unrelated files (`ai-operator.md`, `hill-climbing.md`, `larry.md`, `money.md`, `taxes.md`) — verified to exist on `main` before my changes via `git stash` + re-run. Those are stale `_site/*.html` issues from a broken Jekyll build environment, not regressions from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured the addiction classification framework to distinguish between addiction, passion, and hobby based on compulsion and life impact criteria
  * Updated definitions and examples for clarity across all three categories
  * Refreshed internal navigation links to reflect content reorganization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->