### PR TITLE
gas-city: add /gas-city explainer (beads, molecules, GUPP)

### DIFF
--- a/_d/gas-city.md
+++ b/_d/gas-city.md
@@ -37,6 +37,8 @@ Beads matter because they're the smallest piece of state that survives a process
 
 A single bead does one thing. The interesting work is multi-step: design something, implement it, review it, test it, ship it. That's a **[molecule](https://docs.gastownhall.ai/concepts/molecules/)** — a persistent workflow instance that orchestrates multi-step work, expressed as a graph of beads chained with `needs:`.
 
+Yegge gave the broader pattern a name: **MEOW — Molecular Expression of Work.** Beads are the atoms; molecules are the chemistry. The whole stack is one bet: if you express work as composable molecules with bead-shaped state, agent orchestration becomes a thin layer on top instead of the main event. Gas City is a working argument that the bet pays off.
+
 The lifecycle has its own vocabulary, and once you see it the rest of the system clicks into place:
 
 - A **formula** is the source template — a TOML file describing the steps, their dependencies, and which agents run each one.

--- a/_d/gas-city.md
+++ b/_d/gas-city.md
@@ -75,6 +75,18 @@ Three nodes. The graph stays in Dolt. Auto-convoys group related beads so the re
 
 That's the meta-loop my [/gas-city-home](/gas-city-home) post named: the system describing itself, with the description being a worked example of the system. Same shape here, smaller scope.
 
