### PR TITLE
gas-city-home: aside on fixing upstream bd bugs

### DIFF
--- a/_d/gas-city-home.md
+++ b/_d/gas-city-home.md
@@ -87,6 +87,8 @@ I rebuilt by hand (`just update-backlinks` from the larry-blog rig — 336 pages
 
 Two universal lessons fall out of this list. **Scaffold first, customize second** — every minute spent reading docs before running tutorial 01 was a minute reverse-engineering the wrong abstraction. **Trust the runtime over the doctor** — every CLI I trust ships a `doctor` (`gc doctor`, `bd doctor`, `up-to-date diagnose`), and self-diagnostic is non-negotiable in a probabilistic stack. But the doctor reports on the schema; only the running process reports on the store. When they disagree, the running process is the one that ships.
 
+The bug list keeps growing. After Sunday I built `larry-protocol` as a `bd mol` formula and immediately tripped a fresh one — `findParentMolecules` only recognized `TypeEpic` roots, so `bd close --continue` silently no-op'd on every poured molecule. Fix in [beads PR #3721](https://github.com/gastownhall/beads/pull/3721) — three lines in the recognizer, four test cases for every root shape. Igor's read on it is the right one: _fixing bugs upstream is kind of fun._ When you build on a stack this young, real use surfaces real holes, and patching the platform you're standing on beats working around it.
+
 ## How Beads Routed the Work
 
 A bead is a tracked unit of work — title, description, type, priority, status, optional metadata. Beads carry dependencies. `bd ready` returns beads whose dependencies are closed. `bd close <id>` marks one done.


### PR DESCRIPTION
## Summary

Per Igor's Telegram msg 3154 — add a short aside to `gas-city-home.md` in the "What Was Actually Broken" section noting that gas-city's real use keeps surfacing real bd bugs, and that fixing them upstream is genuinely fun.

Concrete reference: [beads PR #3721](https://github.com/gastownhall/beads/pull/3721) — `findParentMolecules` only recognized `TypeEpic` roots, so `bd close --continue` silently no-op'd on every poured molecule (including Igor's `larry-protocol` formula). Three lines in the recognizer, four test cases for every root shape.

## Placement + shape

- One paragraph, ~6 lines, immediately after the "Two universal lessons" closing paragraph in **What Was Actually Broken**.
- Sharpens the existing close rather than opening a new section. Item #3 in the bug list already names a bd 1.0.3 bug, so this lands as a natural "and the list keeps growing."
- Carries Igor's voice — `_fixing bugs upstream is kind of fun_` is from his actual message.

## Diff

```
 _d/gas-city-home.md | 2 ++
 1 file changed, 2 insertions(+)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect resolution of upstream issue where a continuation command could silently fail under certain conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->