### PR TITLE
fix(amelia): rename H2 anchor id to fix duplicate-id collision (moves grid empty bug)

### DIFF
--- a/amelia.html
+++ b/amelia.html
@@ -179,7 +179,7 @@ description: "A framework that maps Igor's four affirmations onto fathering a da
             >Audit</a
           >
           <a
-            href="#moves"
+            href="#moves-section"
             class="chip pill px-3 py-1.5 rounded-full text-xs text-slate-200 hover:bg-white/15 shrink-0"
             >Moves</a
           >
@@ -314,8 +314,8 @@ description: "A framework that maps Igor's four affirmations onto fathering a da
       ></div>
 
       <!-- Moves library -->
-      <h2 id="moves" class="text-2xl font-semibold mb-2 scroll-mt-20">
-        <span id="moves-heading">20 concrete moves</span>
+      <h2 id="moves-section" class="text-2xl font-semibold mb-2 scroll-mt-20">
+        20 concrete moves
       </h2>
       <p class="text-slate-400 text-sm mb-4">
         Filter by which affirmation you want to practice. Pick 1–3 for the week.
@@ -541,7 +541,7 @@ description: "A framework that maps Igor's four affirmations onto fathering a da
             active = 0;
             render();
             window.scrollTo({
-              top: document.getElementById("moves-heading")?.offsetTop || 0,
+              top: document.getElementById("moves-section")?.offsetTop || 0,
               behavior: "smooth",
             });
           };
@@ -556,7 +556,7 @@ description: "A framework that maps Igor's four affirmations onto fathering a da
               active = n;
               render();
               window.scrollTo({
-                top: document.getElementById("moves-heading")?.offsetTop || 0,
+                top: document.getElementById("moves-section")?.offsetTop || 0,
                 behavior: "smooth",
               });
             };


### PR DESCRIPTION
## Bug

On `/amelia`, the 20 moves grid was rendering empty — both filter chip rows appeared stacked together with no moves visible between them.

## Root cause

The `<h2>` ("20 concrete moves") and the `<div>` (grid container) both had `id="moves"`. `document.getElementById("moves")` returns the first match, which is the H2. So `renderMoves()` emptied the H2 and tried to fill it with move cards — breaking the layout AND leaving the actual grid div empty.

## Fix

Rename the H2 anchor to `id="moves-section"`. Update the nav link `href="#moves"` → `#moves-section` and the auto-scroll target. The grid div keeps `id="moves"` so the existing render code is unchanged — minimal blast radius.

## Test plan

- [x] Local: `grep -c 'id="moves"'` shows 1 (just the grid div)
- [ ] After merge: visit `/amelia` on iPad/desktop — verify 20 moves render between the two filter rows
- [ ] Verify nav "Moves" chip still scrolls to the moves section
- [ ] Verify both top + bottom filter chips still scroll back to the moves heading after a filter pick