+## The deeper frame: work is the primitive
+
+The cleanest statement of the whole architecture isn't on the docs site — it's in the [AGENTS.md](https://github.com/gastownhall/gascity/blob/main/AGENTS.md) at the root of the source tree. Two lines worth lifting:
+
+> _"ZERO hardcoded roles. The SDK has no built-in Mayor, Deacon, Polecat, or any other role. If a line of Go references a specific role name, it's a bug."_
+>
+> _"Work is the primitive, not orchestration."_
+
+Read those twice. Most multi-agent systems start by asking "what are the agents?" and bake the answers into the framework. Gas City asks **"what is work?"** and bakes the answer (a bead with dependencies and metadata) into the substrate, then makes everything else — agents, mail, dispatch, health patrol — composable on top. The doc lays out **five irreducible primitives** (Agent Protocol, Beads/Task Store, Event Bus, Config, Prompt Templates) and **four derived mechanisms** (Messaging, Formulas/Molecules, Dispatch, Health Patrol) — with the proof that all four derived shapes compose from the five primitives. Mail is `TaskStore.Create(bead{type:"message"})`. Sling is `find/spawn agent → select formula → create molecule → hook to agent`. None of it requires a special "Mayor" or "Polecat" type in the SDK — those are user configuration.
+
+That's why I keep saying _the unit of distribution is the formula, not the agent_. The agents are configurable. The work shape is the contract.
+
 ## Where to go next
 
 - The authoritative docs: **[docs.gastownhall.ai](https://docs.gastownhall.ai/)**. Start with [molecules](https://docs.gastownhall.ai/concepts/molecules/), [architecture](https://docs.gastownhall.ai/design/architecture/), and the [propulsion principle](https://docs.gastownhall.ai/concepts/propulsion-principle/).

--- a/_d/gas-city.md
+++ b/_d/gas-city.md
@@ -1,0 +1,85 @@
+---
+layout: post
+title: "Gas City: Beads, Molecules, and the Propulsion Principle"
+permalink: /gas-city
+tags:
+  - ai
+  - tools
+  - how
+  - explainer
+---
+
+If you've read [Standing Up Gas City](/gas-city-home), or seen "Gas City" mentioned in [/wally](/wally) or [/igors-claws](/igors-claws), and you want to know what the thing actually _is_ before you stand up your own — this is that post. Three concepts carry the whole design: **beads** (the unit of work), **molecules** (the choreography), and the **propulsion principle** (what keeps the engine running). Each one is plain enough on its own; the leverage is in how they compose.
+
+{% include ai-slop.html percent="80" %}
+
+The source of truth for all of this is [docs.gastownhall.ai](https://docs.gastownhall.ai/). My job here is to translate, not to duplicate — when a section needs the precise definition, I link out.
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [Beads — the unit](#beads--the-unit)
+- [Molecules — the choreography](#molecules--the-choreography)
+- [The Propulsion Principle](#the-propulsion-principle)
+- [Putting it together — how this post got made](#putting-it-together--how-this-post-got-made)
+- [Where to go next](#where-to-go-next)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+## Beads — the unit
+
+A **bead** is a tracked unit of work — title, description, type, priority, status, optional metadata. Beads carry dependencies (`needs:`), so `bd ready` returns only beads whose blockers are closed. The CLI is `bd`: `bd create` to file one, `bd ready` to see what's actionable, `bd close <id>` when it's done. Underneath it's a [Dolt](https://www.dolthub.com/) database — versioned SQL — so the whole graph is queryable, replayable, and durable across sessions. The `bd` man page is the surface; the storage is the substance.
+
+Beads matter because they're the smallest piece of state that survives a process death. An agent restarts, queries `bd ready`, finds work, and keeps moving. There's no in-memory queue to lose, no chat-log scroll to scan. If a bead exists and isn't closed, somebody — eventually — will pick it up.
+
+## Molecules — the choreography
+
+A single bead does one thing. The interesting work is multi-step: design something, implement it, review it, test it, ship it. That's a **[molecule](https://docs.gastownhall.ai/concepts/molecules/)** — a persistent workflow instance that orchestrates multi-step work, expressed as a graph of beads chained with `needs:`.
+
+The lifecycle has its own vocabulary, and once you see it the rest of the system clicks into place:
+
+- A **formula** is the source template — a TOML file describing the steps, their dependencies, and which agents run each one.
+- The formula gets **cooked** into a **protomolecule** — a frozen, immutable plan that won't drift mid-run.
+- A protomolecule is **poured** into a live **molecule** — an actual instance of the workflow, with its own beads, its own state, its own clock.
+- The molecule's individual **step beads** get created and routed to the right agents.
+- A **wisp** is the ephemeral cousin — a molecule that vanishes when it finishes rather than persisting.
+
+The canonical example shipped with Gas City is the **Shiny Workflow**: design → implement → review → test → submit. Five steps, five beads, one molecule. Each step blocks on the previous one's close. You can write your own formulas — that's the whole point.
+
+The line that makes molecules feel different from a shell script is from the docs themselves: _**"Molecules ARE the ledger — each step closure is a timestamped CV entry."**_ A shell script runs, exits, and leaves you grepping logs. A molecule records itself as it executes — every step's state transition is a row in Dolt with a timestamp. The workflow and its history are the same object.
+
+Agents talk to each other over a [mail protocol](https://docs.gastownhall.ai/other/beads-native-messaging/) — beads-flavored messages flowing between them, with groups, queues, and channels. For understanding Gas City you can treat that as plumbing; what matters here is that molecules don't need a central scheduler to advance, because each agent watches its own hook.
+
+## The Propulsion Principle
+
+The piece that took me longest to internalize isn't a data structure — it's an operating philosophy. The docs name it **GUPP — the Gastown Universal [Propulsion Principle](https://docs.gastownhall.ai/concepts/propulsion-principle/):**
+
+> _If there is work on your Hook, YOU MUST RUN IT._
+
+That's the whole rule. An agent that finds a bead routed to it on its hook executes immediately — no announcement, no permission cycle, no waiting for a nudge. The metaphor in the docs is a steam engine: agents function like pistons; efficiency depends on continuous execution. Every moment you wait is a moment the engine stalls.
+
+The principle is load-bearing for the **[polecat](https://docs.gastownhall.ai/concepts/polecat-lifecycle/)** — the ephemeral worker that spawns into a rig, claims its bead, does the work, and dies. The polecat-lifecycle doc is unusually blunt about this: _"There is no idle state. Polecats don't exist without work."_ A polecat that's awake but not running isn't waiting — by the design's own definition, it's in a failure state. Stalled or zombie. Pick one.
+
+I learned this concretely [the morning I stood up `igor-city`](/gas-city-home). First-time polecats sat idle on wake — supervisor up, beads routed, polecats spawned, nothing happening. I had to manually `gc session nudge <id> "pick up your bead"` for each one. That's a propulsion-principle violation. Polecats existing in a state the design says cannot exist. The fix — a `polecat-step-0-self-claim` step in the agent prompt that runs `bd ready --json | jq …` immediately on wake — wasn't a feature; it was GUPP re-asserted. The bug was a class of state the system isn't supposed to have. Once you internalize the principle, the fix writes itself.
+
+## Putting it together — how this post got made
+
+The bead lifecycle for the post you're reading:
+
+- **`lb-771`** — draft. A `larry-blog/editor` polecat read the brief, surveyed the related posts, wrote the explainer.
+- **Reviewer pair** — slung after the PR opens. Different polecat, different bias, adversarial pass on distill-don't-accrete and voice.
+- **Igor** — final reviewer, owns the merge.
+
+Three nodes. The graph stays in Dolt. Auto-convoys group related beads so the reviewer can't run before the editor closes. The whole sequence is queryable, replayable, durable across sessions — and, because of GUPP, no human had to push any of these agents to start. They woke up, queried their hooks, found work, and ran.
+
+That's the meta-loop my [/gas-city-home](/gas-city-home) post named: the system describing itself, with the description being a worked example of the system. Same shape here, smaller scope.
+
+## Where to go next
+
+- The authoritative docs: **[docs.gastownhall.ai](https://docs.gastownhall.ai/)**. Start with [molecules](https://docs.gastownhall.ai/concepts/molecules/), [architecture](https://docs.gastownhall.ai/design/architecture/), and the [propulsion principle](https://docs.gastownhall.ai/concepts/propulsion-principle/).
+- The lived narrative — five upstream bugs, one Sunday morning, one `igor-city`: [Standing Up Gas City](/gas-city-home).
+- The work-side companion — same MEOW pattern, different deployment: [Wally and My Work Gastown](/wally).
+- The wider claw context — why I'm running multiple AI entities at all: [Igor's Three Claws](/igors-claws).
+
+Formulas are designed to be shared — there's an in-progress registry called **Mol Mall**, npm-for-workflows, where you'll eventually browse and install other people's molecules. The fact that the unit of distribution is the formula, not the agent, is the part of this design I keep coming back to. Most coordination problems aren't about smarter agents; they're about better-shaped work. Gas City picked the work as the shareable artifact. That bet is going to age well.

--- a/back-links.json
+++ b/back-links.json
@@ -415,7 +415,7 @@
         },
         "/4dx": {
             "description": "The 4 Disciplines of Execution (4DX) is a proven framework for executing your most important strategic priorities in the midst of the whirlwind of day-to-day demands. This framework has been tested and refined by hundreds of organizations and thousands of teams over many years.\n\n",
-            "doc_size": 21000,
+            "doc_size": 20000,
             "file_path": "_site/4dx.html",
             "incoming_links": [
                 "/goals"
@@ -866,7 +866,7 @@
         },
         "/ai-cockpit": {
             "description": "Agents are slow. Not slow like “wait a second,” slow like “go make coffee and come back.” So you run several in parallel. But now you’ve got a different problem: you’re an air traffic controller with no radar. You need a cockpit - a physical and software control surface that gives you visibility into what your agents are doing and lets you switch between them instantly.\n\n",
-            "doc_size": 32000,
+            "doc_size": 31000,
             "file_path": "_site/ai-cockpit.html",
             "incoming_links": [
                 "/ai-feed",
@@ -2014,7 +2014,7 @@
                 "/igors-claws",
                 "/larry"
             ],
-            "last_modified": "2026-05-03T17:18:33.279669+00:00",
+            "last_modified": "2026-05-03T17:20:34+00:00",
             "markdown_path": "_d/claw.md",
             "outgoing_links": [
                 "/ai-journal",
@@ -2446,7 +2446,7 @@
         },
         "/day-in-the-life": {
             "description": "A running journal of days that actually worked - the ones where health habits stuck, family time hit different, or I remembered what it feels like to be fully alive. Not every day needs to be Instagram-worthy, but some days deserve a bookmark. This is that bookmark collection.\n\n",
-            "doc_size": 19000,
+            "doc_size": 18000,
             "file_path": "_site/day-in-the-life.html",
             "incoming_links": [],
             "last_modified": "2025-10-04T18:43:51-07:00",
@@ -3199,7 +3199,7 @@
         },
         "/gap-year-igor": {
             "description": "Done right, a gap year isn’t a year off; it’s a year on — intentional investment in health, relationships, and mastery while you still have the capital to invest. Think of it as pursuing a PhD in Life Optimization, making deposits that compound for decades. A gap year is one of those uncharted spaces—seductive when discussed longingly over a beer, terrifying when holding a resignation letter outside your boss’s office. Early maps warned: “HC SVNT DRACONES.” Here be dragons. I’m mapping them in real time: the Scarcity Dragon whispering you can’t afford it, the Entropy Dragon promising you’ll decay without structure, and the Squander Dragon insisting you’ll waste this precious opportunity. But these dragons guard treasure — the chance to invest in what truly matters while you still have the capacity to do so. This is the map of how to tame them.\n\n",
-            "doc_size": 73000,
+            "doc_size": 72000,
             "file_path": "_site/gap-year-igor.html",
             "incoming_links": [
                 "/42",
@@ -3248,12 +3248,31 @@
             "title": "Will Igor Take a Gap Year? Wrestling with Dragons and Dreams",
             "url": "/gap-year-igor"
         },
+        "/gas-city": {
+            "description": "If you’ve read Standing Up Gas City, or seen “Gas City” mentioned in /wally or /igors-claws, and you want to know what the thing actually is before you stand up your own — this is that post. Three concepts carry the whole design: beads (the unit of work), molecules (the choreography), and the propulsion principle (what keeps the engine running). Each one is plain enough on its own; the leverage is in how they compose.\n\n",
+            "doc_size": 23000,
+            "file_path": "_site/gas-city.html",
+            "incoming_links": [],
+            "last_modified": "2026-05-04T12:23:28.406847+00:00",
+            "markdown_path": "_d/gas-city.md",
+            "outgoing_links": [
+                "/gas-city-home",
+                "/igors-claws",
+                "/wally"
+            ],
+            "redirect_url": "",
+            "title": "Gas City: Beads, Molecules, and the Propulsion Principle",
+            "url": "/gas-city"
+        },
         "/gas-city-home": {
             "description": "I’m Larry, the always-on coach claw at home. Igor is migrating his at-home setup out of hand-rolled config into Steve Yegge’s Gas City. The plan, in three steps: scaffold the canonical city, install Barry as mayor, and — once we trust the system — see if I can do the whole job from the mayor’s seat. We’re not at step three. Igor named the mayor Barry because he wanted a placeholder, and the joke writes itself: don’t worry — once we’re confident we have a useful city, we’ll put Larry in charge.\n\n",
-            "doc_size": 33000,
+            "doc_size": 34000,
             "file_path": "_site/gas-city-home.html",
-            "incoming_links": [],
-            "last_modified": "2026-05-03T12:04:24-07:00",
+            "incoming_links": [
+                "/gas-city",
+                "/igors-claws"
+            ],
+            "last_modified": "2026-05-03T12:22:17-07:00",
             "markdown_path": "_d/gas-city-home.md",
             "outgoing_links": [
                 "/wally"
@@ -3350,7 +3369,7 @@
         },
         "/grammerly": {
             "description": "\n\n",
-            "doc_size": 13000,
+            "doc_size": 12000,
             "file_path": "_site/grammerly.html",
             "incoming_links": [],
             "last_modified": "2025-08-24T09:03:19-07:00",
@@ -3681,20 +3700,22 @@
         },
         "/igors-claws": {
             "description": "Here’s my concrete setup. I run three claws — persistent AI entities with names, memory, and a domain each. Life, work, transportation. This post is the surfaced roster so I can link straight to it when something I made is signed by one of them, and so I can explain why I’m building my own rather than running something off the shelf. If you want the “what is a claw” background first, read /claw; this is the instance, not the theory.\n\n",
-            "doc_size": 25000,
+            "doc_size": 26000,
             "file_path": "_site/igors-claws.html",
             "incoming_links": [
                 "/claw",
+                "/gas-city",
                 "/vibing",
                 "/wally"
             ],
-            "last_modified": "2026-05-03T17:33:19+00:00",
+            "last_modified": "2026-05-03T13:16:40-07:00",
             "markdown_path": "_d/igors-claws.md",
             "outgoing_links": [
                 "/ai-cockpit",
                 "/ai-journal",
                 "/claw",
                 "/design",
+                "/gas-city-home",
                 "/larry",
                 "/mortality-software",
                 "/tesla",
@@ -5506,7 +5527,7 @@
         },
         "/sharpen-the-saw": {
             "description": "A young man saw a woodcutter cutting down a tree and asked “What are you doing?” “Are you blind?” the woodcutter replied. “I’m cutting down this tree.” The young man continued. “You look exhausted! Take a break. Sharpen your saw.” The woodcutter explained he’d been sawing for hours and did not have time to take a break. The young man pushed back… “If you sharpen the saw, you would cut down the tree much faster.” The woodcutter said “I don’t have time to sharpen the saw. Don’t you see I’m too busy. These are my insights based on the 7 habits Chapter 7.\n\n",
-            "doc_size": 15000,
+            "doc_size": 14000,
             "file_path": "_site/sharpen-the-saw.html",
             "incoming_links": [
                 "/7-habits",
@@ -6035,7 +6056,7 @@
         },
         "/td/back_ref": {
             "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
-            "doc_size": 14000,
+            "doc_size": 13000,
             "file_path": "_site/td/back_ref.html",
             "incoming_links": [],
             "last_modified": "2022-04-16T15:22:43-07:00",
@@ -6506,7 +6527,7 @@
         },
         "/timeoff-2020-03": {
             "description": "In March 2020, I took a 2 month sabbatical between leaving Amazon and joining Facebook. Given it was a substantial amount of time, I came up with some big plans, and wrote them down. It was a great plan, BUT my time off correlated perfectly to the Corona Virus and as a result I wasted lots of my mental energy thinking about the Corona Virus, and adjusting to being in pseudo-quarantine. Took me a while, but I finally realized I should ignore corona virus, or at least minimize my time thinking about it.\n\n",
-            "doc_size": 31000,
+            "doc_size": 30000,
             "file_path": "_site/timeoff-2020-03.html",
             "incoming_links": [
                 "/timeoff"
@@ -7056,6 +7077,7 @@
             "doc_size": 34000,
             "file_path": "_site/wally.html",
             "incoming_links": [
+                "/gas-city",
                 "/gas-city-home",
                 "/igors-claws",
                 "/vibing"


### PR DESCRIPTION
## Summary

Standalone explainer post for [Gas City](https://docs.gastownhall.ai/) — a conceptual companion to [/gas-city-home](https://idvork.in/gas-city-home) (the lived narrative).

Three-pillar spine, ~1,200 words:

1. **Beads** — the unit of work (Dolt-backed, dependency-aware)
2. **Molecules** — the choreography (formula → cook → pour → live molecule → step beads, with the "Molecules ARE the ledger" quote anchoring the section)
3. **The Propulsion Principle** — names **GUPP** (Gastown Universal Propulsion Principle), defines polecats with the docs' "no idle state" quote, ties to today's `polecat-step-0-self-claim` fix as GUPP re-asserted

Closes with the meta-loop ("how this post got made") and a Where-to-go-next that mentions **Mol Mall** as the formula registry.

Cross-links: `/gas-city-home`, `/wally`, `/igors-claws`. No Wally narrative — pure concepts.

## Files

- `_d/gas-city.md` — new post, permalink `/gas-city`, tags `[ai, tools, how, explainer]`
- `back-links.json` — regenerated so the inbound "Mentioned in:" graph picks up `/gas-city`

## Test Plan

- [x] `prettier --write` on `_d/gas-city.md`
- [x] TOC regenerated via `.claude/skills/toc/toc.py` (in sync)
- [x] `bundle exec jekyll build --incremental` succeeds (Ruby 3.1)
- [x] `just update-backlinks` regenerated `back-links.json`; new entry includes correct excerpt and outgoing links
- [x] `prek run --files _d/gas-city.md back-links.json` — all hooks pass (anchor checker, lychee, etc.)
- [ ] Igor reads it for voice + accuracy
- [ ] Reviewer polecat does adversarial pass on distill-don't-accrete + GUPP framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Launched the "Gas City" guide explaining beads (tracked work units), molecules (multi-step workflows), and the propulsion principle (GUPP), including a table of contents, deeper framing, end-to-end example workflow, and next-step pointers (including a growing "Mol Mall" registry).
  * Updated site navigation and redirects plus internal link mappings and metadata to surface the new content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->