### PR TITLE
igors-claws: link goop to claws-doing-goop upside

### DIFF
--- a/_d/igors-claws.md
+++ b/_d/igors-claws.md
@@ -70,6 +70,8 @@ The Claude Code Telegram bridge is the cleanest example I have. In early March I
 
 This is also why "just install OpenClaw" was never real for me. Even if you took the goop I'd written so far and threw it out, I'd be writing my replacement set inside a week — because the business logic is _mine_, the infra is _theirs_, and the goop is the only place a claw becomes anything specific.
 
+The upside, finally arriving: **the claws are getting good enough to do the goop themselves.** I spent a recent Sunday morning standing up [Steve Yegge's Gas City](/gas-city-home) at home — and the work I would have done by hand a year ago (scaffolding the city, debugging five upstream bugs, even drafting the post you're reading the link to) was done by the claws under direction. Goop didn't disappear; the labor on it shifted. That's the second half of the half-life pattern: **infra eats some, claws eat the rest.** The 80% goop number is starting to feel like a temporary high-water mark, not a permanent ceiling.
+
 ## Why I Build My Own
 
 People ask me why I'm rolling my own claws instead of running OpenClaw or waiting for the polished product. Fair question. A few reasons, in order of how much they actually move me.


### PR DESCRIPTION
Per Igor msg 3026: 'Link goop to upside can have claws do the goop. Link to last post.'

## Change

One new paragraph in `/igors-claws §Challenges: Business Logic, Goop, Infra`, right after the 'business logic is mine, infra is theirs, goop is where a claw becomes specific' close.

The new paragraph: claws are getting good enough to do the goop themselves. Cross-link to `/gas-city-home` as the Sunday-morning proof point — Wally drafted the city config, debugged five upstream bugs, wrote the post itself. Goop didn't disappear; the labor on it shifted. **Infra eats some, claws eat the rest.** The 80% goop number is a temporary high-water mark, not a permanent ceiling.

## Test plan

- [x] Link to `/gas-city-home` (the Sunday post)
- [x] No new permalinks or other cross-links → no backlinks rebuild needed
- [x] Lands inside the existing 'Challenges: Business Logic, Goop, Infra' section, no new heading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect expanded automated capabilities for infrastructure handling and task processing, reducing manual setup effort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->