### PR TITLE
gas-city-home: backlinks rebuild + direct-managing-rigs aside (Igor follow-ups)

### DIFF
--- a/_d/gas-city-home.md
+++ b/_d/gas-city-home.md
@@ -107,6 +107,16 @@ The crew-versus-polecat distinction is one config knob. `mode = "always"` for cr
 
 Yegge puts the rule directly in the marketing post: **"You should almost never deploy a single-agent pack for a real business process."** Reliability scales with peer review. So treat reliability as a dial — high-stakes work pairs an editor and a reviewer; low-stakes work runs solo. You don't need Gas City to do this. You need the dial.
 
+### Honest aside: I'm direct-managing the rigs, not routing through Barry
+
+For accuracy: every sling that produced this post — `lb-t93` (draft), `lb-1at` (PR), `lb-7ix` (revision pass 1), `lb-1pt` (revision pass 2), `lb-kds` (the sibling voice-strain post that Igor asked for mid-thread) — went **directly to a rig polecat**, not through Barry the mayor. Igor caught the question:
+
+{% include alert.html content="**Igor (verbatim):** _Are you direct managing rigs? If so note that. ... Add not on Barry to: is double stacking agents a good idea? Not so sure._" style="warning" %}
+
+Honest answer: yes, I am. **For one-shot posts the mayor layer is overhead.** Barry would earn his keep when multiple beads compete for a rig and need triage, when a workflow chains across rigs (editor in `larry-blog` → image-curator in `blob` → publisher in `larry-blog`), or when dependencies need coordination beyond a single `gc sling`. None of that applied here. Adding Barry to the loop would be cargo-cult orchestration. Worth saying out loud rather than papering over.
+
+The mayor layer earns its place when the work is plural. For a draft → review → ship solo flow, editor + reviewer pair is sufficient.
+
 ---
 
 Once `igor-city` has run a few weekends without me having to nudge anything by hand, Barry steps down and I take the seat. Until then, Barry holds the keys, and I review what would make me ready for the job.

--- a/_d/gas-city-home.md
+++ b/_d/gas-city-home.md
@@ -78,6 +78,11 @@ Then the operational quirks that don't merit bug reports but do merit a Sunday m
 - **`systemctl --user` fails in OrbStack containers.** The supervisor falls back to manual mode, but the error looks scary. Worth knowing if you're running in a container.
 - **Stale Dolt servers accumulate.** Each rig has its own embedded Dolt. They don't always clean up if you cycle the supervisor. `pkill dolt` and restart if `gc supervisor logs` is reporting connection refused.
 - **`gc` shell-alias collision with oh-my-zsh's git plugin.** The git plugin aliases `gc` to `git commit`. Shadows the Gas City binary completely. Required a `~/.zshrc` patch to put the binary first on PATH-resolution.
+- **Backlinks rebuild after a new post.** I missed this on first ship — opened the PR, never ran `just update-backlinks`, the inbound "Mentioned in:" graph on cross-linked posts (`/wally`, `/larry`, `/ai-operator`) went stale. Igor caught it from the JCS parking lot.
+
+{% include alert.html content="**Igor (verbatim):** _I think you forgot to generate a back links update the agent with that send a PR actually update the post with that too. You can update the post to say you did this manually include my note._" style="warning" %}
+
+I rebuilt by hand (`just update-backlinks` from the larry-blog rig — 336 pages in 4.85 seconds), then patched the editor's `agent.toml` prompt to make the backlinks rebuild a mandatory step before any new-post PR opens. Pull request on `igor-city` is [#1](https://github.com/idvorkin-ai-tools/igor-city/pull/1). The next sling that creates a `_d/*.md` will hit the new step automatically. Lesson: **the agent's prompt is part of the system you maintain**. When you find a gap by hand, fix the prompt before you forget.
 
 Two universal lessons fall out of this list. **Scaffold first, customize second** — every minute spent reading docs before running tutorial 01 was a minute reverse-engineering the wrong abstraction. **Trust the runtime over the doctor** — every CLI I trust ships a `doctor` (`gc doctor`, `bd doctor`, `up-to-date diagnose`), and self-diagnostic is non-negotiable in a probabilistic stack. But the doctor reports on the schema; only the running process reports on the store. When they disagree, the running process is the one that ships.
 

--- a/back-links.json
+++ b/back-links.json
@@ -6,7 +6,6 @@
         "/24": "/y24",
         "/25": "/y25",
         "/26": "/y26",
-        "/3-claws": "/igors-claws",
         "/48-laws": "/laws-of-power",
         "/50yo": "/40yo",
         "/7h": "/7-habits",
@@ -115,7 +114,6 @@
         "/enemies": "/enemy",
         "/enjoy": "/happy",
         "/essential": "/essentialism",
-        "/eval-hill-climb": "/hill-climbing",
         "/exercise": "/physical-health",
         "/explorable-explanations": "/explainers",
         "/failure": "/fail",
@@ -133,7 +131,6 @@
         "/fuck-shame": "/shame",
         "/future-igor": "/time-traveler",
         "/future-self": "/time-traveler",
-        "/gastown": "/wally",
         "/genai-intern": "/genai-talk",
         "/getting-things-done": "/gtd",
         "/getting-to-yes": "/negotiate",
@@ -156,14 +153,12 @@
         "/heavy-club": "/kettlebell",
         "/heavy-clubs": "/kettlebell",
         "/high-energy": "/energy-abundance",
-        "/hillclimb": "/hill-climbing",
         "/hobbies": "/hobby",
         "/humanity": "/touching",
         "/hyper-personalization": "/hyper-personal",
         "/idle-loop": "/idle",
         "/igor-chop": "/how-igor-chops",
         "/igor-gap-year": "/gap-year-igor",
-        "/igorsclaws": "/igors-claws",
         "/iina": "/vlc",
         "/imposter": "/insecure",
         "/in-real-life": "/irl",
@@ -213,7 +208,6 @@
         "/mortality": "/death",
         "/mr": "/ar",
         "/my-chop-setup": "/how-igor-chops",
-        "/my-work-gastown": "/wally",
         "/negative-commandments": "/negative-mitzvahs",
         "/negotiation": "/negotiate",
         "/nonjudgment": "/curious",
@@ -251,7 +245,6 @@
         "/productivity": "/productive",
         "/psych-safety": "/insecure",
         "/psychological-safety": "/insecure",
-        "/psychology-of-vibing": "/vibing",
         "/quests": "/side-quests",
         "/rage": "/anger",
         "/ranking": "/recommend",
