### PR TITLE
7h-c6: rewrite Synergize in Igor voice

### DIFF
--- a/_d/7h-c6.md
+++ b/_d/7h-c6.md
@@ -12,199 +12,127 @@ redirect_from:
   - /7h-c6
 ---
 
-We've all got stuff we're good at, and stuff we're bad at. We can combine these in ways that make the system greater than the sum of its parts.
+We've all got stuff we're good at and stuff we're bad at. Combine them right and the system is greater than the sum of the parts — sometimes a lot greater. Synergy is the payoff for everything that came before: independence, [Win/Win](/win-win), and [seeking first to understand](/first-understand) all converge here. These are my insights from [7 habits](/7h) Chapter 6.
 
-These are my insights based on the [7 habits](/7h) Chapter 6.
+{% include ai-slop.html percent="60" %}
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
 - [What Makes Synergy Possible](#what-makes-synergy-possible)
 - [Examples of Synergy in Action](#examples-of-synergy-in-action)
-- [In the Classroom](#in-the-classroom)
-- [In Business](#in-business)
-- [In Communication](#in-communication)
 - [Finding that Third Alternative](#finding-that-third-alternative)
 - [Negative Synergy](#negative-synergy)
 - [Valuing the Differences](#valuing-the-differences)
 - [Force Field Analysis](#force-field-analysis)
 - [Books](#books)
-  <!-- vim-markdown-toc-end -->
-  <!-- prettier-ignore-end -->
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
 
 ### What Makes Synergy Possible
 
-- **Complementary Strengths**: When people with different skills collaborate, they cover each other's weaknesses while amplifying strengths
-- **Diverse Perspectives**: Multiple viewpoints lead to more creative solutions than any individual could develop alone
-- **Collaborative Energy**: The interaction between people often generates new ideas and enthusiasm that wouldn't exist in isolation
-- **Emergent Properties**: Systems working together often develop capabilities that none of the individual components possess
+Synergy is when 1 + 1 = 3. Or 8. Or 1,600. The classic frame: plant two trees close together and the roots co-mingle, the soil improves, both trees grow taller than they would have alone. That's the picture I keep in my head — interdependence isn't compromise, it's compounding.
+
+Three things have to be true for it to fire:
+
+1. **Real differences in the room.** If everyone thinks the same way, one of us is unnecessary. Sameness is not unity.
+2. **Enough trust to risk being wrong out loud.** Synergy is creative, and creative is unpredictable. If I'm spending half my attention defending my position, the other half isn't enough to discover anything.
+3. **The intent to find a better answer**, not to win the argument. The moment "winning" enters the room, synergy leaves.
+
+The first three habits give me the internal security to handle the risk of being open. The next two — Win/Win and empathic listening — give me the right motive and the right skill. Synergy is what falls out when all of that is in place.
 
 ### Examples of Synergy in Action
 
-#### In Teams and Workplace
+The clearest example I have is at work. When I'm running a project well, the engineer I'd never want to lose isn't the one who agrees with me — it's the one who pushes back in a way I can't dismiss. We both leave the conversation with something neither of us walked in with. That's the goose that lays the golden eggs of a team.
 
-- A developer's technical skills combined with a designer's aesthetic sense creates a product better than either could make independently
-- Product development teams that combine engineering, design, and marketing perspectives create innovative solutions
-- Leadership teams that balance visionaries with practical implementers execute more effectively
+A few other places I see it land:
 
-#### In Relationships and Family
+- **Pair programming and code review at its best.** Two engineers seeing the same diff through different eyes catch a class of bug neither would have alone. Add a designer to the same conversation and the surface area gets bigger again.
+- **Family planning conversations.** Tammy and I plan the week on Sunday. Left to me, the calendar would be all bike rides, magic, and side projects. Left to her, it would be more time with the kids and dinners with friends. The actual week we agree on isn't a 50/50 split — it's a different week, one that neither of us would have proposed solo.
+- **Running 1:1s with my engineers.** The point isn't for me to download my plan into them or for them to download status into me. The good ones are the ones where we co-author the next move on whatever they're stuck on, and I leave smarter than I came in.
 
-- Partners who balance each other's traits (one organized, one spontaneous) create a more adaptable partnership
-- Families that combine different generational perspectives solve problems more creatively
-- Friends with complementary personalities often create more memorable experiences together
-
-#### In the Classroom
-
-- Group projects where students with different learning styles complement each other
-- Peer teaching where explaining concepts helps both the teacher and learner
-- Classroom discussions that build collective understanding beyond individual insights
-
-#### In Business
-
-- Strategic alliances that combine complementary strengths of different organizations
-- Matrix organizations that maintain both functional expertise and project focus
-- Customer co-creation that incorporates user feedback throughout development
-
-#### In Communication
-
-- Dialogue that values both advocacy and inquiry leads to deeper understanding
-- Combining verbal, visual, and experiential communication creates more complete understanding
-- Multi-directional feedback systems that capture insights from all levels of an organization
+The half-form of this — respectful but uncreative — is compromise. Compromise is 1 + 1 = 1.5. Both sides give and take, the conversation is polite, and nothing new is created. That's not synergy; that's just a draw.
 
 ### Finding that Third Alternative
 
-The third alternative is at the heart of synergistic thinking. It's not my way, not your way, but a better way that neither of us could have discovered alone.
+The third alternative is the heart of the habit. It's not my way. It's not your way. It's a third way that neither of us could have reached alone.
 
-Covey explains that most people see only two alternatives when faced with disagreement: "my way" or "your way." This either/or thinking limits possibilities. The third alternative transcends this dichotomy by creating something new and better.
+Most disagreements lock into _either/or_ within the first 30 seconds. Either we go to the lake or we visit your mother. Either we ship the feature or we fix the test suite. Either I'm right or you're right. The trap is that I take the framing as given and start optimizing inside it, instead of stepping back and asking whether the framing itself is the problem.
 
-The process requires:
+The classic Covey example is a family vacation: husband has booked a fishing cottage, wife wants to visit her ailing mother 250 miles away. The compromise — split up, he takes the boys, she goes to her mother — leaves both of them guilty and the boys reading the tension. The third alternative is to ask what each of them actually wants. He wants outdoors with the boys. She wants meaningful time with her mother. So they look for a place to camp and fish near the mother, fold in the cousins, and the week now serves both wants without anyone giving anything up. The original positions become irrelevant.
 
-1. **Defining the problem or opportunity**, not as competing positions but as a shared challenge
-2. **Seeking first to understand** the other person's needs and concerns deeply
-3. **Expressing your own views** with equal courage and consideration
-4. **Creating together** without attachment to preconceived solutions
+The rough recipe I use:
 
-The third alternative isn't compromise where both sides give up something. Instead, it's a creative breakthrough where both sides get more of what they truly want by reframing the problem.
+1. **State the problem as shared, not as positions.** "We have one week and two important things" is workable. "I want X and you want Y" is a fight.
+2. **[Listen first](/first-understand) until the other person says, "yes, that's exactly it."** I can't reframe what I haven't actually understood.
+3. **Then say my own piece — fully, not half-strength.** A third alternative needs both sets of needs in the room, not a sanitized version.
+4. **Brainstorm without ownership.** No "my idea" vs. "your idea" — just ideas on the whiteboard, and we both get to riff on each.
 
-Covey shares examples like business negotiations where competitors become partners, or family conflicts where new solutions emerge that honor everyone's needs. The key is shifting from "either/or" to "and" thinking.
+The output is almost never one of the original two options. It's a thing nobody walked in with.
 
-#### How the Third Alternative Differs from Think Win-Win
+#### Win/Win vs. the Third Alternative
 
-People often confuse Synergy (Habit 6) with [Think Win-Win (Habit 4)](/win-win), but they're distinct concepts that build upon each other:
+People conflate this with [Think Win/Win (Habit 4)](/win-win). They're related but not the same.
 
-**Think Win-Win (Habit 4)** is about:
+| Habit 4: Win/Win                        | Habit 6: Synergy / Third Alternative                |
+| --------------------------------------- | --------------------------------------------------- |
+| A mindset and intention                 | A creative process                                  |
+| "Let's both come out OK"                | "Let's create something neither of us has imagined" |
+| Often arrives at compromise or trade    | Transcends the original positions entirely          |
+| You can think Win/Win alone, in advance | You can only synergize together, in real time       |
+| 1 + 1 = 2                               | 1 + 1 = 3 (or 1,600)                                |
 
-- An _attitude_ or mindset of mutual benefit
-- The _intention_ to find solutions where all parties benefit
-- A _character-based_ approach to negotiation
-- Setting up _agreements_ where everyone's needs are addressed
+Win/Win is the prerequisite — without the abundance mindset I'm playing zero-sum in my head, and synergy can't fire. But it's only the table stakes. The third alternative is what's possible once both people have that mindset _and_ the empathic listening to use it.
 
-**Synergy and the Third Alternative** go beyond this by:
+For more on how I apply this in negotiations, see my notes on [Getting to yes](/gty), which is essentially third-alternative thinking applied to deal-making.
 
-- Being the _creative process_ that produces win-win solutions
-- Requiring active _collaboration_ rather than just agreement
-- Creating solutions that are _better than anyone initially imagined_
-- Producing _unexpected breakthroughs_ through the creative tension of differences
+{% include summarize-page.html src='/win-win' %}
 
-In practice, typical **Win-Win Solutions** involve:
+{% include summarize-page.html src='/first-understand' %}
 
-- Finding a middle ground between competing positions
-- Negotiating to ensure both parties get something they want
-- Trading concessions ("I'll give you X if you give me Y")
-- Splitting the difference or finding a compromise
-
-The **Third Alternative** is fundamentally different because it:
-
-- Transcends the original positions entirely
-- Creates a new solution no one initially considered
-- Doesn't require either party to give up what's truly important
-- Often makes the original positions irrelevant
-
-### Examples of Win-Win vs. Third Alternative Solutions
-
-#### Business Context
-
-**Win-Win Approach:**
-
-- Two departments fighting over budget might agree to split the difference
-- Marketing and sales teams might compromise on messaging that partially satisfies both
-- Different business units might negotiate territory boundaries that everyone can accept
-
-**Third Alternative Approach:**
-
-- Departments might create a joint initiative that generates new funding neither had access to before
-- Teams might develop an integrated approach that achieves both marketing's brand goals and sales' conversion targets
-- Business units might create a collaborative model that expands the total market rather than dividing existing territory
-
-#### Personal Relationships
-
-**Win-Win Approach:**
-
-- A couple might alternate choosing vacation destinations each year
-- Friends with different interests might take turns choosing activities
-- Roommates might create a chore schedule that divides responsibilities fairly
-
-**Third Alternative Approach:**
-
-- A couple might discover an entirely new type of vacation that satisfies both adventure and relaxation needs simultaneously
-- Friends might find activities that combine elements of both their interests in unexpected ways
-- Roommates might redesign their living space and routines to minimize the need for chores altogether
-
-#### Workplace Collaboration
-
-**Win-Win Approach:**
-
-- Team members might compromise on a project approach that partially satisfies everyone
-- Different departments might negotiate resource allocation that seems fair to all
-- Colleagues might trade off who leads different initiatives
-
-**Third Alternative Approach:**
-
-- The team might develop an innovative approach incorporating the best elements of everyone's ideas
-- Departments might create a new resource-sharing model that increases overall capacity
-- Colleagues might develop a collaborative leadership structure that leverages everyone's strengths simultaneously
-
-#### Family Decisions
-
-**Win-Win Approach:**
-
-- Parents and teenagers might negotiate screen time limits that both can tolerate
-- Siblings might take turns using shared resources or spaces
-- Family members might compromise on vacation activities to ensure everyone gets something they want
-
-**Third Alternative Approach:**
-
-- The family might create a technology plan that enhances connection while addressing concerns about balance
-- Siblings might transform shared spaces into zones that serve multiple purposes simultaneously
-- The family might discover new activities that engage everyone's interests in unexpected ways
-
-The Third Alternative isn't about meeting in the middle—it's about moving to a higher level where the original problem is reframed and transformed.
-
-For more on how I apply these principles in negotiations, see my notes on [Getting to yes](/gty), which incorporates third alternative thinking into reaching agreements that satisfy everyone's core needs.
+{% include summarize-page.html src='/gty' %}
 
 ### Negative Synergy
 
-- **Groupthink**: When the desire for harmony or conformity results in irrational decision-making
-- **Defensive Communication**: When people feel threatened and focus on protecting themselves rather than solving problems
-- **Personality Conflicts**: When differences become sources of tension rather than creative opportunities
-- **Power Struggles**: When winning the argument becomes more important than finding the best solution
+Negative synergy is what most meetings actually produce. It's the meeting where everyone leaves dumber than they came in. The same energy that could compound creativity is being burned on protecting backsides, scoring points, and second-guessing.
+
+The shape I recognize:
+
+- **Groupthink.** Everyone agrees on the surface. Nobody believes the agreement. The room optimized for harmony and got compliance.
+- **Defensive everything.** Half the bandwidth goes to prepping the next defense instead of hearing the actual point. Memos written to be unfalsifiable. Slack threads that read like legal depositions.
+- **Borrowed-strength power moves.** Someone pulls rank — title, tenure, "I've seen this before" — and the room shuts down. Even if they're right, the fact that they had to use the lever means nobody else's brain is in the conversation anymore.
+- **One foot on the gas, one foot on the brake.** The team is publicly committed to a goal and privately working against it. Output drops, frustration rises, and the answer is usually "more pressure" — which is more gas, when the actual fix is taking the foot off the brake.
+
+The diagnostic on myself is honest: when I'm in negative-synergy mode, it's almost always because I've stopped feeling secure enough to be wrong in public. The fix lives in the first three habits, not in better meeting facilitation.
 
 ### Valuing the Differences
 
-- **Mental**: Appreciating different ways of thinking and problem-solving approaches
-- **Emotional**: Respecting varying emotional responses and how they inform perspectives
-- **Psychological**: Understanding different personality types and their unique contributions
-- **Interdependence**: Recognizing that our differences create the very opportunity for synergy
+The cornerstone insight: **people don't see the world as it is — they see it as they are**. If I think I'm objective and everyone else is biased, I'll never get anything from anyone. I'll be limited to the size of my own conditioning.
+
+This shows up most for me as a manager. I have engineers whose strengths look nothing like mine — someone who is twice as careful as I am about edge cases, someone who reads org politics in a way I find exhausting, someone who'll grind on a debug for ten hours where I'd have given up at three. My instinct, when those differences first show up, is to read them as deficits. _Why won't they just move faster / care less / push harder?_ The honest answer is that I'd be building a team of clones of myself, and a team of me is much weaker than a team of complements.
+
+Same with my marriage. Tammy and I are different in ways that I sometimes wish away — and every time I sit with it, the differences are exactly what makes the partnership work. The mistake would be trying to talk her into seeing it my way. The move is to say, "good, you see it differently. Help me see what you see."
+
+The internal version of this matters too. The analytical, verbal, left-brain part of me wants facts and bullet points. The intuitive, image-based, right-brain part of me wants to feel into a thing before naming it. When I treat one of those as the only legitimate way to think, I'm running on half a brain. Synergy starts inside.
 
 ### Force Field Analysis
 
-- **Identifying Driving Forces**: Recognizing factors that push toward desired change
-- **Identifying Restraining Forces**: Understanding factors that maintain the status quo
-- **Strengthening Positive Forces**: Amplifying factors that support the desired outcome
-- **Weakening Restraining Forces**: Addressing and reducing barriers to change
+Kurt Lewin's frame, and one of the more useful tools I've kept from this chapter. Any current state — a team's morale, my fitness level, the climate at home, the tone of a 1:1 — is an equilibrium between two sets of forces:
+
+- **Driving forces** push toward the goal. They're usually the logical, conscious, easy-to-list ones: the goal itself, the deadline, the incentive, my willpower.
+- **Restraining forces** hold the current state in place. They're usually emotional, social, half-conscious, embarrassing to name out loud: fear of looking dumb, an old story about who I am, a bad past experience, a habit nobody wants to confront.
+
+The default move is to push harder on the drivers. More pressure. More logic. More deadlines. It works for a while and then snaps back, like pushing on a spring. The actual leverage is on the restraining side — name the thing that's holding the state in place, talk about it, and the spring loosens.
+
+Concrete example for me: I want my team to ship faster. Driving forces — quarterly goal, customer pressure, my own urgency. Restraining forces — fear that the previous launch's bugs will repeat, a code review process that's grown into theater, one engineer who's burned out and not saying so. Pushing harder on the drivers makes the restraining forces stronger. Naming the restraining forces (and treating them as legitimate, not as obstacles to bulldoze) is what actually moves the equilibrium.
+
+This is why synergy beats willpower in interdependent situations. Willpower can crank the drivers. Only the combination of Habits 4, 5, and 6 — Win/Win motive, empathic listening, creative interaction — can dissolve the restraining forces, because most of them only show up when someone feels safe enough to name them.
+
+{% include summarize-page.html src='/coaching' %}
 
 ### Books
 
 {% include amazon.html asin="0743269519" %}
 
-For deeper exploration of synergy and the third alternative, I recommend Stephen Covey's "The 3rd Alternative," which expands on these concepts with practical applications for finding breakthrough solutions in both personal and professional contexts.
+For deeper exploration of synergy and the third alternative, Stephen Covey's _The 3rd Alternative_ expands on these concepts with practical applications for finding breakthrough solutions in personal and professional contexts.


### PR DESCRIPTION
## Summary

Rewrites `/synergize` (Habit 6) from generic AI-generated essay into first-person Igor voice with concrete personal examples. Per the brief, this chapter was already long but the prose had the tells of content-farm AI: three-words-and-a-colon bullet definitions, symmetric "Approach A / Approach B" lists across four contexts, and "Covey says/explains/shares" attributions throughout.

This is more **rewrite than augment** — the existing surface area was largely AI-generated and needed Igor-ifying, not adding more bullets.

## What changed

**Tightened:**
- Collapsed five "Complementary Strengths / Diverse Perspectives" three-words-and-a-colon bullet patterns into prose with personal examples.
- Replaced four parallel symmetric "Win-Win Approach / Third Alternative Approach" sections (Business / Personal / Workplace / Family) with **one** comparison table and one concrete vacation-negotiation example from the ebook.
- Cut every "Covey says / Covey explains / Covey shares" attribution.
- Reframed Force Field Analysis with a concrete personal example (managing a team that's shipping slowly — driving forces vs. restraining forces).

**Igor-ified examples now in:**
- Sunday planning with Tammy (week-planning negotiation as third-alternative case)
- Pushing-back engineers in 1:1s (synergy at work)
- Pair programming and code review (1+1=3 in practice)
- Team-shipping-slower force-field example

**Preserved:**
- Frontmatter, permalink, redirect_from
- Opening paragraph (sharpened, kept the 1+1=3 frame)
- `{% include amazon.html asin="0743269519" %}` book card
- `/gty` inline link in negotiation paragraph
- `/win-win` cross-link in comparison section
- Section anchors: `#what-makes-synergy-possible`, `#finding-that-third-alternative`, `#negative-synergy`, `#valuing-the-differences`, `#force-field-analysis`
- Subsection `#examples-of-synergy-in-action` (existed in old TOC, kept)

**Added:**
- `{% include ai-slop.html percent="60" %}` after opening paragraph (higher than 50% — honest attribution since the prior version was largely AI-generated)
- summarize-page cards: `/win-win`, `/first-understand`, `/gty`, `/coaching`
- New cross-link to `/first-understand` (synergy depends on empathic listening — this is the prerequisite mentioned in the chapter intro)
- Win/Win vs. Third Alternative comparison table (replaces the bulleted dichotomy)

**Word count:** 1387 → 1952 words. The growth is in personal examples replacing hollow bullets — every section is more concrete than before.

## Notes

- Local Jekyll build can't complete on this dev VM (Ruby 4.x + `String#tainted?` removed — known CLAUDE.md issue). `back-links.json` delta in this commit is partial — the CI rebuild on this PR will produce the full update including new outgoing links to `/first-understand` and `/coaching`.

## Test plan

- [ ] Rendered page reads as Igor's voice, not AI-essay
- [ ] All five preserved anchors resolve from inbound links
- [ ] ai-slop label appears after opening paragraph (not before)
- [ ] Four summarize-page cards render
- [ ] Comparison table renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)