### PR TITLE
7h-c1: augment Be Proactive from Covey ebook

### DIFF
--- a/_d/7h-c1.md
+++ b/_d/7h-c1.md
@@ -17,27 +17,31 @@ redirect_from:
 
 I choose '.' I am responsible for my own life '.' My behavior is a function of my decisions, not my conditions '.' I can subordinate feelings to values '.' I have the initiative and the responsibility to make things happen. These are my insights from [7 habits](/7h) Chapter 1.
 
+{% include ai-slop.html percent="50" %}
+
 TODO: Link to videos
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
 - [Equanimity calm the mind](#equanimity-calm-the-mind)
-    - [See ourselves - independent of feeling and mood and others](#see-ourselves---independent-of-feeling-and-mood-and-others)
-    - [Make our own weather - can prefer it to be sunny, but should be able to generate own value without it](#make-our-own-weather---can-prefer-it-to-be-sunny-but-should-be-able-to-generate-own-value-without-it)
-    - [Carry a bubble of our own emotions](#carry-a-bubble-of-our-own-emotions)
+  - [See ourselves - independent of feeling and mood and others](#see-ourselves---independent-of-feeling-and-mood-and-others)
+  - [Make our own weather - can prefer it to be sunny, but should be able to generate own value without it](#make-our-own-weather---can-prefer-it-to-be-sunny-but-should-be-able-to-generate-own-value-without-it)
+  - [Carry a bubble of our own emotions](#carry-a-bubble-of-our-own-emotions)
 - [Respond don't react](#respond-dont-react)
-    - [Create Time between stimulus and response](#create-time-between-stimulus-and-response)
-    - [Freedom to choose the response](#freedom-to-choose-the-response)
-    - [Two ends, action and consequence, pick action, get consequence](#two-ends-action-and-consequence-pick-action-get-consequence)
+  - [Create Time between stimulus and response](#create-time-between-stimulus-and-response)
+  - [Freedom to choose the response](#freedom-to-choose-the-response)
+  - [Two ends, action and consequence, pick action, get consequence](#two-ends-action-and-consequence-pick-action-get-consequence)
 - [Be Proactive](#be-proactive)
-    - [Initiative - Our responsibility to make things happen](#initiative---our-responsibility-to-make-things-happen)
-    - [Act or be acted upon](#act-or-be-acted-upon)
-    - [Reactive vs Proactive Language - I have to vs I choose](#reactive-vs-proactive-language---i-have-to-vs-i-choose)
-    - [Love verb vs noun](#love-verb-vs-noun)
-    - [CI/CC - Circle of Influence/Circle of Concern](#cicc---circle-of-influencecircle-of-concern)
-    - [Growing our CI](#growing-our-ci)
-    - [Keeping Commitments - our most valuable PC](#keeping-commitments---our-most-valuable-pc)
+  - [Initiative - Our responsibility to make things happen](#initiative---our-responsibility-to-make-things-happen)
+  - [Act or be acted upon](#act-or-be-acted-upon)
+  - [Reactive vs Proactive Language - I have to vs I choose](#reactive-vs-proactive-language---i-have-to-vs-i-choose)
+  - [Love verb vs noun](#love-verb-vs-noun)
+  - [CI/CC - Circle of Influence/Circle of Concern](#cicc---circle-of-influencecircle-of-concern)
+  - [Growing our CI](#growing-our-ci)
+  - [Have's vs Be's](#haves-vs-bes)
+  - [Keeping Commitments - our most valuable PC](#keeping-commitments---our-most-valuable-pc)
+  - [The 30-day test](#the-30-day-test)
 - [Books](#books)
 
 <!-- vim-markdown-toc-end -->
@@ -45,29 +49,107 @@ TODO: Link to videos
 
 ## Equanimity calm the mind
 
+Before I can be proactive I need a self I can hear. The whole habit rests on one uniquely human capacity: I can think about my own thinking. I can stand apart from a feeling, look at it, name it, and decide what to do with it. Animals can't. Most of the time, neither can I — but I can train it.
+
 {%include summarize-page.html src='/siy' %}
 
 ### See ourselves - independent of feeling and mood and others
 
+I am not my feelings. I am not my mood. I'm not even my thoughts. The fact that I can _observe_ my mood means I'm not it. The observer and the observed can't be the same thing.
+
+This is the first move in the whole book. Without it, every later habit collapses. If I'm fused with my mood, "respond don't react" is meaningless — there's no _I_ doing the responding, just the mood doing whatever it does. Self-awareness is what creates the gap.
+
+The practice is small and constant: name the state. _I'm anxious. I'm spinning on this Slack message. I'm exhausted and reading the kid's whining as personal._ Naming the state demotes it from being-me to a thing-I'm-having. The thing-I'm-having can be put down.
+
 ### Make our own weather - can prefer it to be sunny, but should be able to generate own value without it
+
+Reactive people are weather vanes. Sun comes out, they're up. Cold comes in, they're flat. Their boss is curt at standup, they're flat. The kid is a brat at breakfast, they're flat all morning.
+
+I can prefer good weather. I can prefer the boss to be warm and the kid to eat their oatmeal. But if my entire emotional state is downstream of those, I've handed every person and event in my life a remote control to my nervous system.
+
+The proactive move is to carry my own weather. The values I've chosen — what I think a good day looks like, what kind of person I'm trying to be — drive the day. External weather adds or subtracts a little, but the baseline is mine. I notice the difference most when I work out in the morning before anything else can hijack me. The weather is set by 7am.
 
 ### Carry a bubble of our own emotions
 
+Same idea, social version. Reactive people sponge up the emotional state of whoever they're with — angry coworker, the day is angry; anxious teammate, the day is anxious. They're emotionally permeable.
+
+Carrying a bubble means I can sit with someone's distress without becoming distressed, sit with someone's anger without becoming angry. Not because I don't feel it — I do — but because I've practiced the gap between feeling it and being it. This is the prerequisite for [empathic listening](/first-understand): you can't hear someone clearly if you're catching their mood like a virus.
+
+The bubble is permeable on purpose. When my kid is genuinely scared, I want to feel some of that with her — that's connection. The work is on the involuntary version: catching irritation from a coworker's tone and carrying it home, becoming impatient with my wife because someone in the meeting was impatient with me.
+
 ## Respond don't react
+
+The whole habit lives in the space between stimulus and response. Reactive people collapse that space — stimulus arrives, response fires, no daylight in between. Proactive people defend that space and use it.
 
 ### Create Time between stimulus and response
 
+Viktor Frankl is the canonical example. A psychiatrist imprisoned in the Nazi death camps, watching his family die, with the Nazis controlling every external thing about his existence. He discovered the one freedom they couldn't take: between what was happening to him and his response, he had a gap. They controlled his liberty (options in the environment). He kept his freedom (the choice of response).
+
+The everyday version is mundane. Slack ping. Email. Kid spilling juice. Spouse criticizing. Driver cutting me off. The reactive default is stimulus-→-response in milliseconds, with the response shaped by whatever I happened to be feeling at the moment. The proactive practice is to widen the gap — even by half a second — long enough to ask: what response do I _choose_?
+
+The technologies for widening the gap are old: a breath, a pause, naming the feeling, walking around the block, sleeping on the email before sending it. None of them are clever. All of them work.
+
 ### Freedom to choose the response
 
+Inside the gap are four endowments that animals don't have:
+
+| Endowment       | What it does                                            |
+| --------------- | ------------------------------------------------------- |
+| Self-awareness  | I can examine my own thoughts and patterns              |
+| Imagination     | I can simulate responses I haven't tried before         |
+| Conscience      | I can sense whether a response aligns with my values    |
+| Independent will | I can act on my values, even against feelings or scripts |
+
+Eleanor Roosevelt: _"No one can hurt you without your consent."_ Gandhi: _"They cannot take away our self respect if we do not give it to them."_ These are not denials of the original injury — physical or economic harm is real. They're claims about the second-order effect: my consent is what lets the harm continue to bruise me long after the moment is over.
+
+The hardest version of this principle is admitting it about old wounds. _I am what I am today because of the choices I made yesterday._ Until I can say that, I can't say _I choose otherwise_. The freedom only lights up once I claim the responsibility.
+
 ### Two ends, action and consequence, pick action, get consequence
+
+I am free to choose actions. I am not free to choose their consequences — those are governed by natural law and arrive whether I like them or not. _When you pick up one end of the stick, you pick up the other._
+
+I can decide to skip the workout. I cannot decide that skipping the workout doesn't compound. I can decide to be dishonest in a small way at work; I cannot decide what that does to my character or to the trust account with my colleague.
+
+This is liberating, not depressing. It moves me from "I'll do X and hope it works out" to "X comes attached to Y — am I willing to take Y?" Most bad decisions are decisions where I tried to take the good end of the stick without the bad end.
+
+Sometimes I pick up the wrong stick anyway — that's a mistake. The proactive move with mistakes is fast: acknowledge, correct, learn, move on. The slow move is the cover-up, where the rationalization causes more damage than the original mistake. Chasing the snake that bit me only drives the poison deeper.
 
 ## Be Proactive
 
 ### Initiative - Our responsibility to make things happen
 
+Proactivity isn't pushiness. It's the recognition that my behavior is a function of my decisions, not my conditions. _Response-ability_ — the ability to choose my response.
+
+When my kids start a complaint with "but he won't / she won't / they won't…" the answer in our house is "use your R and I" — resourcefulness and initiative. The complaint is a request for someone else to fix the situation. R and I is the move from request to action.
+
+The same applies in my own life. The job-search version: most people who want a better job describe a better job they want. The proactive few study the company, identify a problem the company is facing, and bring a proposal for how their skills solve it. "Solution selling" — and it works because it's so rare.
+
 ### Act or be acted upon
 
+The gap between people who exercise initiative and people who don't isn't 25% or 50%. It's a 5000-percent gap. Compounded over a career, the proactive person is in a different universe.
+
+The reason is the feedback loop. Acting produces information; information produces better action; better action produces results; results produce confidence; confidence produces more acting. Not acting produces nothing — and the absence of information gets backfilled with anxiety and stories about why action wouldn't work anyway.
+
+If I'm not acting, the world is acting on me. There's no neutral state.
+
 ### Reactive vs Proactive Language - I have to vs I choose
+
+The fastest diagnostic for whether I'm being proactive: listen to my own language.
+
+| Reactive (determined)         | Proactive (chosen)                       |
+| ----------------------------- | ---------------------------------------- |
+| There's nothing I can do      | Let's look at our alternatives           |
+| That's just the way I am      | I can choose a different approach        |
+| He makes me so mad            | I control my own feelings                |
+| They won't allow that         | I can create an effective presentation   |
+| I have to do that             | I will choose an appropriate response    |
+| I can't                       | I choose                                 |
+| I must                        | I prefer                                 |
+| If only…                      | I will                                   |
+
+"I have to go on a tennis trip" really means "I _choose_ to go because I want the consequence of staying on the team." The word _have_ launders the choice and the responsibility right out of the sentence. The cost is real — I lose the felt sense of agency. The dial drifts toward _I am being lived_.
+
+Proactive language isn't a verbal tic to swap in. The words follow the paradigm. But the words also reinforce the paradigm. So both directions matter — change the paradigm to change the words, and watch the words to catch the paradigm slipping.
 
 {%include summarize-page.html src='/essentialism' %}
 
@@ -75,13 +157,78 @@ TODO: Link to videos
 
 Love is a verb, it is something you do, even when it's hard. It's not a feeling. If it's a feeling you'll never find it. But, the verb you can always do.
 
+Reactive people make love a feeling — and then declare the marriage over when the feeling fades. _The feeling just isn't there anymore. What can I do?_ Love her. Serve her. Sacrifice. Listen. Empathize. Appreciate. The feeling is the fruit of the verb, not the cause of it. Hollywood scripted us backwards.
+
+Same for almost every value worth having: integrity, courage, patience, gratitude. They're verbs that occasionally produce the matching feeling. Wait for the feeling first and you wait forever.
+
 ### CI/CC - Circle of Influence/Circle of Concern
 
 Very similar to the concept of anxiety being 'trying to control something', and shifting the question to how can you maximize your influence.
 
+Two circles, nested:
+
+- **Circle of Concern** — everything I care about. National politics, the weather, my boss's mood, the economy, my kid's report card, my health, my marriage, the team's roadmap.
+- **Circle of Influence** — the subset of the Circle of Concern that I can actually do something about. My health, my own work, how I show up at home, the conversations I have today.
+
+The circles are descriptive — everyone has both. The proactive question is _which circle am I spending my energy in?_
+
+Reactive people sit in the gap between the two circles, complaining about the things in Concern they can't influence. National politics. Their boss. Their spouse. The economy. The energy spent there is wasted — by definition, Concern minus Influence is the set of things complaining can't change. And worse, the energy comes out of the Circle of Influence, which then shrinks.
+
+Proactive people focus their energy in the Circle of Influence. The energy is positive — building, doing, shipping, listening. And the Circle of Influence _grows_, because doing the work in Influence creates the conditions where new things become influenceable. Promotion. Trust. New skills. New relationships.
+
 ### Growing our CI
 
+The story I keep coming back to: the dictatorial executive everyone in the corridors complained about. The complainers stayed reactive — _can he really not retire for six more years?_ — and their Circle of Influence stayed exactly where it was.
+
+One executive went the other way. He read the boss's style. He compensated for the weaknesses without flagging them. He brought the boss not just data but analysis and recommendations consistent with the analysis. The boss started saying "what's your opinion?" while the others kept getting "go for this." His Circle of Influence grew until nothing significant happened in the org without his input.
+
+The mechanism is the same one that worked for Gandhi while his accusers stayed in the legislative chambers complaining about the British. Gandhi went to the rice paddies and built influence with the field laborers, one conversation at a time, until he held no office and could still bring an empire to its knees.
+
+Growing my Circle of Influence is almost always done by being more useful at the boundary, not by demanding more authority. The expansion follows the contribution.
+
+### Have's vs Be's
+
+A diagnostic for which circle I'm operating in: am I thinking in _haves_ or _bes_?
+
+Circle of Concern is full of _haves_:
+
+- I'll be happy _when I have_ my house paid off.
+- _If only I had_ a boss who wasn't such a dictator.
+- _If I had_ more time to myself.
+- _If I had_ a more patient spouse.
+
+Circle of Influence is full of _bes_:
+
+- I can _be_ more patient.
+- I can _be_ more resourceful.
+- I can _be_ a better listener.
+- I can _be_ a more loving partner.
+
+_Anytime I think the problem is "out there," that thought is the problem._ The change paradigm is inside-out: be different, and by being different, change what's out there. Joseph in slavery, then in prison — both times he worked on _be_, not on the circumstances, and both times the circumstances reorganized around him.
+
+If I'm complaining about my marriage, the question isn't whether the complaint is fair. The question is: am I working on _having_ a different spouse, or _being_ a different partner? The first is mostly impotent. The second is almost always available.
+
 ### Keeping Commitments - our most valuable PC
+
+At the very heart of the Circle of Influence is the ability to make and keep commitments — to myself first, and then to others.
+
+Every promise I keep to myself deposits in an internal trust account. _I said I'd run today. I ran today._ _I said I'd write the hard email. I wrote it._ The deposit is small. The compounding is enormous. Over time, my honor grows greater than my moods — meaning I can rely on myself even when I don't feel like it.
+
+Every promise I break to myself withdraws. _I said I'd start the diet Monday. It's Wednesday._ The withdrawal teaches me, at the level below conscious thought, that my own word doesn't bind me. Once that lesson lands, every future commitment is a smaller deposit, because part of me already expects the breakage.
+
+This is the most important production-capability investment I make. The PC that produces _every other_ habit on this list. Without the muscle of commitment-keeping to myself, none of the rest is reachable.
+
+The intervention is to start small enough that I can't fail. A 5-minute commitment kept beats a 60-minute commitment broken. The deposit isn't proportional to the size — it's proportional to the kept-ness.
+
+### The 30-day test
+
+The challenge: for 30 days, work _only_ in your Circle of Influence. Make small commitments and keep them. Be a light, not a judge. Be a model, not a critic. Be part of the solution, not part of the problem.
+
+Don't argue for other people's weaknesses. Don't argue for your own. When you make a mistake, admit it, correct it, learn from it — fast. Don't enter the blaming/accusing frame. Work on what you control. Work on _be_.
+
+If you catch yourself thinking "the problem is out there" — stop. _That thought is the problem._
+
+I find 30 days is the right unit because it's long enough that the habit starts changing my baseline state, and short enough that I can hold the discipline without negotiating. Day 5 feels stupid. Day 12 feels suspicious. Day 22 something shifts. Day 30 I don't want to stop.
 
 ## Books
 

--- a/_d/7h-c1.md
+++ b/_d/7h-c1.md
@@ -53,6 +53,8 @@ Before I can be proactive I need a self I can hear. The whole habit rests on one
 
 {%include summarize-page.html src='/siy' %}
 
+{%include summarize-page.html src='/four-healths' %}
+
 ### See ourselves - independent of feeling and mood and others
 
 I am not my feelings. I am not my mood. I'm not even my thoughts. The fact that I can _observe_ my mood means I'm not it. The observer and the observed can't be the same thing.
@@ -77,6 +79,8 @@ Carrying a bubble means I can sit with someone's distress without becoming distr
 
 The bubble is permeable on purpose. When my kid is genuinely scared, I want to feel some of that with her — that's connection. The work is on the involuntary version: catching irritation from a coworker's tone and carrying it home, becoming impatient with my wife because someone in the meeting was impatient with me.
 
+{%include summarize-page.html src='/curious' %}
+
 ## Respond don't react
 
 The whole habit lives in the space between stimulus and response. Reactive people collapse that space — stimulus arrives, response fires, no daylight in between. Proactive people defend that space and use it.
@@ -88,6 +92,8 @@ Viktor Frankl is the canonical example. A psychiatrist imprisoned in the Nazi de
 The everyday version is mundane. Slack ping. Email. Kid spilling juice. Spouse criticizing. Driver cutting me off. The reactive default is stimulus-→-response in milliseconds, with the response shaped by whatever I happened to be feeling at the moment. The proactive practice is to widen the gap — even by half a second — long enough to ask: what response do I _choose_?
 
 The technologies for widening the gap are old: a breath, a pause, naming the feeling, walking around the block, sleeping on the email before sending it. None of them are clever. All of them work.
+
+{%include summarize-page.html src='/breath' %}
 
 ### Freedom to choose the response
 
@@ -153,6 +159,8 @@ Proactive language isn't a verbal tic to swap in. The words follow the paradigm.
 
 {%include summarize-page.html src='/essentialism' %}
 
+{%include summarize-page.html src='/affirmations' %}
+
 ### Love verb vs noun
 
 Love is a verb, it is something you do, even when it's hard. It's not a feeling. If it's a feeling you'll never find it. But, the verb you can always do.
@@ -175,6 +183,8 @@ The circles are descriptive — everyone has both. The proactive question is _wh
 Reactive people sit in the gap between the two circles, complaining about the things in Concern they can't influence. National politics. Their boss. Their spouse. The economy. The energy spent there is wasted — by definition, Concern minus Influence is the set of things complaining can't change. And worse, the energy comes out of the Circle of Influence, which then shrinks.
 
 Proactive people focus their energy in the Circle of Influence. The energy is positive — building, doing, shipping, listening. And the Circle of Influence _grows_, because doing the work in Influence creates the conditions where new things become influenceable. Promotion. Trust. New skills. New relationships.
+
+{%include summarize-page.html src='/anxiety' %}
 
 ### Growing our CI
 


### PR DESCRIPTION
## Summary

Same pattern as #607 (now merged). Filled the previously-empty TOC sections in [/be-proactive](https://idvorkin.github.io/be-proactive) (Habit 1) with first-person prose drawn from Habit 1 of Covey's ebook. Preserves Igor's three-act structure (Equanimity → Respond don't react → Be Proactive) — just adds content underneath each header.

## What's filled in

**Equanimity (calm the mind)**
- Self-awareness as the prerequisite endowment
- Observer/observed split (I am not my mood)
- "Make our own weather" — carry the baseline
- "Carry a bubble" — emotional permeability and empathic listening

**Respond don't react**
- Frankl's gap, plus the everyday version (Slack pings, traffic)
- The four endowments table (self-awareness / imagination / conscience / independent will)
- Roosevelt and Gandhi quotes — second-order injury
- The stick metaphor (action and consequence are bound) + fast-mistake handling

**Be Proactive**
- "R and I" family rule, solution-selling for jobs
- Act-or-be-acted-upon (the 5000% gap, feedback loop)
- The full Reactive vs Proactive language table + the tennis-trip dialog
- Expanded CI/CC with story of the dictatorial executive and Gandhi in the rice paddies
- **NEW: Have's vs Be's** — the diagnostic question Igor's TOC was missing
- Keeping Commitments as the heart-of-CI compounding argument
- **NEW: The 30-day test** — Covey's challenge frame

## Preserved verbatim

- Opening four-clause definition ("I choose. I am responsible…")
- Existing summarize-page includes (`/siy`, `/essentialism`, `/frog`)
- Love verb vs noun paragraph
- Existing CI/CC anxiety-reframe sentence
- The Flinch link, amazon include, the "TODO: Link to videos" placeholder

## Marked

`ai-slop percent="50"` — placed after the opening paragraph per content guidelines.

## Test plan

- [x] TOC regenerated with `.claude/skills/toc/toc.py`
- [x] Page renders at http://localhost:4000/be-proactive (HTTP 200, ~40 KB)
- [x] All 18 anchor IDs present and unchanged from prior version (the two new anchors are additive)
- [ ] Igor visual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)