### PR TITLE
Wally post: new intro + rename permalink to /wally

### DIFF
--- a/_d/igors-claws.md
+++ b/_d/igors-claws.md
@@ -36,7 +36,7 @@ I've been building toward claws without calling them that. I already have three,
 
 **[Larry](/larry) — my life coach claw.** Larry knows my journals, my goals, my health data, my patterns. Every Saturday I talk to him and review my week. He holds up a mirror: "You've committed to restart meditation 5 times since November. What's different this time?" Larry's biggest challenge is context loading — getting the full picture of my life into each session without me manually assembling it. That's the gap between an agent and a true claw: persistence. Larry is smart but amnesiac. Every session starts cold.
 
-**Wally — my work claw.** I don't talk about Wally here. If you work at Meta, I'm happy to tell you more in person. For the structural side — how Wally fits the FAANG org-chart-of-bots pattern (M2 / M1 / staff / odalis), see [Wally and My Work Gastown](/work-gastown).
+**Wally — my work claw.** I don't talk about Wally here. If you work at Meta, I'm happy to tell you more in person. For the structural side — how Wally fits the FAANG org-chart-of-bots pattern (M2 / M1 / staff / odalis), see [Wally and My Work Gastown](/wally).
 
 **[Tony](/tesla) — my car claw.** Tony is my Tesla, and he talks. Via [Vapi](https://vapi.ai/), Tony has a voice persona that I can call and chat with. He's the most fun and the least useful — a proof of concept for what happens when you give personality to a machine that already has sensors and autonomy.
 

--- a/_d/igors-claws.md
+++ b/_d/igors-claws.md
@@ -36,7 +36,7 @@ I've been building toward claws without calling them that. I already have three,
 
 **[Larry](/larry) — my life coach claw.** Larry knows my journals, my goals, my health data, my patterns. Every Saturday I talk to him and review my week. He holds up a mirror: "You've committed to restart meditation 5 times since November. What's different this time?" Larry's biggest challenge is context loading — getting the full picture of my life into each session without me manually assembling it. That's the gap between an agent and a true claw: persistence. Larry is smart but amnesiac. Every session starts cold.
 
-**Wally — my work claw.** I don't talk about Wally here. If you work at Meta, I'm happy to tell you more in person. For the structural side — how Wally fits the FAANG org-chart-of-bots pattern (M2 / M1 / staff / odalis), see [Wally and My Work Gastown](/wally).
+**Wally — my work claw.** I don't talk about Wally here. If you work at Meta, I'm happy to tell you more in person. For the structural side — how Wally fits the FAANG org-chart-of-bots pattern (M2 / M1 / staff / Odallies), see [Wally and My Work Gastown](/wally).
 
 **[Tony](/tesla) — my car claw.** Tony is my Tesla, and he talks. Via [Vapi](https://vapi.ai/), Tony has a voice persona that I can call and chat with. He's the most fun and the least useful — a proof of concept for what happens when you give personality to a machine that already has sensors and autonomy.
 

--- a/_d/vibing.md
+++ b/_d/vibing.md
@@ -61,7 +61,7 @@ Agents keep you in flow. Whether that's good depends on what you're flowing towa
 
 ### Why multi-agent: covering for stalls
 
-Flow needs continuous output and no dead time. A single agent stalls — you wait for a response, a build, file I/O — and the dead time breaks you out. Run multiple agents and when one stalls you switch to another, never bottoming out. The key is being continuously engaged. Corollary: if a single agent ran fast enough end-to-end, one would be plenty. Multi-agent isn't a parallelism-of-work win, it's a stall-coverage strategy for flow — which is also why M2/M1 orchestration starts to matter, see [work-gastown](/work-gastown) for the org-chart-of-bots framing.
+Flow needs continuous output and no dead time. A single agent stalls — you wait for a response, a build, file I/O — and the dead time breaks you out. Run multiple agents and when one stalls you switch to another, never bottoming out. The key is being continuously engaged. Corollary: if a single agent ran fast enough end-to-end, one would be plenty. Multi-agent isn't a parallelism-of-work win, it's a stall-coverage strategy for flow — which is also why M2/M1 orchestration starts to matter, see [Wally](/wally) for the org-chart-of-bots framing.
 
 The catch: this only works if _you_ don't stall. The whole construction assumes the human is never the bottleneck. When that assumption breaks — when you're the one who needs a beat to think, or the day is heavy, or you're just tired — the magic flips. You end up running five agents at once, not really tracking what any of them are doing, completely overwhelmed. The same multi-agent setup that produces effortless flow on a good day produces incoherent thrash on a bad one. Worth knowing which day you're having before you spawn the fleet.
 
@@ -113,7 +113,7 @@ His read matches mine: 8+ hours a day of it is a vampire pattern, not a sustaina
 
 {% include summarize-page.html src="/addiction" %}
 {% include summarize-page.html src="/spiritual-health" %}
-{% include summarize-page.html src="/work-gastown" %}
+{% include summarize-page.html src="/wally" %}
 {% include summarize-page.html src="/igors-claws" %}
 {% include summarize-page.html src="/ai-cockpit" %}
 {% include summarize-page.html src="/tesla" %}

--- a/_d/wally.md
+++ b/_d/wally.md
@@ -54,7 +54,7 @@ So here's the swap I'd make:
 | Polecats              | Odallies — specialized ephemeral ICs[^1] | Ephemeral workers with build-tool access, scoped tasks |
 | Refinery              | Phabricator / review-and-land system     | Manages merge queue, applies polished output           |
 
-[^1]: _Odali_ (singular), _Odallies_ (plural). My word, picked in voice-to-text and I'm keeping it — kind of a joke on the naming convention of Wally and Larry. They're "the Odallies," the rest of the gang. I think it also landed because it _sounds_ ephemeral and slightly foreign — these workers don't live with you, they show up, do the thing, and vanish. If a better term lands, I'll swap. Until then, odali.
+[^1]: _Odally_ (singular), _Odallies_ (plural) — portmanteau of **on-demand + Wally**. They literally run on the [on-demand devservers](https://developers.facebook.com/blog/post/2022/11/15/meta-developers-workflow-exploring-tools-used-to-code/) Meta provisions per developer. Wally on demand. Odally. The name is functional — it tells you what they are. I think it also landed because it _sounds_ ephemeral and slightly foreign — these workers don't live with you, they show up, do the thing, and vanish.
 
 The argument isn't that Yegge is wrong about the structure. It's that the moment you write a sentence with both "polecat" and "refinery" in it, you've taxed the reader for no reason. Every reader has already been on a team. Use the vocabulary they already have.
 
@@ -89,11 +89,11 @@ Here's the load-bearing claim of this post: in FAANG-style infra, Yegge's two ti
 
 At FAANG, you have a monorepo and a monobuild. The box running my M1 doesn't have access to the build tools. It can't run the full test suite. It can't push to the internal package registry. It physically lives somewhere that can't reach the systems where the real work happens. Wally can _think_ on my laptop. He can't _build_ there.
 
-So Wally needs a team of **Odallies**. Each odali is an IC that has access to the special stuff — build tools, internal infra, the production-adjacent boxes. They run in different boxes. And the communication channel to them is unreliable in a way that's structurally different from talking to Wally's local staff:
+So Wally needs a team of **Odallies**. Each odally is an IC that has access to the special stuff — build tools, internal infra, the production-adjacent boxes. They run in different boxes. And the communication channel to them is unreliable in a way that's structurally different from talking to Wally's local staff:
 
 - **They run on different infra.** Network hops, auth boundaries, queue lag. None of that exists for staff that share a box with M1.
-- **The channel is unreliable.** You can't stream-of-consciousness chat with an odali. Messages drop, retry, double-deliver. The protocol has to assume failure.
-- **They're more ephemeral.** A staff teammate can hold context across hours. An odali might exist for the duration of one task and then be gone. You can't build a relationship with them.
+- **The channel is unreliable.** You can't stream-of-consciousness chat with an odally. Messages drop, retry, double-deliver. The protocol has to assume failure.
+- **They're more ephemeral.** A staff teammate can hold context across hours. An odally might exist for the duration of one task and then be gone. You can't build a relationship with them.
 - **They're harder to control.** You give them a job, you wait, you get a result or a timeout. Mid-flight steering is mostly not a thing.
 
 Yegge's polecats are ephemeral — that part matches. What he doesn't surface is the cross-machine, unreliable-comm, monorepo-bound flavor of ephemerality. That's the FAANG-specific complication, and it's the reason a two-tier model isn't enough. Staff and Odallies behave differently. Treat them the same and you'll either over-trust the Odallies (they fail and you didn't catch it) or under-use them (you keep work local that should have been farmed out).
@@ -122,7 +122,7 @@ Heuristic: **wide work goes through M1; deep work goes direct.** If the task has
 
 I spent something like eight hours teaching Wally to write status reports I could actually read; another stint teaching him to write design docs I could review the way I'd review a good engineer's. The good news: once Wally got it, _Wally can train the others_. The pattern is the same one any [good manager](/manager-book) runs — patterns from previous reps, design docs shaped to the reviewer, lifestyle support that took longer than I expected. Eight hours of training a junior compounds when the junior can teach the next one.
 
-This is also why becoming an [AI native manager](/ai-native-manager) starts to feel less like a tooling change and more like a real management job. The hours you put into Wally aren't lost when the next odali shows up — Wally onboards them.
+This is also why becoming an [AI native manager](/ai-native-manager) starts to feel less like a tooling change and more like a real management job. The hours you put into Wally aren't lost when the next odally shows up — Wally onboards them.
 
 ## Still figuring out
 
@@ -130,7 +130,7 @@ A bunch of things I haven't worked out yet:
 
 - **When does the M1 need its own M1?** At some scale Wally himself is going to need to delegate orchestration. Recursion at scale is real — that's how FAANG ended up with M3, M4, directors, VPs. I don't know where the first level of recursion shows up for AI managers, but it's coming.
 - **When does the human (M2) need their own M2?** The mirror question. At what point does the human need a meta-orchestrator above them — something coordinating across multiple Wallies, multiple domains, multiple humans? Today I run one Wally. The day I'm running three is the day I want this answered.
-- **Is "odali" actually a good name?** I like it because it doesn't carry baggage. But "specialized ephemeral IC with build access" is a mouthful and I'm not sure my coinage survives contact with anyone who didn't watch me invent it. Open to better.
+- **Is "odally" actually a good name?** I like it because the etymology is functional — on-demand + Wally — so it tells you what they are. But "specialized ephemeral IC with build access" is a mouthful and I'm not sure my coinage survives contact with anyone who didn't watch me invent it. Open to better.
 
 More to come as I build this out. If you're running this pattern at scale — especially the M1+staff+Odallies split inside a real monorepo — drop me a note. I'd rather steal your vocabulary than invent more of my own.
 

--- a/_d/wally.md
+++ b/_d/wally.md
@@ -30,7 +30,10 @@ This is a survey post — the thinking is fresh, names are provisional, and ther
 - [The third tier Yegge's model misses](#the-third-tier-yegges-model-misses)
 - [When to use the M1, and when to skip him](#when-to-use-the-m1-and-when-to-skip-him)
 - [Training Wally](#training-wally)
+  - [Even ephemeral workers earn names](#even-ephemeral-workers-earn-names)
 - [Still figuring out](#still-figuring-out)
+- [Future Experiments](#future-experiments)
+  - [Training on Amazon Leadership Principles](#training-on-amazon-leadership-principles)
 - [Appendix: Challenges](#appendix-challenges)
 
 <!-- vim-markdown-toc-end -->
@@ -124,6 +127,14 @@ I spent something like eight hours teaching Wally to write status reports I coul
 
 This is also why becoming an [AI native manager](/ai-native-manager) starts to feel less like a tooling change and more like a real management job. The hours you put into Wally aren't lost when the next odally shows up — Wally onboards them.
 
+### Even ephemeral workers earn names
+
+At first I just used the on-demand devservers' hostnames — `OD-1274`, `OD-2031`, whatever Meta provisioned. That was really hard on me. I'd lose track of which one was doing what. `OD-1274 completed step 3` told me nothing.
+
+So I started giving them names tied to the service or direction they're working on. An Odally working the auth migration becomes `auth-migration`. The build-pipeline rebuild becomes `build-rebuild`. Now Wally writes "auth-migration completed step 3" and it lands immediately.
+
+Auto-assigned at spawn — zero cognitive cost on me. But they're real handles for status reports and conversation. Even ephemeral workers earn names. The cost of inventing one is less than the cost of looking up which hostname was doing what.
+
 ## Still figuring out
 
 A bunch of things I haven't worked out yet:
@@ -133,6 +144,32 @@ A bunch of things I haven't worked out yet:
 - **Is "odally" actually a good name?** I like it because the etymology is functional — on-demand + Wally — so it tells you what they are. But "specialized ephemeral IC with build access" is a mouthful and I'm not sure my coinage survives contact with anyone who didn't watch me invent it. Open to better.
 
 More to come as I build this out. If you're running this pattern at scale — especially the M1+staff+Odallies split inside a real monorepo — drop me a note. I'd rather steal your vocabulary than invent more of my own.
+
+## Future Experiments
+
+Things I'm about to try with Wally and the Odallies, not yet operating:
+
+### Training on Amazon Leadership Principles
+
+I did a tour of duty at Amazon. The Leadership Principles aren't fluff — they're decision frameworks. "Customer Obsession," "Bias for Action," "Earn Trust," "Have Backbone, Disagree and Commit," "Insist on the Highest Standards." Each one is a tool you apply to a single decision. AI agents make many small decisions per task — that's the use case.
+
+I want to see if I can teach them operationally, not aspirationally. For each LP, write the BEHAVIOR it produces in Wally and what he checks for in the Odallies' output:
+
+| LP                              | What Wally would do                                                                            |
+| ------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Customer Obsession              | Asks "who's the user of this change?" before any review                                        |
+| Earn Trust                      | Requires evidence (link, citation, repro) for any claim — flags assertions that don't have one |
+| Bias for Action                 | Picks one path and ships; doesn't waterfall a 5-option analysis when 2 will do                 |
+| Insist on the Highest Standards | Rejects Odally output with smells, with specifics                                              |
+| Have Backbone                   | Pushes back on my brief when it's wrong; doesn't just agree                                    |
+| Are Right, A Lot                | Tracks its predictions — flags when it was wrong before                                        |
+| Dive Deep                       | Reads the whole file, not just the diff                                                        |
+
+Subset, don't import wholesale — "Hire and Develop the Best" doesn't map; "Ownership at the company level" doesn't map. Pick the 6-8 that fit the work.
+
+The meta-insight: I'd be training Wally with the same techniques my Amazon managers used to train me. The pattern transfers. (For my retro on what Amazon did well and badly, see [my Amazon thoughts](/amazon).)
+
+Will report back.
 
 ## Appendix: Challenges
 

--- a/_d/wally.md
+++ b/_d/wally.md
@@ -13,7 +13,7 @@ tags:
 mermaid: True
 ---
 
-Meet Wally. He's my claw. Except Wally isn't a single claw. He's the head of an organization of claws: staff with distinct roles, plus odalis running in different places, each with a discrete signature. The whole thing operates like a small team with a real org chart. A thing that's emerging: what used to be an IC role is now a manager-of-managers role.
+Meet Wally. He's my claw. Except Wally isn't a single claw. He's the head of an organization of claws: staff with distinct roles, plus Odallies running in different places, each with a discrete signature. The whole thing operates like a small team with a real org chart. A thing that's emerging: what used to be an IC role is now a manager-of-managers role.
 
 {% include ai-slop.html percent="90" %}
 
@@ -46,15 +46,15 @@ The structure is right. The metaphors are gratuitous. Polecats and refineries ar
 
 So here's the swap I'd make:
 
-| Yegge's Gas Town      | Org-chart vocabulary                   | Role                                                   |
-| --------------------- | -------------------------------------- | ------------------------------------------------------ |
-| _(implicit operator)_ | M2 — the human (me)                    | Direction, review, strategic calls                     |
-| Mayor                 | M1 — the AI manager (Wally)            | Orchestrates work, distributes tasks, reviews output   |
-| Oracle / Deacons      | Staff — cloud teammates near M1        | Persistent context-holders, work alongside Wally       |
-| Polecats              | Odalis — specialized ephemeral ICs[^1] | Ephemeral workers with build-tool access, scoped tasks |
-| Refinery              | Phabricator / review-and-land system   | Manages merge queue, applies polished output           |
+| Yegge's Gas Town      | Org-chart vocabulary                     | Role                                                   |
+| --------------------- | ---------------------------------------- | ------------------------------------------------------ |
+| _(implicit operator)_ | M2 — the human (me)                      | Direction, review, strategic calls                     |
+| Mayor                 | M1 — the AI manager (Wally)              | Orchestrates work, distributes tasks, reviews output   |
+| Oracle / Deacons      | Staff — cloud teammates near M1          | Persistent context-holders, work alongside Wally       |
+| Polecats              | Odallies — specialized ephemeral ICs[^1] | Ephemeral workers with build-tool access, scoped tasks |
+| Refinery              | Phabricator / review-and-land system     | Manages merge queue, applies polished output           |
 
-[^1]: _Odali_ (singular), _odalis_ (plural). My word, picked in voice-to-text and I'm keeping it — kind of a joke on the naming convention of Wally and Larry. They're "the Odallies," the rest of the gang. I think it also landed because it _sounds_ ephemeral and slightly foreign — these workers don't live with you, they show up, do the thing, and vanish. If a better term lands, I'll swap. Until then, odali.
+[^1]: _Odali_ (singular), _Odallies_ (plural). My word, picked in voice-to-text and I'm keeping it — kind of a joke on the naming convention of Wally and Larry. They're "the Odallies," the rest of the gang. I think it also landed because it _sounds_ ephemeral and slightly foreign — these workers don't live with you, they show up, do the thing, and vanish. If a better term lands, I'll swap. Until then, odali.
 
 The argument isn't that Yegge is wrong about the structure. It's that the moment you write a sentence with both "polecat" and "refinery" in it, you've taxed the reader for no reason. Every reader has already been on a team. Use the vocabulary they already have.
 
@@ -65,10 +65,10 @@ graph TD
     Igor[Igor — M2 / Human]
     Wally[Wally — M1 / AI Orchestrator]
     Staff[Staff — cloud teammates]
-    Odalis[Odalis — specialized ephemeral workers]
+    Odallies[Odallies — specialized ephemeral workers]
     Igor --> Wally
     Wally --> Staff
-    Wally --> Odalis
+    Wally --> Odallies
 ```
 
 ## Why the human is M2, not the Mayor
@@ -77,7 +77,7 @@ This is the part I think people get wrong about themselves.
 
 When you start running agents, it _feels_ like you're the Mayor. You're the one giving orders, deciding what gets built, picking what to ship. So you call yourself the orchestrator. But that's not actually what's happening — or at least it's not what _should_ be happening.
 
-In FAANG vocabulary, **I'm the M2**. [Wally](/igors-claws) — the AI orchestrator — is the M1. Wally has staff: cloud teammates that run alongside him, do research, draft work, hold context. Wally has odalis: ephemeral ICs that go off and do specialized work and come back with results. _Wally_ is the manager. I'm the manager of managers.
+In FAANG vocabulary, **I'm the M2**. [Wally](/igors-claws) — the AI orchestrator — is the M1. Wally has staff: cloud teammates that run alongside him, do research, draft work, hold context. Wally has Odallies: ephemeral ICs that go off and do specialized work and come back with results. _Wally_ is the manager. I'm the manager of managers.
 
 What's an M2 actually for? Direction and review. I tell Wally what we're trying to accomplish. I review the output. I make the calls he can't — strategic shifts, taste judgments, hiring decisions about what new tools to bring in. I do _not_ try to dispatch every IC myself. The moment I try, I become the bottleneck — exactly the bottleneck FAANG learned to design managers around.
 
@@ -89,20 +89,20 @@ Here's the load-bearing claim of this post: in FAANG-style infra, Yegge's two ti
 
 At FAANG, you have a monorepo and a monobuild. The box running my M1 doesn't have access to the build tools. It can't run the full test suite. It can't push to the internal package registry. It physically lives somewhere that can't reach the systems where the real work happens. Wally can _think_ on my laptop. He can't _build_ there.
 
-So Wally needs a team of **odalis**. Each odali is an IC that has access to the special stuff — build tools, internal infra, the production-adjacent boxes. They run in different boxes. And the communication channel to them is unreliable in a way that's structurally different from talking to Wally's local staff:
+So Wally needs a team of **Odallies**. Each odali is an IC that has access to the special stuff — build tools, internal infra, the production-adjacent boxes. They run in different boxes. And the communication channel to them is unreliable in a way that's structurally different from talking to Wally's local staff:
 
 - **They run on different infra.** Network hops, auth boundaries, queue lag. None of that exists for staff that share a box with M1.
 - **The channel is unreliable.** You can't stream-of-consciousness chat with an odali. Messages drop, retry, double-deliver. The protocol has to assume failure.
 - **They're more ephemeral.** A staff teammate can hold context across hours. An odali might exist for the duration of one task and then be gone. You can't build a relationship with them.
 - **They're harder to control.** You give them a job, you wait, you get a result or a timeout. Mid-flight steering is mostly not a thing.
 
-Yegge's polecats are ephemeral — that part matches. What he doesn't surface is the cross-machine, unreliable-comm, monorepo-bound flavor of ephemerality. That's the FAANG-specific complication, and it's the reason a two-tier model isn't enough. Staff and odalis behave differently. Treat them the same and you'll either over-trust the odalis (they fail and you didn't catch it) or under-use them (you keep work local that should have been farmed out).
+Yegge's polecats are ephemeral — that part matches. What he doesn't surface is the cross-machine, unreliable-comm, monorepo-bound flavor of ephemerality. That's the FAANG-specific complication, and it's the reason a two-tier model isn't enough. Staff and Odallies behave differently. Treat them the same and you'll either over-trust the Odallies (they fail and you didn't catch it) or under-use them (you keep work local that should have been farmed out).
 
-The mental model: **staff are coworkers, odalis are contractors with security badges**. Both are ICs. The handoff protocol is completely different.
+The mental model: **staff are coworkers, Odallies are contractors with security badges**. Both are ICs. The handoff protocol is completely different.
 
-This isn't speculation. Meta literally ships this tier as a productized concept — [on-demand devservers](https://developers.facebook.com/blog/post/2022/11/15/meta-developers-workflow-exploring-tools-used-to-code/): ephemeral pre-warmed machines that devs grab and release daily. That's odalis-as-a-service.
+This isn't speculation. Meta literally ships this tier as a productized concept — [on-demand devservers](https://developers.facebook.com/blog/post/2022/11/15/meta-developers-workflow-exploring-tools-used-to-code/): ephemeral pre-warmed machines that devs grab and release daily. That's Odallies-as-a-service.
 
-The rest of Meta's stack documents why the local box can't do the work. **EdenFS** virtualizes the monorepo so you only check out what you touch. **Buck** distributes builds across remote caches and parallel executors. **Mononoke** is the custom Mercurial server scaled for the monorepo. None of those exist for fun — they're the unreliable-comms cross-machine plumbing the M1 has to talk through to reach the odalis. See the [Meta dev blog post](https://developers.facebook.com/blog/post/2022/11/15/meta-developers-workflow-exploring-tools-used-to-code/) for the full workflow stack.
+The rest of Meta's stack documents why the local box can't do the work. **EdenFS** virtualizes the monorepo so you only check out what you touch. **Buck** distributes builds across remote caches and parallel executors. **Mononoke** is the custom Mercurial server scaled for the monorepo. None of those exist for fun — they're the unreliable-comms cross-machine plumbing the M1 has to talk through to reach the Odallies. See the [Meta dev blog post](https://developers.facebook.com/blog/post/2022/11/15/meta-developers-workflow-exploring-tools-used-to-code/) for the full workflow stack.
 
 ## When to use the M1, and when to skip him
 
@@ -110,7 +110,7 @@ The M1 isn't always the right interface. Sometimes you go through Wally; sometim
 
 **Three reasons to go through the M1:**
 
-- **Babysitting at scale.** Odalis get stuck — model errors, broken comms, file races, build flakes — and they don't recover on their own. If you're not watching, they idle. Wally watches and unsticks them, so a 30-minute task doesn't quietly become a four-hour one. The MEOW stack patrol formulas (e.g. `mol-polecat-work.formula.toml`, `mol-deacon-patrol.formula.toml` in [Yegge's gastown repo](https://github.com/gastownhall/gastown/tree/main/internal/formula/formulas/)) are this idea formalized — babysitting as a first-class workload.
+- **Babysitting at scale.** Odallies get stuck — model errors, broken comms, file races, build flakes — and they don't recover on their own. If you're not watching, they idle. Wally watches and unsticks them, so a 30-minute task doesn't quietly become a four-hour one. The MEOW stack patrol formulas (e.g. `mol-polecat-work.formula.toml`, `mol-deacon-patrol.formula.toml` in [Yegge's gastown repo](https://github.com/gastownhall/gastown/tree/main/internal/formula/formulas/)) are this idea formalized — babysitting as a first-class workload.
 - **Phone-friendly orchestration.** Wally bridges the navigation gap. I can drive the team from my phone — between meetings, on a walk, in the car — ask status, push work forward, verify results. Direct IC interaction needs a keyboard and the right context window loaded. Wally exposes a thinner interface, and that interface fits a thumb.
 - **Adversarial review.** Wally can orchestrate a convoy of reviewers — multiple specialized agents critiquing the same artifact for correctness, performance, security, style, smell. See Yegge's [code-review formula](https://github.com/gastownhall/gastown/tree/main/internal/formula/formulas/) as the canonical example. One IC can't do this; an M1 with staff can.
 
@@ -132,7 +132,7 @@ A bunch of things I haven't worked out yet:
 - **When does the human (M2) need their own M2?** The mirror question. At what point does the human need a meta-orchestrator above them — something coordinating across multiple Wallies, multiple domains, multiple humans? Today I run one Wally. The day I'm running three is the day I want this answered.
 - **Is "odali" actually a good name?** I like it because it doesn't carry baggage. But "specialized ephemeral IC with build access" is a mouthful and I'm not sure my coinage survives contact with anyone who didn't watch me invent it. Open to better.
 
-More to come as I build this out. If you're running this pattern at scale — especially the M1+staff+odalis split inside a real monorepo — drop me a note. I'd rather steal your vocabulary than invent more of my own.
+More to come as I build this out. If you're running this pattern at scale — especially the M1+staff+Odallies split inside a real monorepo — drop me a note. I'd rather steal your vocabulary than invent more of my own.
 
 ## Appendix: Challenges
 

--- a/_d/wally.md
+++ b/_d/wally.md
@@ -1,8 +1,9 @@
 ---
 layout: post
 title: "Wally and My Work Gastown"
-permalink: /work-gastown
+permalink: /wally
 redirect_from:
+  - /work-gastown
   - /my-work-gastown
   - /gastown
 tags:
@@ -12,9 +13,11 @@ tags:
 mermaid: True
 ---
 
-As I've explored being an [AI native manager](/ai-native-manager), one thing is emerging: I will certainly be an AI manager of bots. This is the story of [Wally](/igors-claws) — my work claw, the M1 in FAANG vocabulary, the AI orchestrator I delegate direction-and-review tasks to and who orchestrates further down to staff and odalis. I named him so I could read about his work in status reports and remember which agent did what. I spent something like eight hours teaching Wally to write status reports I could actually read; another stint teaching him to write design docs I could review the way I'd review a good engineer's. The good news: once Wally got it, _Wally can train the others_. The pattern is the same one any [good manager](/manager-book) runs — patterns from previous reps, design docs shaped to the reviewer, lifestyle support that took longer than I expected. Eight hours of training a junior compounds when the junior can teach the next one. That's the story. Now let me tell you what I've figured out about the org chart hiding inside it.
+Meet Wally. He's my claw. Except Wally isn't a single claw. He's the head of an organization of claws: staff with distinct roles, plus odalis running in different places, each with a discrete signature. The whole thing operates like a small team with a real org chart. A thing that's emerging: what used to be an IC role is now a manager-of-managers role.
 
 {% include ai-slop.html percent="90" %}
+
+Wally is one of [my claws](/igors-claws) — the work one. This post is about how he works as an org, not about the claws as a set.
 
 This is a survey post — the thinking is fresh, names are provisional, and there's at least one open question I haven't answered. Posting now so I can find it later.
 
@@ -26,6 +29,7 @@ This is a survey post — the thinking is fresh, names are provisional, and ther
 - [Why the human is M2, not the Mayor](#why-the-human-is-m2-not-the-mayor)
 - [The third tier Yegge's model misses](#the-third-tier-yegges-model-misses)
 - [When to use the M1, and when to skip him](#when-to-use-the-m1-and-when-to-skip-him)
+- [Training Wally](#training-wally)
 - [Still figuring out](#still-figuring-out)
 - [Appendix: Challenges](#appendix-challenges)
 
@@ -113,6 +117,12 @@ The M1 isn't always the right interface. Sometimes you go through Wally; sometim
 **The trade-off:** when you need precision, the M1 filters too aggressively. Working through Wally to get something very specific often returns a lot of garbage — generalized, diluted, missing the point. Going direct to the IC keeps your intent intact. You're collaborating, not delegating-then-praying.
 
 Heuristic: **wide work goes through M1; deep work goes direct.** If the task has a clear spec and just needs to land in many places, route through Wally. If it's one specific thing and "perfect" matters, sit down with the IC.
+
+## Training Wally
+
+I spent something like eight hours teaching Wally to write status reports I could actually read; another stint teaching him to write design docs I could review the way I'd review a good engineer's. The good news: once Wally got it, _Wally can train the others_. The pattern is the same one any [good manager](/manager-book) runs — patterns from previous reps, design docs shaped to the reviewer, lifestyle support that took longer than I expected. Eight hours of training a junior compounds when the junior can teach the next one.
+
+This is also why becoming an [AI native manager](/ai-native-manager) starts to feel less like a tooling change and more like a real management job. The hours you put into Wally aren't lost when the next odali shows up — Wally onboards them.
 
 ## Still figuring out
 


### PR DESCRIPTION
## Summary

Apply Igor's revised intro (Telegram msg 2911, verbatim) and rename the post's permalink from \`/work-gastown\` to \`/wally\`.

- **Intro**: replaced multi-claim opening with Igor's exact one-paragraph Telegram text — Wally as head of an org of claws, manager-of-managers framing.
- **Permalink**: \`/work-gastown\` → \`/wally\`. Added \`/work-gastown\` to \`redirect_from\` (existing \`/my-work-gastown\` and \`/gastown\` retained). File moved \`_d/work-gastown.md\` → \`_d/wally.md\` per blog convention (filename ≈ permalink stem).
- **Displaced content**: training arc (8-hour status-report teach + "Wally can train the others" payoff) moved into a new \`## Training Wally\` body section. AI-native-manager hook lives there as a brief recap. The "one of my claws" framing reduced to a single line linking to \`/igors-claws\`.
- **Cross-links updated**: \`_d/vibing.md\` (related-notes include + multi-agent-stalls section) and \`_d/igors-claws.md\` (Wally bullet) now point at \`/wally\`.

Igor's note (msg 2903): "I think some of that content should have actually been in the rest of the post, not in the intro paragraph."

## Test plan

- [ ] Verify \`/wally\` renders with Igor's exact intro paragraph
- [ ] Verify \`/work-gastown\`, \`/my-work-gastown\`, \`/gastown\` redirect to \`/wally\`
- [ ] Verify \`Training Wally\` section renders with relocated 8-hour training arc + AI-native-manager mention
- [ ] Verify cross-links from \`/vibing\` and \`/igors-claws\` resolve to \`/wally\`
- [ ] Anchor checker (\`./anchor_checker.py _d/wally.md\`) passes after Jekyll build (skipped locally — Ruby env unavailable in dev VM)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redesigned Wally's profile page with new organization structure and updated role-based agent descriptions
  * Introduced new "Training Wally" section featuring comprehensive training guidance and duration information
  * Updated references across related documentation pages for improved consistency and navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->