### PR TITLE
Wire 7-habits chapter raccoons (c2-c7) — covers + inline float-right

### DIFF
--- a/_d/7h-c1.md
+++ b/_d/7h-c1.md
@@ -13,6 +13,7 @@ redirect_from:
   - /7h-c1
   - /proactive
   - /responsible
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c1.webp
 ---
 
 I choose '.' I am responsible for my own life '.' My behavior is a function of my decisions, not my conditions '.' I can subordinate feelings to values '.' I have the initiative and the responsibility to make things happen. These are my insights from [7 habits](/7h) Chapter 1.
@@ -46,6 +47,8 @@ TODO: Link to videos
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
+
+{% include blob_image_float_right.html src="blog/raccoon-7h-c1.webp" alt="Raccoon being proactive" %}
 
 ## Equanimity calm the mind
 

--- a/_d/7h-c2.md
+++ b/_d/7h-c2.md
@@ -16,6 +16,7 @@ alias:
   - /end-in-mind
   - /7h-c2
   - /begin-with-the-end-in-mind
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c2.webp
 ---
 
 All things are created twice, once in the design phase, and then again in the implementation phase. If you don't perform the first creation, someone else will. At the extreme, imagine your eulogy, that's the end too.
@@ -42,6 +43,8 @@ These are my insights based on the [7 habits](/7h) Chapter 2.
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
+
+{% include blob_image_float_right.html src="blog/raccoon-7h-c2.webp" alt="Raccoon visualizing the end in mind" %}
 
 ## All things are created twice
 

--- a/_d/7h-c3.md
+++ b/_d/7h-c3.md
@@ -11,6 +11,7 @@ permalink: /first-things-first
 redirect_from:
   - /7h-c3
   - /first-thing-first
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c3.webp
 ---
 
 The key to effective management, is allocating energy through the lens of importance rather than urgency. E.g, ask yourself what one thing could you do that if you did on a regular basis, would make a tremendous positive difference in your life? Lemme guess, it's important, but not urgent so you're not doing it. These are my insights based on the [7 habits](/7h) Chapter 3.
@@ -42,6 +43,8 @@ The key to effective management, is allocating energy through the lens of import
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
+
+{% include blob_image_float_right.html src="blog/raccoon-7h-c3.webp" alt="Raccoon putting first things first" %}
 
 ## Habit 3 in context
 

--- a/_d/7h-c4.md
+++ b/_d/7h-c4.md
@@ -11,6 +11,7 @@ permalink: /win-win
 redirect_from:
   - /7h-c4
   - /win-win-or-no-deal
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c4.webp
 ---
 
 Win/Win is a constantly seeking mutual benefit in all interactions. Win/Win means that agreements or solutions are mutually beneficial, mutually satisfying. With a Win/Win solution, all parties feel good about the decision and feel committed to the action plan. Win/Win sees life as a cooperative, not a competitive arena. Most people tend to think in terms of dichotomies: strong or weak, hardball or softball, win or lose. But that kind of thinking is fundamentally flawed. It’s based on power and position rather than on principle. Win/Win is based on the paradigm that there is plenty for everybody, that one person’s success is not achieved at the expense or exclusion of the success of others.
@@ -42,6 +43,8 @@ These are my insights based on the [7 habits](/7h) Chapter 4.
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
+
+{% include blob_image_float_right.html src="blog/raccoon-7h-c4.webp" alt="Raccoon thinking win-win" %}
 
 ### Everything else is Lose/Lose
 

--- a/_d/7h-c5.md
+++ b/_d/7h-c5.md
@@ -10,6 +10,7 @@ tags:
 permalink: /first-understand
 redirect_from:
   - /7h-c5
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c5.webp
 ---
 
 Imagine going to the eye doctor. After hearing your complaint he takes off his glasses and hands them to you.
@@ -38,6 +39,8 @@ _Lead with curiosity, not judgment. This applies to yourself and to others. Thin
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
+
+{% include blob_image_float_right.html src="blog/raccoon-7h-c5.webp" alt="Raccoon seeking first to understand" %}
 
 ### Character and communication
 

--- a/_d/7h-c6.md
+++ b/_d/7h-c6.md
@@ -10,6 +10,7 @@ tags:
 permalink: /synergize
 redirect_from:
   - /7h-c6
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c6.webp
 ---
 
 We've all got stuff we're good at and stuff we're bad at. Combine them right and the system is greater than the sum of the parts — sometimes a lot greater. Synergy is the payoff for everything that came before: independence, [Win/Win](/win-win), and [seeking first to understand](/first-understand) all converge here. These are my insights from [7 habits](/7h) Chapter 6.
@@ -29,6 +30,8 @@ We've all got stuff we're good at and stuff we're bad at. Combine them right and
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
+
+{% include blob_image_float_right.html src="blog/raccoon-7h-c6.webp" alt="Raccoon synergizing" %}
 
 ### What Makes Synergy Possible
 

--- a/_d/7h-c7.md
+++ b/_d/7h-c7.md
@@ -11,6 +11,7 @@ permalink: /sharpen-the-saw
 redirect_from:
   - /7h-c7
   - /the-saw
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c7.webp
 ---
 
 A young man saw a woodcutter cutting down a tree and asked “What are you doing?” “Are you blind?” the woodcutter replied. “I’m cutting down this tree.” The young man continued. “You look exhausted! Take a break. Sharpen your saw.” The woodcutter explained he'd been sawing for hours and did not have time to take a break. The young man pushed back… “If you sharpen the saw, you would cut down the tree much faster.” The woodcutter said “I don’t have time to sharpen the saw. Don’t you see I’m too busy. These are my insights based on the [7 habits](/7h) Chapter 7.
@@ -37,6 +38,8 @@ A young man saw a woodcutter cutting down a tree and asked “What are you doing
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
+
+{% include blob_image_float_right.html src="blog/raccoon-7h-c7.webp" alt="Raccoon sharpening the saw" %}
 
 ## The four dimensions of renewal
 


### PR DESCRIPTION
## Summary

Wires six per-chapter raccoon illustrations into the 7-habits chapter posts (`_d/7h-c{2..7}.md`). Each post now gets:

- An `imagefeature:` cover in frontmatter (renders on index cards + social preview)
- An inline `{% include blob_image_float_right.html ... %}` embed placed after the TOC, matching the convention used in `_d/mania.md`

| Chapter | Habit | Raccoon |
| --- | --- | --- |
| c2 | Begin with the end in mind | `raccoon-7h-c2.webp` |
| c3 | Put first things first | `raccoon-7h-c3.webp` |
| c4 | Think win-win | `raccoon-7h-c4.webp` |
| c5 | Seek first to understand, then to be understood | `raccoon-7h-c5.webp` |
| c6 | Synergize | `raccoon-7h-c6.webp` |
| c7 | Sharpen the saw | `raccoon-7h-c7.webp` |

Habit 1 is intentionally skipped — Igor hasn't picked a c1 raccoon illustration yet.

## ⚠️ Merge order

**Depends on https://github.com/idvorkin/blob/pull/20** landing first. Until that PR merges, the cover and inline image URLs (`https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c<N>.webp`) will 404. Same shipping order pattern as the addiction-vs-passion raccoon PR pair.

## Test plan

- [ ] After blob PR lands, visit `/end-in-mind`, `/first-things-first`, `/win-win`, `/first-understand`, `/synergize`, `/sharpen-the-saw` and verify each shows the raccoon float-right below the TOC
- [ ] Check the chapter cards on `/7h` (or wherever they appear) show the new cover image
- [ ] Confirm transparent .webp renders cleanly on light + dark themes