### PR TITLE
wally: add public column to mapping table (Ammon feedback)

### DIFF
--- a/_d/wally.md
+++ b/_d/wally.md
@@ -49,13 +49,13 @@ The structure is right. The metaphors are gratuitous. Polecats and refineries ar
 
 So here's the swap I'd make:
 
-| Yegge's Gas Town      | Org-chart vocabulary                     | Role                                                   |
-| --------------------- | ---------------------------------------- | ------------------------------------------------------ |
-| _(implicit operator)_ | M2 — the human (me)                      | Direction, review, strategic calls                     |
-| Mayor                 | M1 — the AI manager (Wally)              | Orchestrates work, distributes tasks, reviews output   |
-| Oracle / Deacons      | Staff — cloud teammates near M1          | Persistent context-holders, work alongside Wally       |
-| Polecats              | Odallies — specialized ephemeral ICs[^1] | Ephemeral workers with build-tool access, scoped tasks |
-| Refinery              | Phabricator / review-and-land system     | Manages merge queue, applies polished output           |
+| Yegge's Gas Town      | Meta vocabulary                          | Public / open-source equivalent  | Role                                                   |
+| --------------------- | ---------------------------------------- | -------------------------------- | ------------------------------------------------------ |
+| _(implicit operator)_ | M2 — the human (me)                      | —                                | Direction, review, strategic calls                     |
+| Mayor                 | M1 — the AI manager (Wally)              | (no clean public equivalent yet) | Orchestrates work, distributes tasks, reviews output   |
+| Oracle / Deacons      | Staff — cloud teammates near M1          | Background agents / Codex        | Persistent context-holders, work alongside Wally       |
+| Polecats              | Odallies — specialized ephemeral ICs[^1] | EC2 / cloud VM                   | Ephemeral workers with build-tool access, scoped tasks |
+| Refinery              | Phabricator / review-and-land system     | GitHub / GitLab + CI             | Manages merge queue, applies polished output           |
 
 [^1]: _Odally_ (singular), _Odallies_ (plural) — portmanteau of **on-demand + Wally**. They literally run on the [on-demand devservers](https://developers.facebook.com/blog/post/2022/11/15/meta-developers-workflow-exploring-tools-used-to-code/) Meta provisions per developer. Wally on demand. Odally. The name is functional — it tells you what they are. I think it also landed because it _sounds_ ephemeral and slightly foreign — these workers don't live with you, they show up, do the thing, and vanish.
 


### PR DESCRIPTION
## Summary

Address reader feedback from Ammon on the [Wally post](https://idvork.in/wally) (PR #590).

Ammon: _"I like that to make it easier to understand you swapped two words I don't know (polecats and refinery) with two other words I don't know (Odallies and Phabricator). Perhaps use the public words in the table as well, github and ec2 cloud vm"_

He's right. The two-column mapping translated Yegge jargon into Meta jargon — both insider. Adds a third column with public/open-source equivalents:

- **Polecats / Odallies → EC2 / cloud VM** — ephemeral on-demand compute
- **Refinery / Phabricator → GitHub / GitLab + CI** — code review + merge queue
- **Oracle / Staff → Background agents / Codex** — persistent cloud teammates
- **Mayor / M1 (Wally) → "(no clean public equivalent yet)"** — orchestrator agent doesn't have a recognizable public-world name yet
- **(implicit operator) / M2** → "—" (the human; no equivalent needed)

Renamed the second column header from "Org-chart vocabulary" to "Meta vocabulary" since that's what it actually is, and the third column now carries the org-chart-agnostic public terms.

## Test plan

- [ ] Visual check that the four-column table renders cleanly on /wally
- [ ] No prose around the table assumed "two columns" (verified — none did)
- [ ] Pre-commit anchor-checker errors are pre-existing on main (verified by checking out main's wally.md and running the hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced vocabulary reference documentation with improved table structure to include public and open-source equivalent terminology, providing clearer mapping between internal and external role definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->