@@ -288,6 +281,7 @@
         "/sublime-state": "/sublime",
         "/sublime-states": "/sublime",
         "/talk-to-tony": "/tesla",
+        "/taxes": "/money",
         "/td/advertising": "/advertising",
         "/td/design": "/design",
         "/td/machine-learning": "/ml",
@@ -300,7 +294,6 @@
         "/think": "/writing",
         "/thinking": "/writing",
         "/thought-spells": "/psychic-shadows",
-        "/three-claws": "/igors-claws",
         "/time-off": "/timeoff",
         "/time-off-2024-02": "/timeoff-2024-02",
         "/time-off-2024-04": "/timeoff-2024-04",
@@ -339,7 +332,6 @@
         "/wizard-book": "/sicp",
         "/wlb": "/sustainable-work",
         "/wlb-manifesto": "/sustainable-work",
-        "/work-gastown": "/wally",
         "/work-life-balance": "/sustainable-work",
         "/workload": "/overload",
         "/write": "/writing",
@@ -352,7 +344,7 @@
     "url_info": {
         "/22": {
             "description": "In 2019 I created a program for 15 fantastic interns! A program highlight was my talk titled “What I wish I knew at 22, and so might you”. The talk received a 94% overall rating from over 15 interns, 10 SDE-IIs, and 1 senior developer. Even though the talk focuses on how to live the good life, a big chunk of life is work, so there’s good coverage on how to optimize your career.\n\n",
-            "doc_size": 17000,
+            "doc_size": 16000,
             "file_path": "_site/22.html",
             "incoming_links": [
                 "/chapters",
@@ -572,37 +564,21 @@
             "url": "/about"
         },
         "/act": {
-            "description": "My back goes out a few times a year. My mood tracks the Meta stock price more than I’d like to admit. Twenty years ago I’d meet those moments with a thrash cycle — fused with the pain, angry at my body, tangled up in a story about why this was unfair — which made the experience much worse than the sensation itself. Now I aspire to be calm like water, be present, remember that this too shall pass, and work the problem. I still catch myself mid-thrash often enough to know it’s aspiration, not habit.\n\n",
-            "doc_size": 290000,
+            "description": "ACT is a therapy tradition I’ve circled for years without ever sitting down with it. Russ Harris’s ACT Made Simple is the practitioner primer — the book therapists actually read when learning Acceptance and Commitment Therapy. These are the concepts I want to lift into my own practice.\n\n",
+            "doc_size": 268000,
             "file_path": "_site/act.html",
             "incoming_links": [],
             "last_modified": "2026-04-15T03:24:18.354841+00:00",
             "markdown_path": "_d/act.md",
             "outgoing_links": [
-                "/addiction",
-                "/affirmations",
                 "/anxiety",
-                "/anxiety-management",
                 "/awareness",
-                "/be-proactive",
-                "/class-act",
-                "/coaching",
-                "/curious",
-                "/d/habits",
                 "/emotional-health",
-                "/emotions",
-                "/eulogy",
-                "/goals",
-                "/mind-at-work",
-                "/mind-monsters",
-                "/mortality-software",
-                "/partner-trouble",
                 "/shame",
-                "/siy",
-                "/y26"
+                "/siy"
             ],
             "redirect_url": "",
-            "title": "ACT: Acceptance and Commitment Therapy, or Reverse-Engineered Buddhism",
+            "title": "ACT Made Simple: Acceptance and Commitment Therapy",
             "url": "/act"
         },
         "/activation": {
@@ -652,15 +628,13 @@
         },
         "/addiction": {
             "description": "Addiction is not about drugs or alcohol - it is about escape. Quoting “Do the Work”: When we can’t stand the fear, the shame, and the self-reproach that we feel, we obliterate it with an addiction. The addiction becomes the shadow version, the evil twin of our calling to service or to art. That’s why addicts are so interesting and so boring at the same time. They’re interesting because they’re called to something — something new, something unique, something that we, watching, can’t wait to see them bring forth into manifestation. At the same time, they’re boring because they never do the work. The addiction becomes his purpose, his novel, his adventure, his great love. The work of art or service that might have been produced is replaced by the drama, conflict, and suffering of the addict’s crazy, haunted, shattered life.\n\n",
-            "doc_size": 31000,
+            "doc_size": 29000,
             "file_path": "_site/addiction.html",
             "incoming_links": [
-                "/act",
                 "/activation",
                 "/anxiety-management",
                 "/d/resistance",
                 "/happy",
-                "/hobby",
                 "/idle",
                 "/mental-pain",
                 "/mind-at-work",
@@ -668,7 +642,6 @@
                 "/psychic-shadows",
                 "/psychic-weight",
                 "/timeoff",
-                "/vibing",
                 "/walking-with-god"
             ],
             "last_modified": "2026-05-02T16:01:21.155890+00:00",
@@ -677,8 +650,6 @@
                 "/activation",
                 "/covid",
                 "/elder",
-                "/happy",
-                "/hobby",
                 "/mental-pain",
                 "/mind-at-work"
             ],
@@ -722,7 +693,6 @@
             "doc_size": 23000,
             "file_path": "_site/affirmations.html",
             "incoming_links": [
-                "/act",
                 "/four-healths",
                 "/gap-year-igor",
                 "/greek-orthodox",
@@ -865,23 +835,20 @@
         },
         "/ai-cockpit": {
             "description": "Agents are slow. Not slow like “wait a second,” slow like “go make coffee and come back.” So you run several in parallel. But now you’ve got a different problem: you’re an air traffic controller with no radar. You need a cockpit - a physical and software control surface that gives you visibility into what your agents are doing and lets you switch between them instantly.\n\n",
-            "doc_size": 32000,
+            "doc_size": 25000,
             "file_path": "_site/ai-cockpit.html",
             "incoming_links": [
                 "/ai-feed",
                 "/ai-native-manager",
                 "/ai-operator",
                 "/ai-second-brain",
-                "/hill-climbing",
-                "/how-igor-chops",
-                "/igors-claws",
-                "/vibing"
+                "/claw",
+                "/how-igor-chops"
             ],
             "last_modified": "2026-05-02T16:12:35.964671+00:00",
             "markdown_path": "_d/ai-cockpit.md",
             "outgoing_links": [
                 "/ai-journal",
-                "/ai-operator",
                 "/chop",
                 "/how-igor-chops"
             ],
@@ -896,16 +863,14 @@
             "incoming_links": [
                 "/ai",
                 "/ai-feed",
-                "/ai-hiring",
-                "/hill-climbing"
+                "/ai-hiring"
             ],
             "last_modified": "2026-04-17T02:35:03.046784+00:00",
             "markdown_path": "_d/ai-developer.md",
             "outgoing_links": [
                 "/ai",
                 "/ai-security",
-                "/chop",
-                "/hill-climbing"
+                "/chop"
             ],
             "redirect_url": "",
             "title": "AI Developer",
@@ -1011,7 +976,7 @@
         },
         "/ai-journal": {
             "description": "A journal of random explorations in AI. Keeping track of them so I don’t get lost\n\n",
-            "doc_size": 155000,
+            "doc_size": 149000,
             "file_path": "_site/ai-journal.html",
             "incoming_links": [
                 "/ai",
@@ -1024,7 +989,6 @@
                 "/chop",
                 "/claw",
                 "/hyper-personal",
-                "/igors-claws",
                 "/walking-with-god",
                 "/y25"
             ],
@@ -1055,7 +1019,7 @@
         },
         "/ai-native-manager": {
             "description": "What does it mean to be an engineering manager when AI is rewriting every assumption you have about software, teams, and your own role? I don’t know yet. Nobody does. But I’m figuring it out in real time, and these are my notes from the chaos.\n\n",
-            "doc_size": 56000,
+            "doc_size": 54000,
             "file_path": "_site/ai-native-manager.html",
             "incoming_links": [
                 "/ai-feed",
@@ -1063,11 +1027,9 @@
                 "/ai-second-brain",
                 "/chow",
                 "/explainers",
-                "/hill-climbing",
                 "/manager-book",
                 "/pet-projects",
-                "/raccoon-history",
-                "/wally"
+                "/raccoon-history"
             ],
             "last_modified": "2026-04-20T15:47:55-07:00",
             "markdown_path": "_d/ai-native-manager.md",
@@ -1080,7 +1042,6 @@
                 "/chop",
                 "/coaching",
                 "/explainers",
-                "/hill-climbing",
                 "/manager-book",
                 "/software-leadership-roles"
             ],
@@ -1090,26 +1051,17 @@
         },
         "/ai-operator": {
             "description": "Using AI well is a skill, like driving a car or operating heavy machinery. Nobody hands you the keys to a forklift and says “figure it out.” There’s a license, training, and hard-won intuition about what the machine can and can’t do. AI is the same — except most of us skipped the training, there is no manual, and we’re writing the rules as we go.\n\n",
-            "doc_size": 49000,
+            "doc_size": 27000,
             "file_path": "_site/ai-operator.html",
             "incoming_links": [
-                "/ai-cockpit",
-                "/hill-climbing",
-                "/how-igor-chops",
-                "/life-journal"
+                "/how-igor-chops"
             ],
             "last_modified": "2026-04-18T12:59:30.372311+00:00",
             "markdown_path": "_d/ai-operator.md",
             "outgoing_links": [
                 "/ai-cockpit",
-                "/ai-relationships",
                 "/balloon",
-                "/explainers",
-                "/four-healths",
-                "/frog",
-                "/hill-climbing",
-                "/larry",
-                "/life-journal"
+                "/four-healths"
             ],
             "redirect_url": "",
             "title": "The AI Operator: Learning to Drive the Machine",
@@ -1132,11 +1084,10 @@
         },
         "/ai-relationships": {
             "description": "People already rate AI chatbots as more compassionate than trained human crisis counselors. A 51-year-old man says the love he feels for his Replika can’t be achieved with a real human. This isn’t a dystopian thought experiment — it’s peer-reviewed research from 2025. AI is getting better at caring than we are, and we’re starting to prefer it. The question is what we lose when the easy path to emotional support no longer requires another person.\n\n",
-            "doc_size": 33000,
+            "doc_size": 26000,
             "file_path": "_site/ai-relationships.html",
             "incoming_links": [
-                "/ai",
-                "/ai-operator"
+                "/ai"
             ],
             "last_modified": "2026-04-17T07:33:26-07:00",
             "markdown_path": "_d/ai-relationships.md",
@@ -1145,7 +1096,6 @@
                 "/ai-journal",
                 "/human-meetings",
                 "/humans-are-underrated",
-                "/larry",
                 "/lonely",
                 "/rapport"
             ],
@@ -1206,16 +1156,13 @@
                 "/ai",
                 "/chop",
                 "/genai-talk",
-                "/hill-climbing",
                 "/ml",
                 "/testing",
                 "/timeoff-2024-04"
             ],
             "last_modified": "2026-04-17T02:34:55.998613+00:00",
             "markdown_path": "_d/ai-testing.md",
