### PR TITLE
7h-c0: add summarize-page cards + fix broken /some link

### DIFF
--- a/_d/7h-c0.md
+++ b/_d/7h-c0.md
@@ -56,6 +56,8 @@ The Personality Ethic isn't all wrong — communication skills and a positive mi
 
 This is the cram vs. the farm. You can cram for a test and pass; you can't cram a harvest. Relationships, leadership, parenting — these are farms. The price gets paid in seasons, not weekends.
 
+{% include summarize-page.html src="/four-healths" %}
+
 ### Paradigm - rabbit vs duck
 
 A paradigm is the lens — the map, the model, the frame. It's the way I "see" the world before I think about what I'm seeing. Most of mine are invisible to me, which is exactly what makes them so powerful.
@@ -196,9 +198,11 @@ This is also why I write these summaries. The post is the act of teaching, and I
 
 ### How we "see" the problem, becomes our subjective problem.
 
-From [Sleight of Mouth](/some):
+From [Sleight of Mouth](/sleight-of-mouth):
 
 _Language, often unknown to us, creates our mental models, our reality, and defines our meaning. But the model is not the terrain, and by engaging with the language we can change mental models. Sleight of mouth (SoM) is a series of techniques for changing our models, reality and meanings and thus our experiences. Our mental models are a frame, and we need help going from a 'problem frame' to a 'desired outcome frame', a 'failure frame' to a 'feedback frame', and an 'impossible frame' to an 'as if' frame. To experience the power of language, find anything that is invisible to you, and name it. Now as you've given it a name, see how you perceive it, and become aware of it._
+
+{% include summarize-page.html src="/sleight-of-mouth" %}
 
 Said another way: _"The way we see the problem is the problem."_ When my employees seem disengaged, the Personality Ethic answer is to find a better motivation seminar or more inspiring slogans. The inside-out question is: do they sense that I see them as mechanical objects? Is there some truth to that? Is the way I look at the people who work for me part of what I'm calling the problem?
 
@@ -216,3 +220,5 @@ Inside-out isn't a checklist you complete once. It's an upward spiral:
 Each habit feeds the next. Being proactive (Habit 1) is what lets me begin with the end in mind (Habit 2), which is what lets me put first things first (Habit 3). Independence opens the door to Win/Win (4). Win/Win is the prerequisite for empathic listening (5). Both are required for synergy (6). And Habit 7 — sharpen the saw — is what keeps the whole spiral spinning instead of grinding flat.
 
 Einstein: _"The significant problems we face cannot be solved at the same level of thinking we were at when we created them."_ Each rotation of the spiral is a small jump in level. That's the whole game.
+
+{% include summarize-page.html src="/eulogy" %}

