### PR TITLE
7h-c7: augment Sharpen the Saw from Covey ebook

### DIFF
--- a/_d/7h-c7.md
+++ b/_d/7h-c7.md
@@ -15,21 +15,133 @@ redirect_from:
 
 A young man saw a woodcutter cutting down a tree and asked “What are you doing?” “Are you blind?” the woodcutter replied. “I’m cutting down this tree.” The young man continued. “You look exhausted! Take a break. Sharpen your saw.” The woodcutter explained he'd been sawing for hours and did not have time to take a break. The young man pushed back… “If you sharpen the saw, you would cut down the tree much faster.” The woodcutter said “I don’t have time to sharpen the saw. Don’t you see I’m too busy. These are my insights based on the [7 habits](/7h) Chapter 7.
 
+{% include ai-slop.html percent="50" %}
+
 {% include youtube.html src="HzLwY0rSCyY" %}
 
-### [Physical Health](/physical-health)
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
 
-- [Diet](/diet)
+- [The four dimensions of renewal](#the-four-dimensions-of-renewal)
+- [Physical Health](#physical-health)
+  - [Diet](#diet)
+  - [Sleep](#sleep)
+  - [Exercise](#exercise)
+- [Emotional Health](#emotional-health)
+- [Mental Health](#mental-health)
+- [Identity Health](#identity-health)
+- [Scripting others](#scripting-others)
+- [Balance and the upward spiral](#balance-and-the-upward-spiral)
+- [Sometimes you need to stop sharpening the saw, and start cutting the shit.](#sometimes-you-need-to-stop-sharpening-the-saw-and-start-cutting-the-shit)
+- [Books](#books)
 
-### [Emotional Health](/emotional-health)
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
 
-### Identity Health
+## The four dimensions of renewal
 
-### Sometimes you need to stop sharpening the saw, and start cutting the shit.
+Habit 7 is personal PC. The asset I'm preserving is _me_ — the only instrument I have for doing any of the other six habits. There are four dimensions to keep sharp, and skipping any one will eventually drag the others down:
+
+| Dimension            | What I'm renewing                          | Habit it powers        |
+| -------------------- | ------------------------------------------ | ---------------------- |
+| Physical             | The body                                   | Habit 1 — Be Proactive |
+| Identity / Spiritual | The values, the center                     | Habit 2 — End in Mind  |
+| Mental               | The mind                                   | Habit 3 — First Things |
+| Emotional / Social   | Relationships and the self I bring to them | Habits 4-6             |
+
+This is Quadrant II work — important and not urgent — which is why most of us don't do it. The crises in Quadrant I crowd it out, and skipping the saw-sharpening is what makes the crises bigger next time. The compounding runs both ways.
+
+I have my own version of this framework — same four dimensions, my names. The full breakdown lives in a dedicated post:
+
+{% include summarize-page.html src='/four-healths' %}
+
+## Physical Health
+
+The body is the platform. If it's broken, every other dimension performs worse — I'm shorter-tempered with my family, dimmer at work, less able to pray or meditate or notice anything beyond my own discomfort. I've learned this the boring way, repeatedly. I have a [longer post](/physical-health) on what I run for the body specifically.
+
+The physical PC has three legs: what I eat, how I sleep, how I move. Skip any one and the other two drop in efficiency.
+
+### Diet
+
+What goes in is the cheapest, most leveraged input I have on energy and mood, and also the one I'm most prone to outsourcing to whatever's easiest at the moment.
+
+{% include summarize-page.html src='/diet' %}
+
+### Sleep
+
+Sleep is the goose. Every hour I steal from it I'm cashing in PC for one extra egg today, and the egg count drops the next week — the math is brutal and I keep having to relearn it.
+
+{% include summarize-page.html src='/sleep' %}
+
+### Exercise
+
+Endurance, flexibility, strength. Three to six hours a week is enough — the trap is treating it as optional because it's never urgent. Then you find yourself in Quadrant I dealing with the health crisis you could have prevented.
+
+For me the working stack is biking (endurance), kettlebells (strength), and stretching (flexibility). The biggest secondary benefit isn't even fitness — it's that doing the workout I scheduled, on a morning I didn't feel like it, is itself a Habit 1 rep. I'm not just renewing my body; I'm voting for the proactive version of myself before the day starts negotiating with me.
+
+The "no pain, no gain" framing is mostly wrong. The essence is _consistent_ exercise that preserves and enhances capacity. Start slow, build up, listen to the body. The willpower muscle gets exercised every time it rains and I go anyway.
+
+## Emotional Health
+
+The [emotional dimension](/emotional-health) and the social one are tied together because most of my emotional life shows up in my relationships — with my wife, my kids, my coworkers, the stranger in traffic. Renewing here doesn't take separate time the way exercise does. It happens inside the interactions I'm already having.
+
+What it does take is the strength to bring Habits 4, 5, and 6 — Win/Win, Seek First to Understand, Synergize — into moments when my emotional fuse is short. That strength is intrinsic security: a sense of personal worth that isn't downstream of how the meeting went or how the kids behaved at dinner. When my security comes from inside, I can disagree without becoming defensive, listen without becoming the listener-mood, and let someone be wrong about me without rewriting my self-image.
+
+The practices that build it are unglamorous: weekly date with my wife, planned 1:1s with each kid, magic and ballooning for the smile-on-someone-else's-face dose, the gratitude entries, the conversations where I push past my first instinct to defend.
+
+{% include summarize-page.html src='/grateful' %}
+
+## Mental Health
+
+The mind atrophies the moment school stops forcing it to work, and most of mine atrophies in front of a screen unless I actively prevent it. _The person who doesn't read is no better off than the person who can't read._
+
+The Quadrant II move is reading. A book a month, then a book every two weeks, then a book a week. Not as a productivity hack — as the cheapest way to get into the best minds that ever existed. The cost is the same as the cost of a coffee. The return is years of someone else's hard-won thinking, compressed.
+
+Writing is the other side of the mental saw. Putting things in words exposes the holes in my understanding. Half the reason I write these summaries is that I can't tell what I actually believe until I try to teach it. The post is where the thinking gets honest.
+
+Planning belongs here too — not the calendar-tetris kind, but the weekly look-up-and-out where I ask what mattered last week and what's actually worth my hours next week. Wars are won in the general's tent. So is most of my life.
+
+{% include summarize-page.html src='/siy' %}
+
+## Identity Health
+
+This is the spiritual dimension — my center, my values, the thing the rest of me orbits around. It's private and supremely important and people do it very differently. For me it's a weekly meditation block, my [eulogy](/eulogy), and the ongoing work of staying connected to what I'd want said about me if I died Tuesday.
+
+The point isn't to perform spirituality. It's to spend enough time with my values that I can recognize them when they show up — and notice when I've been drifting from them — before the drift compounds into something I have to apologize for. Spiritual renewal makes a deposit on my personal mission statement; daily life is where I either spend it down or top it up.
+
+Nature does it for some people. Music or great literature for others. Prayer for others. The form is less interesting than the question: am I keeping a regular appointment with the part of me that knows what I'm actually about?
+
+{% include summarize-page.html src='/spiritual-health' %}
+
+## Scripting others
+
+Once my own four healths are tended, the second-order effect is that I start handing out positive scripts to the people around me — instead of the social mirror's distorted ones.
+
+Most people are a function of the social mirror — the opinions and labels handed to them by their neighbors, parents, teachers, and bosses. The reactive version of me joins the mirror, reflects back the small story other people are already living in, and reinforces it. The proactive version reflects back what they could be.
+
+This is the parent move with kids: see them in terms of unseen potential, not the past 24 hours of behavior. It's the manager move with a struggling teammate: assume the system is broken, not the person. The classroom story is the canonical example — the class accidentally labeled "bright" outperformed the class accidentally labeled "dumb" not because the kids changed, but because the teachers' paradigm changed and the kids responded to the new paradigm. _Apparent learner disability was nothing more or less than teacher inflexibility._
+
+Goethe: _"Treat a man as he is and he will remain as he is. Treat a man as he can and should be and he will become as he can and should be."_
+
+The Abundance Mentality move is realizing that giving someone a positive reflection costs me nothing and makes more proactive people in my life — which compounds back to me as more interesting work, more honest relationships, and more leverage on every other habit.
+
+## Balance and the upward spiral
+
+Renewal in any one dimension shows up in the others — that's the synergy. Working out makes the prayer sharper. Reading makes the relationships richer. Time with family fills the tank that lets me think clearly at work. The four healths aren't four separate ledgers; they're one body, four windows.
+
+But synergy only kicks in if all four are getting renewed. Neglecting any one creates a drag the others have to compensate for. Three exercise sessions a week with no reading, no relationships, and no center is a fit miserable person. The full set is the only set that works.
+
+{% include summarize-page.html src='/balance' %}
+
+The renewal itself follows an upward spiral: _learn, commit, do — learn, commit, do._ Each rotation lifts the level slightly. The conscience gets sharper. The character gets sturdier. The next decision is made from a slightly better place than the last one. There's no shortcut; the law of the harvest governs and the closer my paradigm aligns with how things actually are, the better my judgment becomes.
+
+The Daily Private Victory — an hour a day across physical, mental, and identity — is what keeps the spiral spinning. Skip too many days and the spiral grinds flat into a treadmill.
+
+## Sometimes you need to stop sharpening the saw, and start cutting the shit.
 
 That's in fact the core of effectiveness, balancing production, and production capacity
 
-### Books
+## Books
 
 - [Atomic Habits](/atomic-habits)
 - [Search Inside Yourself](/siy)


### PR DESCRIPTION
## Summary

Same pattern as #607/#608/#610 — fills the previously-sparse [/sharpen-the-saw](https://idvorkin.github.io/sharpen-the-saw) post with first-person Igor-voice prose drawn from Habit 7 of Covey's ebook.

## What's filled in

**Four dimensions of renewal** — overview table mapping each dimension to the habit it powers; Quadrant II framing.

**Physical Health** — split into Diet, Sleep, Exercise sub-sections.

**Emotional Health** — relationships + intrinsic security; weekly date / 1:1s / gratitude practices.

**Mental Health** (NEW section) — reading + writing + planning as the three legs of the mental saw.

**Identity Health** — weekly meditation block; eulogy alignment.

**Scripting others** (NEW section) — handing positive scripts back instead of joining the social mirror; Goethe quote.

**Balance and the upward spiral** (NEW section) — synergy across dimensions; the "learn, commit, do" rotation; Daily Private Victory.

## Preserved verbatim

- Frontmatter, permalink (`/sharpen-the-saw`), redirects (`/7h-c7`, `/the-saw`)
- Woodcutter parable opening paragraph
- `{% include youtube.html src="HzLwY0rSCyY" %}`
- "Sometimes you need to stop sharpening the saw, and start cutting the shit." punchline + body
- Books list ([Atomic Habits], [Search Inside Yourself])

## Marked

`ai-slop percent="50"` after the opening parable.

## Summarize-page cards added

Distributed across the relevant dimension sections: `/four-healths`, `/diet`, `/sleep`, `/grateful`, `/siy`, `/spiritual-health`, `/balance`. (Higher density than other PRs because each dimension has a natural companion post.)

## Test plan

- [x] TOC regenerated with `.claude/skills/toc/toc.py`
- [x] Page renders at http://localhost:4000/sharpen-the-saw (HTTP 200)
- [x] Backlinks regenerated (parent-_site swap captured new outgoing summarize-page links)
- [x] All target permalinks verified HTTP 200 before linking
- [ ] Igor visual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)