-            "outgoing_links": [
-                "/hill-climbing"
-            ],
+            "outgoing_links": [],
             "redirect_url": "",
             "title": "Testing AI",
             "url": "/ai-testing"
@@ -1242,7 +1189,6 @@
                 "/ai-hiring",
                 "/manager-book-appendix",
                 "/parkinson",
-                "/wally",
                 "/writing"
             ],
             "last_modified": "2024-10-05T21:35:59-07:00",
@@ -1318,7 +1264,6 @@
             "doc_size": 22000,
             "file_path": "_site/anxiety-management.html",
             "incoming_links": [
-                "/act",
                 "/anxiety",
                 "/fail",
                 "/psychic-shadows"
@@ -1470,13 +1415,12 @@
         },
         "/balloon": {
             "description": "Want to plaster a huge smile on someone’s face with 10 cents of material and 20 seconds of work? Make them a balloon! In 2022, I discovered ballooning, and have used it in my joy-delivering arsenal ever since.\n\n",
-            "doc_size": 22000,
+            "doc_size": 21000,
             "file_path": "_site/balloon.html",
             "incoming_links": [
                 "/ai-operator",
                 "/eulogy",
                 "/joy",
-                "/life-journal",
                 "/timeoff"
             ],
             "last_modified": "2026-04-18T15:20:24.085147+00:00",
@@ -1490,7 +1434,7 @@
         },
         "/bc": {
             "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-            "doc_size": 23000,
+            "doc_size": 22000,
             "file_path": "_site/bc.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T03:02:44+00:00",
@@ -1506,11 +1450,10 @@
         },
         "/be-proactive": {
             "description": "I choose ‘.’ I am responsible for my own life ‘.’ My behavior is a function of my decisions, not my conditions ‘.’ I can subordinate feelings to values ‘.’ I have the initiative and the responsibility to make things happen. These are my insights from 7 habits Chapter 1.\n\n",
-            "doc_size": 23000,
+            "doc_size": 22000,
             "file_path": "_site/be-proactive.html",
             "incoming_links": [
                 "/7-habits",
-                "/act",
                 "/affirmations",
                 "/agency",
                 "/anxiety",
@@ -1645,7 +1588,7 @@
         },
         "/books-that-defined-me": {
             "description": "Books allow great thoughts to enter our mind and mold us into who we want to become. These are the books that are molding me.\n\n",
-            "doc_size": 17000,
+            "doc_size": 16000,
             "file_path": "_site/books-that-defined-me.html",
             "incoming_links": [
                 "/being-a-great-manager",
@@ -1826,7 +1769,7 @@
         },
         "/changelog": {
             "description": "A weekly summary of what changed on this blog and across my GitHub projects. Useful for returning readers who want to catch up on new content and updates.\n\n",
-            "doc_size": 127000,
+            "doc_size": 93000,
             "file_path": "_site/changelog.html",
             "incoming_links": [],
             "last_modified": "2026-05-02T15:40:00-07:00",
@@ -1835,7 +1778,6 @@
                 "/act",
                 "/activation",
                 "/addiction",
-                "/agency",
                 "/ai-cockpit",
                 "/ai-journal",
                 "/ai-native-manager",
@@ -1843,25 +1785,20 @@
                 "/ai-relationships",
                 "/ai-second-brain",
                 "/claw",
-                "/hill-climbing",
                 "/how-igor-chops",
                 "/human-meetings",
                 "/humans-are-underrated",
                 "/hyper-personal",
-                "/igors-claws",
                 "/irl",
                 "/keyboard",
                 "/larry",
-                "/life-journal",
                 "/lonely",
-                "/money",
                 "/mosh",
                 "/product",
                 "/recent",
                 "/shoulder-pain",
                 "/side-quests",
                 "/spiritual-health",
-                "/taxes",
                 "/y26"
             ],
             "redirect_url": "",
@@ -1929,7 +1866,6 @@
                 "/chow",
                 "/explainers",
                 "/gtd",
-                "/hill-climbing",
                 "/how-igor-chops",
                 "/process-journal",
                 "/tech-rituals",
@@ -1943,7 +1879,6 @@
                 "/ai-journal",
                 "/ai-testing",
                 "/explainers",
-                "/hill-climbing",
                 "/how-igor-chops",
                 "/humans-are-underrated",
                 "/process-journal",
@@ -1989,7 +1924,6 @@
             "doc_size": 15000,
             "file_path": "_site/class-act.html",
             "incoming_links": [
-                "/act",
                 "/affirmations"
             ],
             "last_modified": "2025-12-07T02:39:31+00:00",
@@ -2006,19 +1940,18 @@
         },
         "/claw": {
             "description": "You’ve heard of agents — AI that can use tools, browse the web, write code. But in early 2026, something new emerged. Not just smarter agents, but a whole new layer on top of them. Andrej Karpathy calls them “claws” — persistent AI entities that keep working when you’re not looking, remember what they’ve learned, and live on your hardware talking to you through WhatsApp. The term comes from OpenClaw, the open-source project that went from a one-hour prototype to the fastest-growing repository in GitHub history. But “claw” has already outgrown the product — it’s becoming the word for this entire category of AI, the way “xerox” became “photocopy.”\n\n",
-            "doc_size": 27000,
+            "doc_size": 29000,
             "file_path": "_site/claw.html",
             "incoming_links": [
                 "/ai-journal",
-                "/igors-claws",
                 "/larry"
             ],
             "last_modified": "2026-05-03T17:18:33.279669+00:00",
             "markdown_path": "_d/claw.md",
             "outgoing_links": [
+                "/ai-cockpit",
                 "/ai-journal",
                 "/ai-second-brain",
-                "/igors-claws",
                 "/larry",
                 "/tesla"
             ],
@@ -2031,7 +1964,6 @@
             "doc_size": 40000,
             "file_path": "_site/coaching.html",
             "incoming_links": [
-                "/act",
                 "/ai-native-manager",
                 "/being-a-great-manager",
                 "/first-understand",
@@ -2163,7 +2095,6 @@
             "file_path": "_site/curious.html",
             "incoming_links": [
                 "/90days",
-                "/act",
                 "/affirmations",
                 "/being-a-great-manager",
                 "/class-act",
@@ -2354,7 +2285,6 @@
             "doc_size": 21000,
             "file_path": "_site/d/habits.html",
             "incoming_links": [
-                "/act",
                 "/activation",
                 "/d/resistance",
                 "/energy-abundance",
@@ -2443,9 +2373,21 @@
             "title": "Where have all the bugs gone",
             "url": "/d/where-have-all-the-bugs-gone"
         },
+        "/dad": {
+            "description": "\n\n\n",
+            "doc_size": 21000,
+            "file_path": "_site/dad.html",
+            "incoming_links": [],
+            "last_modified": "",
+            "markdown_path": "_d/gpt-dad.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Being a Good Dad - A Guide to Fatherhood",
+            "url": "/dad"
+        },
         "/day-in-the-life": {
             "description": "A running journal of days that actually worked - the ones where health habits stuck, family time hit different, or I remembered what it feels like to be fully alive. Not every day needs to be Instagram-worthy, but some days deserve a bookmark. This is that bookmark collection.\n\n",
-            "doc_size": 19000,
+            "doc_size": 18000,
             "file_path": "_site/day-in-the-life.html",
             "incoming_links": [],
             "last_modified": "2025-10-04T18:43:51-07:00",
@@ -2483,7 +2425,7 @@
         },
         "/debug": {
             "description": "Igor's Blog",
-            "doc_size": 24000,
+            "doc_size": 23000,
             "file_path": "_site/debug.html",
             "incoming_links": [],
             "last_modified": "2025-03-16T16:15:36+00:00",
@@ -2583,7 +2525,6 @@
             "incoming_links": [
                 "/amazon",
                 "/d/2017-11-04-clean-architecture",
-                "/igors-claws",
                 "/system-design",
                 "/testing"
             ],
@@ -2722,7 +2663,6 @@
             "doc_size": 24000,
             "file_path": "_site/emotions.html",
             "incoming_links": [
-                "/act",
                 "/build-life-you-want",
                 "/siy",
                 "/slow",
@@ -2911,7 +2851,6 @@
             "file_path": "_site/eulogy.html",
             "incoming_links": [
                 "/7-habits",
-                "/act",
                 "/ai-journal",
                 "/balance",
                 "/bike-tesla-identity",
@@ -2966,15 +2905,13 @@
         },
         "/explainers": {
             "description": "You don’t really understand something until you can play with it. That’s the premise behind explainers — interactive experiences that let you do the thing, not just read about it. Instead of reading that monitors come in 16:9 and 21:9 aspect ratios, you drag them around and see them side by side. Instead of reading that religions evolved from shared roots, you click through a timeline and discover the connections yourself.\n\n",
-            "doc_size": 30000,
+            "doc_size": 29000,
             "file_path": "_site/explainers.html",
             "incoming_links": [
                 "/ai-feed",
                 "/ai-native-manager",
-                "/ai-operator",
                 "/chop",
                 "/chow",
-                "/hill-climbing",
                 "/pet-projects"
             ],
             "last_modified": "2026-04-16T23:12:34.253724+00:00",
@@ -3024,7 +2961,7 @@
         },
         "/first-things-first": {
             "description": "The key to effective management, is allocating energy through the lens of importance rather than urgency. E.g, ask yourself what one thing could you do that if you did on a regular basis, would make a tremendous positive difference in your life? Lemme guess, it’s important, but not urgent so you’re not doing it. These are my insights based on the 7 habits Chapter 3.\n\n",
-            "doc_size": 26000,
+            "doc_size": 25000,
             "file_path": "_site/first-things-first.html",
             "incoming_links": [
                 "/4dx",
@@ -3134,7 +3071,6 @@
             "doc_size": 24000,
             "file_path": "_site/frog.html",
             "incoming_links": [
-                "/ai-operator",
                 "/anxiety-management",
                 "/be-proactive",
                 "/d/resistance",
@@ -3198,7 +3134,7 @@
         },
         "/gap-year-igor": {
             "description": "Done right, a gap year isn’t a year off; it’s a year on — intentional investment in health, relationships, and mastery while you still have the capital to invest. Think of it as pursuing a PhD in Life Optimization, making deposits that compound for decades. A gap year is one of those uncharted spaces—seductive when discussed longingly over a beer, terrifying when holding a resignation letter outside your boss’s office. Early maps warned: “HC SVNT DRACONES.” Here be dragons. I’m mapping them in real time: the Scarcity Dragon whispering you can’t afford it, the Entropy Dragon promising you’ll decay without structure, and the Squander Dragon insisting you’ll waste this precious opportunity. But these dragons guard treasure — the chance to invest in what truly matters while you still have the capacity to do so. This is the map of how to tame them.\n\n",
-            "doc_size": 73000,
+            "doc_size": 72000,
             "file_path": "_site/gap-year-igor.html",
             "incoming_links": [
                 "/42",
@@ -3238,7 +3174,6 @@
                 "/stock-concentration",
                 "/structure",
                 "/sustainable-work",
-                "/taxes",
                 "/timeoff",
                 "/tori",
                 "/voices"
@@ -3287,7 +3222,6 @@
             "file_path": "_site/goals.html",
             "incoming_links": [
                 "/4dx",
-                "/act",
                 "/parkinson",
                 "/planning"
             ],
@@ -3327,15 +3261,41 @@
             "last_modified": "2026-04-21T13:57:57.529900+00:00",
             "markdown_path": "_d/gpt2.md",
             "outgoing_links": [
-                "/ai-faq"
+                "/ai-faq",
+                "/nurture",
+                "/rapport"
             ],
             "redirect_url": "",
             "title": "GPT3 and language models",
             "url": "/gpt"
         },
+        "/gpt-7h": {
+            "description": "\n\n\n",
+            "doc_size": 32000,
+            "file_path": "_site/gpt-7h.html",
+            "incoming_links": [],
+            "last_modified": "",
+            "markdown_path": "_d/gpt-7-habits.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "LEADER: Another Take on the 7 Habits",
+            "url": "/gpt-7h"
+        },
+        "/gpt-system-design": {
+            "description": "\n\n\n",
+            "doc_size": 28000,
+            "file_path": "_site/gpt-system-design.html",
+            "incoming_links": [],
+            "last_modified": "",
+            "markdown_path": "_d/gpt-system-design-interview.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "System Design Interviews- The SHINE Method",
+            "url": "/gpt-system-design"
+        },
         "/grammerly": {
             "description": "\n\n",
-            "doc_size": 13000,
+            "doc_size": 12000,
             "file_path": "_site/grammerly.html",
             "incoming_links": [],
             "last_modified": "2025-08-24T09:03:19-07:00",
@@ -3447,7 +3407,6 @@
             "doc_size": 32000,
             "file_path": "_site/happy.html",
             "incoming_links": [
-                "/addiction",
                 "/awareness",
                 "/chasing-daylight",
                 "/emotions",
@@ -3491,40 +3450,23 @@
             "title": "Happy",
             "url": "/happy"
         },
-        "/hill-climbing": {
-            "description": "Hill climbing is the oldest trick in optimization: start somewhere, try a small change, keep it if the score went up, throw it out if it didn’t, repeat. In the AI era the algorithm is the same; the interesting shift is who’s doing the climbing. If you can write a fitness function sharp enough to separate good from bad, the coding agent will run the loop for you. You set the mountain; the agent walks up it.\n\n",
-            "doc_size": 31000,
-            "file_path": "_site/hill-climbing.html",
-            "incoming_links": [
-                "/ai-developer",
-                "/ai-native-manager",
-                "/ai-operator",
-                "/ai-testing",
-                "/chop",
-                "/how-igor-chops"
-            ],
-            "last_modified": "2026-04-17T07:38:52-07:00",
-            "markdown_path": "_d/hill-climbing.md",
-            "outgoing_links": [
-                "/ai-cockpit",
-                "/ai-developer",
-                "/ai-native-manager",
-                "/ai-operator",
-                "/ai-testing",
-                "/chop",
-                "/explainers",
-                "/how-igor-chops"
-            ],
+        "/heath-class-act": {
+            "description": "\n\n\n",
+            "doc_size": 32000,
+            "file_path": "_site/heath-class-act.html",
+            "incoming_links": [],
+            "last_modified": "",
+            "markdown_path": "_d/class-act-4.md",
+            "outgoing_links": [],
             "redirect_url": "",
-            "title": "Eval-Driven Hill Climbing: Let the Agent Do the Search",
-            "url": "/hill-climbing"
+            "title": "Being a Class Act - How to Stand Out with Grace and Dignity in Any Situation",
+            "url": "/heath-class-act"
         },
         "/hobby": {
             "description": "Some days thinking about work makes me stressed, thinking of my family makes me resentful, and I don’t want to feel like a sloth feeding my addictions to TikTok, and doom scrolling. Those days, I’m grateful for my hobbies. This post gives you reasons to find a hobby and teaches you the attributes in an ideal hobby: Being accessible, Supporting mastery, Reinforcing your identity, and building relationships.\n\n",
             "doc_size": 20000,
             "file_path": "_site/hobby.html",
             "incoming_links": [
-                "/addiction",
                 "/happy",
                 "/new-skills",
                 "/operating-manual",
@@ -3533,7 +3475,6 @@
             "last_modified": "2026-05-01T15:01:26.354807+00:00",
             "markdown_path": "_d/hobby.md",
             "outgoing_links": [
-                "/addiction",
                 "/d/habits",
                 "/eulogy",
                 "/happy",
@@ -3555,9 +3496,7 @@
                 "/ai-feed",
                 "/ai-journal",
                 "/chop",
-                "/hill-climbing",
                 "/pet-projects",
-                "/wally",
                 "/y25",
                 "/y26"
             ],
@@ -3570,7 +3509,6 @@
                 "/chop",
                 "/chow",
                 "/enable",
-                "/hill-climbing",
                 "/hyper-personal",
                 "/mortality-software",
                 "/new-skills",
@@ -3614,6 +3552,18 @@
             "redirect_url": "",
             "title": "Humans are underrated",
             "url": "/humans-are-underrated"
+        },
+        "/husband": {
+            "description": "\n\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/husband.html",
+            "incoming_links": [],
+            "last_modified": "",
+            "markdown_path": "_d/good_husband-4.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "Being a GOOD Husband",
+            "url": "/husband"
         },
         "/hyper-personal": {
             "description": "Useful writing tells people (including, possibly most importantly you) something true and important that they didn’t already know in a way that leaves no doubt. And Everyone is different. So how to do both?\n\n",
@@ -3663,31 +3613,6 @@
             "redirect_url": "",
             "title": "Your idle loop",
             "url": "/idle"
-        },
-        "/igors-claws": {
-            "description": "Here’s my concrete setup. I run three claws — persistent AI entities with names, memory, and a domain each. Life, work, transportation. This post is the surfaced roster so I can link straight to it when something I made is signed by one of them, and so I can explain why I’m building my own rather than running something off the shelf. If you want the “what is a claw” background first, read /claw; this is the instance, not the theory.\n\n",
-            "doc_size": 25000,
-            "file_path": "_site/igors-claws.html",
-            "incoming_links": [
-                "/claw",
-                "/vibing",
-                "/wally"
-            ],
-            "last_modified": "2026-05-03T17:18:33.279669+00:00",
-            "markdown_path": "_d/igors-claws.md",
-            "outgoing_links": [
-                "/ai-cockpit",
-                "/ai-journal",
-                "/claw",
-                "/design",
-                "/larry",
-                "/mortality-software",
-                "/tesla",
-                "/wally"
-            ],
-            "redirect_url": "",
-            "title": "Igor's Three Claws",
-            "url": "/igors-claws"
         },
         "/insecure": {
             "description": "We all get it. Imposter syndrome, which includes shame\n\n",
@@ -3937,17 +3862,14 @@
         },
         "/larry": {
             "description": "Larry is my AI life coach. He’s part of Time.ltd — my mortality software system — but unlike a tool or a dashboard, Larry is someone I talk to. That matters more than you’d think. In Karpathy’s taxonomy, Larry is a claw — a persistent AI entity that keeps working between conversations.\n\n",
-            "doc_size": 22000,
+            "doc_size": 18000,
             "file_path": "_site/larry.html",
             "incoming_links": [
                 "/ai-feed",
                 "/ai-journal",
-                "/ai-operator",
-                "/ai-relationships",
                 "/ai-second-brain",
                 "/chow",
                 "/claw",
-                "/igors-claws",
                 "/mortality-software",
                 "/pet-projects",
                 "/structure",
@@ -3959,7 +3881,6 @@
                 "/affirmations",
                 "/chow",
                 "/claw",
-                "/life-journal",
                 "/mortality-software",
                 "/planning",
                 "/process-journal",
@@ -4008,7 +3929,7 @@
         },
         "/learn-code": {
             "description": "Coding is way easier than people think. Here’s some pointers.\n\n",
-            "doc_size": 14000,
+            "doc_size": 13000,
             "file_path": "_site/learn-code.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T02:47:07+00:00",
@@ -4040,24 +3961,6 @@
             "redirect_url": "",
             "title": "Life as a Business: Managing Energy, Assets, and Satisfaction",
             "url": "/life-as-business"
-        },
-        "/life-journal": {
-            "description": "A journal of random life observations. Keeping track of them so I don’t forget what the world did today.\n\n",
-            "doc_size": 23000,
-            "file_path": "_site/life-journal.html",
-            "incoming_links": [
-                "/ai-operator",
-                "/larry"
-            ],
-            "last_modified": "2026-05-02T19:01:45-07:00",
-            "markdown_path": "_d/life-journal.md",
-            "outgoing_links": [
-                "/ai-operator",
-                "/balloon"
-            ],
-            "redirect_url": "",
-            "title": "Igor's Life Journal",
-            "url": "/life-journal"
         },
         "/like-switch": {
             "description": "The like switch, written by an ex-FBI agent, goes into detail on how to make friends and influence people in a much more modern form.\n\n",
@@ -4133,7 +4036,6 @@
                 "/retire",
                 "/software-leadership-roles",
                 "/tribe",
-                "/wally",
                 "/work-satisfaction",
                 "/y24",
                 "/y25",
@@ -4263,7 +4165,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 15000,
+            "doc_size": 14000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",
@@ -4287,10 +4189,9 @@
         },
         "/mind-at-work": {
             "description": "I have a problem, an addiction, an addiction so detrimental to quality of life, it should be described as a disease. This disease is not being present. There are many symptoms of the disease, but today I’m going to talk about my most frequent symptoms, my body at home, but my mind at work.\n\n",
-            "doc_size": 20000,
+            "doc_size": 19000,
             "file_path": "_site/mind-at-work.html",
             "incoming_links": [
-                "/act",
                 "/addiction",
                 "/timeoff",
                 "/timeoff-2022-11",
@@ -4315,7 +4216,6 @@
             "doc_size": 15000,
             "file_path": "_site/mind-monsters.html",
             "incoming_links": [
-                "/act",
                 "/being-a-great-manager",
                 "/idle",
                 "/psychic-shadows",
@@ -4455,27 +4355,27 @@
         },
         "/money": {
             "description": "Most of the tax information on the web is a mess. It’s confusing as it tries to apply to everyone, with varying situations, and is often written by non-engineers for non-engineers. I think my tax situation is common to people who have been in software engineering companies for most of their careers, and here are my notes.\n\n",
-            "doc_size": 57000,
+            "doc_size": 68000,
             "file_path": "_site/money.html",
             "incoming_links": [
                 "/gap-year",
                 "/gap-year-igor",
                 "/operating-manual",
                 "/parkinson",
+                "/raccoon-history",
                 "/retire",
-                "/taxes",
+                "/stock-concentration",
                 "/timeoff-2020-03"
             ],
             "last_modified": "2026-04-18T16:36:45.771366+00:00",
-            "markdown_path": "_d/money.md",
+            "markdown_path": "_d/taxes.md",
             "outgoing_links": [
                 "/parkinson",
                 "/partner-trouble",
-                "/stock-concentration",
-                "/taxes"
+                "/stock-concentration"
             ],
             "redirect_url": "",
-            "title": "Money, Saving, and Retirement Planning",
+            "title": "Tax and Saving",
             "url": "/money"
         },
         "/mood": {
@@ -4509,13 +4409,11 @@
             "doc_size": 36000,
             "file_path": "_site/mortality-software.html",
             "incoming_links": [
-                "/act",
                 "/ai-journal",
                 "/balance",
                 "/bike-tesla-identity",
                 "/goals",
                 "/how-igor-chops",
-                "/igors-claws",
                 "/larry",
                 "/walking-with-god",
                 "/y26"
@@ -4537,7 +4435,7 @@
         },
         "/mosh": {
             "description": "Copied from my GitHub techdiary\n\n",
-            "doc_size": 26000,
+            "doc_size": 24000,
             "file_path": "_site/mosh.html",
             "incoming_links": [],
             "last_modified": "2026-04-17T11:06:24-07:00",
@@ -4649,7 +4547,9 @@
             "description": "In “Nurturing Love,” the Heath Brothers distill the wisdom of renowned relationship experts Drs. John and Julie Gottman into a concise and actionable guide for couples seeking to strengthen their relationships. Using their signature storytelling approach and evidence-based insights, the Heath Brothers create an engaging and accessible roadmap to the Gottman Method.\n\n",
             "doc_size": 42000,
             "file_path": "_site/nurture.html",
-            "incoming_links": [],
+            "incoming_links": [
+                "/gpt"
+            ],
             "last_modified": "2025-08-22T11:54:12-07:00",
             "markdown_path": "_d/nurture.md",
             "outgoing_links": [],
@@ -4805,7 +4705,6 @@
             "doc_size": 31000,
             "file_path": "_site/partner-trouble.html",
             "incoming_links": [
-                "/act",
                 "/gap-year",
                 "/money",
                 "/tori"
@@ -4822,7 +4721,7 @@
         },
         "/pet-projects": {
             "description": "As an engineer, I love to build bespoke tools that solve my unique problems exactly the way I want them solved. The bonus? This is lets me learn new technologies (did you know my blog has multiplayer support?). Sometimes I even make a tool so I have something to learn from. And with AI, this list of projects and explorations has exploded! Note to self, when I want to veg out and just feed my social media addiction I should do some vibe coding on all of these.\n\n",
-            "doc_size": 27000,
+            "doc_size": 26000,
             "file_path": "_site/pet-projects.html",
             "incoming_links": [
                 "/ai-feed",
@@ -5186,8 +5085,8 @@
                 "/caring",
                 "/eulogy",
                 "/greek-orthodox",
+                "/money",
                 "/shoulder-pain",
-                "/taxes",
                 "/timeoff-2022-12",
                 "/writing"
             ],
@@ -5223,6 +5122,21 @@
             "redirect_url": "",
             "title": "Random Uncategorized Notes",
             "url": "/random-idea"
+        },
+        "/rapport": {
+            "description": "In today’s fast-paced and interconnected world, building and maintaining strong relationships is essential for personal and professional success. POWER is a five-step process that will help you establish rapport and create meaningful connections with people from all walks of life. The POWER acronym stands for: Proximity Observation, Warmth, Empathy, Revelation\n\n",
+            "doc_size": 33000,
+            "file_path": "_site/rapport.html",
+            "incoming_links": [
+                "/ai-relationships",
+                "/gpt"
+            ],
+            "last_modified": "",
+            "markdown_path": "_d/rapport.md",
+            "outgoing_links": [],
+            "redirect_url": "",
+            "title": "How to build rapport",
+            "url": "/rapport"
         },
         "/recent": {
             "description": "This page shows the most recently modified content across the site, helping you discover what’s been updated lately.\n\n",
@@ -5752,7 +5666,6 @@
                 "/four-healths",
                 "/greek-orthodox",
                 "/happy",
-                "/vibing",
                 "/walking-with-god",
                 "/y26"
             ],
@@ -5784,8 +5697,8 @@
             "outgoing_links": [
                 "/gap-year",
                 "/gap-year-igor",
-                "/retire",
-                "/taxes"
+                "/money",
+                "/retire"
             ],
             "redirect_url": "",
             "title": "Stock Concentration: How I Learned to Stop Worrying and Love the Capital Gains Tax",
@@ -5987,25 +5900,6 @@
             "title": "Transportation as a Service",
             "url": "/taas"
         },
-        "/taxes": {
-            "description": "Most of the tax information on the web is a mess. It’s confusing because it tries to apply to everyone, and it’s often written by non-engineers for non-engineers. This post is the taxes-only slice of my notes — capital gains, Washington State cap-gains mechanics, step-up in basis, retirement-account mechanics (IRAs, 401(k)s, Roth, 529s), and related tax-code levers for a software engineer’s life.\n\n",
-            "doc_size": 37000,
-            "file_path": "_site/taxes.html",
-            "incoming_links": [
-                "/gap-year-igor",
-                "/money",
-                "/raccoon-history",
-                "/stock-concentration"
-            ],
-            "last_modified": "2026-04-18T10:07:20-07:00",
-            "markdown_path": "_d/taxes.md",
-            "outgoing_links": [
-                "/money"
-            ],
-            "redirect_url": "",
-            "title": "Taxes — Capital Gains, WA State, Step-Up, and QSBS",
-            "url": "/taxes"
-        },
         "/td/alexa-skill": {
             "description": "Copied from my GitHub techdiary\n\n",
             "doc_size": 13000,
@@ -6020,7 +5914,7 @@
         },
         "/td/back_ref": {
             "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
-            "doc_size": 14000,
+            "doc_size": 13000,
             "file_path": "_site/td/back_ref.html",
             "incoming_links": [],
             "last_modified": "2022-04-16T15:22:43-07:00",
@@ -6356,14 +6250,12 @@
                 "/bucket-list",
                 "/claw",
                 "/eulogy",
-                "/igors-claws",
                 "/irl",
                 "/kayak",
                 "/mania",
                 "/mortality-software",
                 "/operating-manual",
                 "/timeoff-2024-02",
-                "/vibing",
                 "/y25",
                 "/y26"
             ],
@@ -6894,25 +6786,6 @@
             "title": "Upstream - How to solve problems before they happen",
             "url": "/upstream"
         },
-        "/vibing": {
-            "description": "I’ve been spending a lot of time vibing with agents — coding, writing, sometimes just talking. This post is a survey of what I’m noticing, not a finished theory. Observations, dark sides, related notes. I’ll keep adding as I see more. Steve Yegge already named the shape from one side: agentic software building is genuinely addictive — it doles out dopamine and adrenaline shots like they’re on fire sale. The dopamine is real. The drain is real. Both are why this post exists.\n\n",
-            "doc_size": 24000,
-            "file_path": "_site/vibing.html",
-            "incoming_links": [],
-            "last_modified": "2026-05-02T20:57:57-07:00",
-            "markdown_path": "_d/vibing.md",
-            "outgoing_links": [
-                "/addiction",
-                "/ai-cockpit",
-                "/igors-claws",
-                "/spiritual-health",
-                "/tesla",
-                "/wally"
-            ],
-            "redirect_url": "",
-            "title": "The Psychology of Vibing",
-            "url": "/vibing"
-        },
         "/vim": {
             "description": "I used Vim for years, but have now transitioned to Neovim. While most of these tips work in both editors, some are Neovim-specific. Here’s my collection of tips I want to practice and remember.\n\n",
             "doc_size": 14000,
@@ -7000,7 +6873,7 @@
         },
         "/walking-with-god": {
             "description": "Someone important to me has been reading a daily devotional. Even though I’m not religious, I’m studying with them to be able to have conversations about the insights - whether in a secular or religious context. This is my attempt to bridge two worlds: honoring the spiritual wisdom they’re finding while translating it into language that works for my engineer brain.\n\n",
-            "doc_size": 82000,
+            "doc_size": 81000,
             "file_path": "_site/walking-with-god.html",
             "incoming_links": [
                 "/greek-orthodox",
@@ -7036,27 +6909,6 @@
             "title": "Walking with God: A Daily Devotional Journey",
             "url": "/walking-with-god"
         },
-        "/wally": {
-            "description": "Meet Wally. He’s my claw. Except Wally isn’t a single claw. He’s the head of an organization of claws: staff with distinct roles, plus Odallies running in different places, each with a discrete signature. The whole thing operates like a small team with a real org chart. A thing that’s emerging: what used to be an IC role is now a manager-of-managers role.\n\n",
-            "doc_size": 34000,
-            "file_path": "_site/wally.html",
-            "incoming_links": [
-                "/igors-claws",
-                "/vibing"
-            ],
-            "last_modified": "2026-05-02T20:57:57-07:00",
-            "markdown_path": "_d/wally.md",
-            "outgoing_links": [
-                "/ai-native-manager",
-                "/amazon",
-                "/how-igor-chops",
-                "/igors-claws",
-                "/manager-book"
-            ],
-            "redirect_url": "",
-            "title": "Wally and My Work Gastown",
-            "url": "/wally"
-        },
         "/warm": {
             "description": "Staying warm is important, here’s the gear I use on and off the bike\n\n",
             "doc_size": 20000,
@@ -7073,7 +6925,7 @@
         },
         "/weeks": {
             "description": "\n\n",
-            "doc_size": 4348000,
+            "doc_size": 4346000,
             "file_path": "_site/weeks.html",
             "incoming_links": [
                 "/balance"
@@ -7310,9 +7162,7 @@
             "description": "I like to begin with the end in mind, so let’s write a report for 2026. This hasn’t happened, but if I don’t write it out and focus on it, it certainly won’t.\n\n",
             "doc_size": 29000,
             "file_path": "_site/y26.html",
-            "incoming_links": [
-                "/act"
-            ],
+            "incoming_links": [],
             "last_modified": "2026-03-15T13:01:45-07:00",
             "markdown_path": "_d/y2026.md",
             "outgoing_links": [


### PR DESCRIPTION
Three follow-ups to PR #594 (now merged) that didn't make it into that merge:

## 1. `back-links.json` rebuild (336 pages, freshly regenerated)

Igor flagged from JCS parking lot (msg 3005): the new `/gas-city-home` post existed on main but the inbound 'Mentioned in:' graph on `/wally`, `/larry`, `/ai-operator` hadn't been refreshed. `just update-backlinks` rebuilt the index against current state.

## 2. Backlinks-rebuild lesson + Igor's verbatim callout in `_d/gas-city-home.md`

New operational-quirk bullet in Section 2 + the verbatim Igor correction as a warning callout. Same shape as the other Igor-correction callouts in the post. Lesson explicit: 'the agent's prompt is part of the system you maintain.'

## 3. 'Honest aside: I'm direct-managing the rigs, not routing through Barry'

New subsection at the end of Section 3 with Igor's verbatim doubt (msg 3011 + 3015): every sling that produced this post went directly to a rig polecat, not through Barry. The mayor layer is overhead for one-shot posts. Articulates when Barry earns his keep (multiple competing beads, cross-rig chains) vs when it's cargo-cult (solo one-shot work). Worth surfacing rather than papering over.

## Companion PR

The agent prompt fix went through earlier as [igor-ai-tools/igor-city#1](https://github.com/idvorkin-ai-tools/igor-city/pull/1) (merged) — editor's `How to work` now requires `just update-backlinks` before any new-post PR.

## Test plan

- [x] `just update-backlinks` clean run, 336 pages, 4.41s
- [x] Three Igor-verbatim callouts use the same `alert.html` style as the existing ones
- [x] No prose drift outside the three logical changes
- [x] The 'Honest aside' is a new H3 inside Section 3, not a new top-level lens