--- a/back-links.json
+++ b/back-links.json
@@ -353,7 +353,7 @@
     "url_info": {
         "/22": {
             "description": "In 2019 I created a program for 15 fantastic interns! A program highlight was my talk titled “What I wish I knew at 22, and so might you”. The talk received a 94% overall rating from over 15 interns, 10 SDE-IIs, and 1 senior developer. Even though the talk focuses on how to live the good life, a big chunk of life is work, so there’s good coverage on how to optimize your career.\n\n",
-            "doc_size": 16000,
+            "doc_size": 17000,
             "file_path": "_site/22.html",
             "incoming_links": [
                 "/chapters",
@@ -415,7 +415,7 @@
         },
         "/4dx": {
             "description": "The 4 Disciplines of Execution (4DX) is a proven framework for executing your most important strategic priorities in the midst of the whirlwind of day-to-day demands. This framework has been tested and refined by hundreds of organizations and thousands of teams over many years.\n\n",
-            "doc_size": 20000,
+            "doc_size": 21000,
             "file_path": "_site/4dx.html",
             "incoming_links": [
                 "/goals"
@@ -438,6 +438,7 @@
             "doc_size": 18000,
             "file_path": "_site/7-habits.html",
             "incoming_links": [
+                "/7h-concepts",
                 "/balance",
                 "/be-proactive",
                 "/books-that-defined-me",
@@ -473,8 +474,8 @@
             "url": "/7-habits"
         },
         "/7h-concepts": {
-            "description": "To discuss the 7 habits we need some foundational ideas, P/PC, paradigms, etc. These are my insights based on the 7 habits Chapter 0.\n\n",
-            "doc_size": 18000,
+            "description": "To talk about the 7 habits I need the foundation that comes before the habits start: paradigms, principles, the maturity continuum, and P/PC balance. These are my insights from 7 habits Chapter 0 — the lens you need to even see what the habits are pointing at.\n\n",
+            "doc_size": 34000,
             "file_path": "_site/7h-concepts.html",
             "incoming_links": [
                 "/7-habits",
@@ -485,9 +486,12 @@
             "last_modified": "2026-05-10T16:23:33.726253+00:00",
             "markdown_path": "_d/7h-c0.md",
             "outgoing_links": [
-                "/7h",
+                "/7-habits",
                 "/balance",
-                "/some"
+                "/curious",
+                "/eulogy",
+                "/four-healths",
+                "/sleight-of-mouth"
             ],
             "redirect_url": "",
             "title": "7 habits concepts",
@@ -865,7 +869,7 @@
         },
         "/ai-cockpit": {
             "description": "Agents are slow. Not slow like “wait a second,” slow like “go make coffee and come back.” So you run several in parallel. But now you’ve got a different problem: you’re an air traffic controller with no radar. You need a cockpit - a physical and software control surface that gives you visibility into what your agents are doing and lets you switch between them instantly.\n\n",
-            "doc_size": 31000,
+            "doc_size": 32000,
             "file_path": "_site/ai-cockpit.html",
             "incoming_links": [
                 "/ai-feed",
@@ -1034,11 +1038,12 @@
                 "/ai-art",
                 "/ai-journal",
                 "/ai-security",
-                "/ai-talk",
                 "/chop",
                 "/chow",
                 "/claw",
+                "/end-in-mind",
                 "/eulogy",
+                "/genai-talk",
                 "/gpt",
                 "/hill-climbing",
                 "/how-igor-chops",
@@ -1491,7 +1496,7 @@
         },
         "/bc": {
             "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-            "doc_size": 22000,
+            "doc_size": 23000,
             "file_path": "_site/bc.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T03:02:44+00:00",
@@ -1507,7 +1512,7 @@
         },
         "/be-proactive": {
             "description": "I choose ‘.’ I am responsible for my own life ‘.’ My behavior is a function of my decisions, not my conditions ‘.’ I can subordinate feelings to values ‘.’ I have the initiative and the responsibility to make things happen. These are my insights from 7 habits Chapter 1.\n\n",
-            "doc_size": 22000,
+            "doc_size": 23000,
             "file_path": "_site/be-proactive.html",
             "incoming_links": [
                 "/7-habits",
@@ -1646,7 +1651,7 @@
         },
         "/books-that-defined-me": {
             "description": "Books allow great thoughts to enter our mind and mold us into who we want to become. These are the books that are molding me.\n\n",
-            "doc_size": 16000,
+            "doc_size": 17000,
             "file_path": "_site/books-that-defined-me.html",
             "incoming_links": [
                 "/being-a-great-manager",
@@ -1827,16 +1832,15 @@
         },
         "/changelog": {
             "description": "A weekly summary of what changed on this blog and across my GitHub projects. Useful for returning readers who want to catch up on new content and updates.\n\n",
-            "doc_size": 127000,
+            "doc_size": 142000,
             "file_path": "_site/changelog.html",
             "incoming_links": [],
-            "last_modified": "2026-05-02T15:40:00-07:00",
+            "last_modified": "2026-05-05T08:16:23-07:00",
             "markdown_path": "_d/changelog.md",
             "outgoing_links": [
                 "/act",
                 "/activation",
                 "/addiction",
-                "/agency",
                 "/ai-cockpit",
                 "/ai-journal",
                 "/ai-native-manager",
@@ -1844,7 +1848,11 @@
                 "/ai-relationships",
                 "/ai-second-brain",
                 "/claw",
+                "/design",
+                "/gas-city",
+                "/gas-city-home",
                 "/hill-climbing",
+                "/hobby",
                 "/how-igor-chops",
                 "/human-meetings",
                 "/humans-are-underrated",
@@ -1863,6 +1871,8 @@
                 "/side-quests",
                 "/spiritual-health",
                 "/taxes",
+                "/vibing",
+                "/wally",
                 "/y26"
             ],
             "redirect_url": "",
@@ -2163,6 +2173,7 @@
             "doc_size": 19000,
             "file_path": "_site/curious.html",
             "incoming_links": [
+                "/7h-concepts",
                 "/90days",
                 "/act",
                 "/affirmations",
@@ -2446,7 +2457,7 @@
         },
         "/day-in-the-life": {
             "description": "A running journal of days that actually worked - the ones where health habits stuck, family time hit different, or I remembered what it feels like to be fully alive. Not every day needs to be Instagram-worthy, but some days deserve a bookmark. This is that bookmark collection.\n\n",
-            "doc_size": 18000,
+            "doc_size": 19000,
             "file_path": "_site/day-in-the-life.html",
             "incoming_links": [],
             "last_modified": "2025-10-04T18:43:51-07:00",
@@ -2484,7 +2495,7 @@
         },
         "/debug": {
             "description": "Igor's Blog",
-            "doc_size": 23000,
+            "doc_size": 24000,
             "file_path": "_site/debug.html",
             "incoming_links": [],
             "last_modified": "2025-03-16T16:15:36+00:00",
@@ -2776,6 +2787,7 @@
                 "/4dx",
                 "/7-habits",
                 "/affirmations",
+                "/ai-journal",
                 "/content-audience",
                 "/d/resistance",
                 "/elder",
@@ -2912,6 +2924,7 @@
             "file_path": "_site/eulogy.html",
             "incoming_links": [
                 "/7-habits",
+                "/7h-concepts",
                 "/act",
                 "/ai-journal",
                 "/balance",
@@ -3025,7 +3038,7 @@
         },
         "/first-things-first": {
             "description": "The key to effective management, is allocating energy through the lens of importance rather than urgency. E.g, ask yourself what one thing could you do that if you did on a regular basis, would make a tremendous positive difference in your life? Lemme guess, it’s important, but not urgent so you’re not doing it. These are my insights based on the 7 habits Chapter 3.\n\n",
-            "doc_size": 25000,
+            "doc_size": 26000,
             "file_path": "_site/first-things-first.html",
             "incoming_links": [
                 "/4dx",
@@ -3101,6 +3114,7 @@
             "doc_size": 41000,
             "file_path": "_site/four-healths.html",
             "incoming_links": [
+                "/7h-concepts",
                 "/ai-operator",
                 "/greek-orthodox",
                 "/mortality-software",
@@ -3199,7 +3213,7 @@
         },
         "/gap-year-igor": {
             "description": "Done right, a gap year isn’t a year off; it’s a year on — intentional investment in health, relationships, and mastery while you still have the capital to invest. Think of it as pursuing a PhD in Life Optimization, making deposits that compound for decades. A gap year is one of those uncharted spaces—seductive when discussed longingly over a beer, terrifying when holding a resignation letter outside your boss’s office. Early maps warned: “HC SVNT DRACONES.” Here be dragons. I’m mapping them in real time: the Scarcity Dragon whispering you can’t afford it, the Entropy Dragon promising you’ll decay without structure, and the Squander Dragon insisting you’ll waste this precious opportunity. But these dragons guard treasure — the chance to invest in what truly matters while you still have the capacity to do so. This is the map of how to tame them.\n\n",
-            "doc_size": 72000,
+            "doc_size": 73000,
             "file_path": "_site/gap-year-igor.html",
             "incoming_links": [
                 "/42",
@@ -3250,7 +3264,7 @@
         },
         "/gas-city": {
             "description": "If you’ve read Standing Up Gas City, or seen “Gas City” mentioned in /wally or /igors-claws, and you want to know what the thing actually is before you stand up your own — this is that post. Three concepts carry the whole design: beads (the unit of work), molecules (the choreography), and the propulsion principle (what keeps the engine running). Each one is plain enough on its own; the leverage is in how they compose.\n\n",
-            "doc_size": 23000,
+            "doc_size": 25000,
             "file_path": "_site/gas-city.html",
             "incoming_links": [],
             "last_modified": "2026-05-04T12:23:28.406847+00:00",
@@ -3272,7 +3286,7 @@
                 "/gas-city",
                 "/igors-claws"
             ],
-            "last_modified": "2026-05-03T12:22:17-07:00",
+            "last_modified": "2026-05-05T07:03:22-07:00",
             "markdown_path": "_d/gas-city-home.md",
             "outgoing_links": [
                 "/wally"
@@ -3317,7 +3331,7 @@
         },
         "/goals": {
             "description": "Goals are critical, there are multiple goal systems and they have consequences. They are mechanisms to deliver without micro management.\n\n",
-            "doc_size": 20000,
+            "doc_size": 21000,
             "file_path": "_site/goals.html",
             "incoming_links": [
                 "/4dx",
@@ -3369,7 +3383,7 @@
         },
         "/grammerly": {
             "description": "\n\n",
-            "doc_size": 12000,
+            "doc_size": 13000,
             "file_path": "_site/grammerly.html",
             "incoming_links": [],
             "last_modified": "2025-08-24T09:03:19-07:00",
@@ -3478,7 +3492,7 @@
         },
         "/happy": {
             "description": "Happy is a 5 letter word that many use as the answer to what is the point of life. The follow up question of “How can you be happy” is usually followed by a blank stare, so here’s my study of the subject. Probably the most important thing is happiness is not a mood, it’s journey - Like the weather vs the climate.\n\n",
-            "doc_size": 32000,
+            "doc_size": 33000,
             "file_path": "_site/happy.html",
             "incoming_links": [
                 "/addiction",
@@ -4045,7 +4059,7 @@
         },
         "/learn-code": {
             "description": "Coding is way easier than people think. Here’s some pointers.\n\n",
-            "doc_size": 13000,
+            "doc_size": 14000,
             "file_path": "_site/learn-code.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T02:47:07+00:00",
@@ -4300,7 +4314,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 14000,
+            "doc_size": 15000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",
@@ -4324,7 +4338,7 @@
         },
         "/mind-at-work": {
             "description": "I have a problem, an addiction, an addiction so detrimental to quality of life, it should be described as a disease. This disease is not being present. There are many symptoms of the disease, but today I’m going to talk about my most frequent symptoms, my body at home, but my mind at work.\n\n",
-            "doc_size": 19000,
+            "doc_size": 20000,
             "file_path": "_site/mind-at-work.html",
             "incoming_links": [
                 "/act",
@@ -5528,7 +5542,7 @@
         },
         "/sharpen-the-saw": {
             "description": "A young man saw a woodcutter cutting down a tree and asked “What are you doing?” “Are you blind?” the woodcutter replied. “I’m cutting down this tree.” The young man continued. “You look exhausted! Take a break. Sharpen your saw.” The woodcutter explained he’d been sawing for hours and did not have time to take a break. The young man pushed back… “If you sharpen the saw, you would cut down the tree much faster.” The woodcutter said “I don’t have time to sharpen the saw. Don’t you see I’m too busy. These are my insights based on the 7 habits Chapter 7.\n\n",
-            "doc_size": 14000,
+            "doc_size": 15000,
             "file_path": "_site/sharpen-the-saw.html",
             "incoming_links": [
                 "/7-habits",
@@ -5693,6 +5707,7 @@
             "doc_size": 26000,
             "file_path": "_site/sleight-of-mouth.html",
             "incoming_links": [
+                "/7h-concepts",
                 "/operating-manual",
                 "/timeoff-2022-02",
                 "/words-we-dont-have"
@@ -6056,7 +6071,7 @@
         },
         "/td/back_ref": {
             "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
-            "doc_size": 13000,
+            "doc_size": 14000,
             "file_path": "_site/td/back_ref.html",
             "incoming_links": [],
             "last_modified": "2022-04-16T15:22:43-07:00",
@@ -6527,7 +6542,7 @@
         },
         "/timeoff-2020-03": {
             "description": "In March 2020, I took a 2 month sabbatical between leaving Amazon and joining Facebook. Given it was a substantial amount of time, I came up with some big plans, and wrote them down. It was a great plan, BUT my time off correlated perfectly to the Corona Virus and as a result I wasted lots of my mental energy thinking about the Corona Virus, and adjusting to being in pseudo-quarantine. Took me a while, but I finally realized I should ignore corona virus, or at least minimize my time thinking about it.\n\n",
-            "doc_size": 30000,
+            "doc_size": 31000,
             "file_path": "_site/timeoff-2020-03.html",
             "incoming_links": [
                 "/timeoff"
@@ -7036,7 +7051,7 @@
         },
         "/walking-with-god": {
             "description": "Someone important to me has been reading a daily devotional. Even though I’m not religious, I’m studying with them to be able to have conversations about the insights - whether in a secular or religious context. This is my attempt to bridge two worlds: honoring the spiritual wisdom they’re finding while translating it into language that works for my engineer brain.\n\n",
-            "doc_size": 81000,
+            "doc_size": 82000,
             "file_path": "_site/walking-with-god.html",
             "incoming_links": [
                 "/greek-orthodox",
@@ -7111,7 +7126,7 @@
         },
         "/weeks": {
             "description": "\n\n",
-            "doc_size": 4346000,
+            "doc_size": 4348000,
             "file_path": "_site/weeks.html",
             "incoming_links": [
                 "/balance"


### PR DESCRIPTION
## Summary

Follow-up to #607 — wires in summarize-page cards for related content in the Core Concepts post, matching the same pattern in #608.

## Cards added

| Section | Card | Why |
|--|--|--|
| Character vs Personality Ethic | `/four-healths` | Igor's character framework — physical/mental/emotional/spiritual |
| How we 'see' the problem | `/sleight-of-mouth` | Companion to the existing inline SoM blockquote |
| Around and around (Feedback loop) | `/eulogy` | The upward-spiral target — who you're becoming |

## Bonus fix

The original c0 had a broken link: `[Sleight of Mouth](/some)`. `/some` was never a permalink anywhere in the repo (preserved from the pre-augment version, my earlier PR didn't fix it). Replaced with the canonical `/sleight-of-mouth`.

## Test plan

- [x] All target permalinks return HTTP 200 (`/four-healths`, `/sleight-of-mouth`, `/eulogy`)
- [x] Backlinks rebuilt with `just update-backlinks`
- [x] Page renders at http://localhost:4000/7h-concepts (HTTP 200, 35 KB)
- [x] Three new summarize-page cards visible in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)