### PR TITLE
Vibe Coding Eats Your Voice: voice-strain post

### DIFF
--- a/_d/voice-strain.md
+++ b/_d/voice-strain.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title: "Vibe Coding Eats Your Voice"
+permalink: /voice-strain
+tags:
+  - ai
+  - tools
+  - health
+  - voice
+---
+
+Voice vibe coding gave me 1:1-day-throat. Here's what I noticed.
+
+Three days of intense [voice-driven AI work](/ai-operator#you-need-to-use-voice) — sustained dictation, mic always live, monologuing at agents the way I used to monologue at people in meetings. By Sunday afternoon my throat was wrecked. I haven't felt this kind of wrecked in years, and the funny part is I knew the exact failure mode the second it landed. I just didn't expect it _here_.
+
+{% include ai-slop.html percent="80" %}
+
+## Same Body, Different Surface
+
+Back when my calendar was a wall of one-on-ones — five, six, seven stacked back-to-back, no buffer — I'd hit Friday afternoon hoarse. Talking is a load. Sustained talking is a _body_ load, and the cord that pays the bill is the same one whether you're talking _to_ a person or _at_ a model.
+
+The voice vibe coding setup looks ergonomic. I'm sitting comfortably. The mic ([Hollyland Lark M2S](https://www.amazon.com/dp/B0DNQ5D1H4)) clips sub-clavicle — no headset, no posture cost. I'm not typing. My hands feel great.
+
+{% include amazon.html asin="B0DNQ5D1H4" tag="ighe-20" %}
+
+But I'm _talking_. For hours. Same vocal load as a packed 1:1 day, except the calendar didn't warn me. There's no Outlook reminder that says "next session: hoarse." Voice tooling solves the typing-fatigue problem and, in the same motion, hands me a vocal-fatigue problem I wasn't watching for. The sub-clavicle mic actually makes it worse — you don't have to project, so you lose the natural feedback signal that tells you you're straining. The throat is doing the work; the body has stopped reporting on it. Who would have guessed it.
+
+## What I'm Doing About It
+
+A few small adjustments since Sunday:
+
+- **Water at the rig.** Same way you don't run a piano without humidity, don't dictate without water within reach.
+- **Warm up the cord.** Five minutes of humming, or talking through morning coffee, before the first long prompt. The mic is patient; my voice isn't.
+- **Type the small stuff.** A two-line correction doesn't need to be voiced. The mic is for thinking-out-loud passages, not "fix this typo."
+- **Throat rest between sessions.** Ten-minute gaps where I shut up. Same advice I'd give about wrist breaks on a heavy typing day.
+- **Alternate days.** Big voice days followed by quiet days. Treat the cord like any other muscle: reps, then recovery.
+
+## The Generalization
+
+Voice input is the right tool for sustained creative work — there's a reason I migrated. But sustained voice input is a body load like any other. Plan accordingly.
+
+The ergonomic surface of AI tooling extends past the keyboard. Nobody warned me; consider this the warning.


### PR DESCRIPTION
## Summary

New short post (`/voice-strain`) on the voice-fatigue failure mode of sustained voice vibe coding. Igor's lived discovery from the weekend: three days of intense voice dictation produced the same vocal-cord fatigue as a packed 1:1 day. The ergonomic surface of AI tooling extends past the keyboard.

- ~450 words, Igor first-person
- Cross-link to [/ai-operator#you-need-to-use-voice](/ai-operator#you-need-to-use-voice) for broader voice-input context
- Includes Hollyland Lark M2S amazon link via `{% include amazon.html asin="B0DNQ5D1H4" tag="ighe-20" %}`
- Permalink `/voice-strain`; tags `ai`, `tools`, `health`, `voice`

## Test plan

- [x] Permalink `/voice-strain` set
- [x] `ai-slop.html` placed AFTER first paragraph (Jekyll excerpt preserved)
- [x] Cross-link `/ai-operator#you-need-to-use-voice` matches `## You Need to Use Voice` heading at `_d/ai-operator.md:107`
- [x] Hollyland Lark M2S asin uses `tag="ighe-20"` per blog convention
- [x] `npx prettier --write` clean
- [ ] **CI to validate jekyll build + anchors** — local build broken on this VM (Ruby 4.0 / liquid 4.0.3 `tainted?` incompatibility, affects all posts equally)
- [ ] Igor preview at `/voice-strain` after merge

🤖 Drafted by `larry-blog/editor` polecat (bead lb-kds), reviewed by `larry-blog/reviewer` adversarial pass.