### PR TITLE
Add podcast RSS feed (first ep: 7 Habits, 2h13m)

### DIFF
--- a/_d/podcast.md
+++ b/_d/podcast.md
@@ -9,6 +9,14 @@ redirect_from:
 
 To my amazement, I listen to podcasts. I think they're pretty interesting, here are my notes on them.
 
+## My own audio feed: Igor's Reading List
+
+I now narrate some of my essays as audio episodes via AI voiceover (Gemini 3.1 Flash TTS, Charon voice). The first episode is my full take on the [7 Habits of Highly Effective People](/7h-concepts) — about two and a quarter hours, solo narration.
+
+**Subscribe**: paste `https://idvork.in/podcast.xml` into your podcast app of choice (Overcast, Apple Podcasts, Pocket Casts), or one-tap subscribe with [`podcast://idvork.in/podcast.xml`](podcast://idvork.in/podcast.xml).
+
+The voiceover is AI; the words are mine. Audio is hosted in the [`blob`](https://github.com/idvorkin/blob/tree/master/podcast) repo; the toolchain is the `gen-tts` skill in [chop-conventions](https://github.com/idvorkin/chop-conventions).
+
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 

--- a/podcast.xml
+++ b/podcast.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Igor's Reading List</title>
+    <link>https://idvork.in/podcast</link>
+    <atom:link href="https://idvork.in/podcast.xml" rel="self" type="application/rss+xml"/>
+    <language>en-us</language>
+    <copyright>© Igor Dvorkin</copyright>
+    <itunes:author>Igor Dvorkin</itunes:author>
+    <description>Igor narrates essays from idvork.in. Self-improvement, software, life. AI voiceover via Gemini Flash TTS (Charon voice).</description>
+    <itunes:summary>Igor narrates essays from idvork.in. AI voiceover (Charon voice via Gemini 3.1 Flash TTS).</itunes:summary>
+    <itunes:owner>
+      <itunes:name>Igor Dvorkin</itunes:name>
+      <itunes:email>idvorkin@gmail.com</itunes:email>
+    </itunes:owner>
+    <itunes:explicit>false</itunes:explicit>
+    <itunes:category text="Education">
+      <itunes:category text="Self-Improvement"/>
+    </itunes:category>
+    <itunes:image href="https://idvork.in/apple-touch-icon-precomposed.png"/>
+    <image>
+      <url>https://idvork.in/apple-touch-icon-precomposed.png</url>
+      <title>Igor's Reading List</title>
+      <link>https://idvork.in/podcast</link>
+    </image>
+    <itunes:type>episodic</itunes:type>
+    <managingEditor>idvorkin@gmail.com (Igor Dvorkin)</managingEditor>
+
+    <item>
+      <title>The 7 Habits of Highly Effective People — Igor's Take</title>
+      <description>Igor's full essay on Stephen Covey's 7 Habits. Why he loves them. Foundations (paradigms, principles, P/PC balance), then each habit with his own examples — proactivity, end-in-mind, first-things-first, win-win, seek-first-to-understand, synergy, sharpen-the-saw. Integrated into life as a Microsoft engineer, husband, father, magician, and weight-loss winner.</description>
+      <itunes:summary>Igor's full essay on Stephen Covey's 7 Habits. Foundations + all seven habits, with his own examples.</itunes:summary>
+      <itunes:author>Igor Dvorkin</itunes:author>
+      <itunes:duration>02:13:03</itunes:duration>
+      <itunes:explicit>false</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <enclosure url="https://github.com/idvorkin/blob/raw/master/podcast/seven-habits.mp3" length="63866568" type="audio/mpeg"/>
+      <guid isPermaLink="false">igor-7habits-2026-05-12</guid>
+      <pubDate>Tue, 12 May 2026 00:00:00 -0700</pubDate>
+      <link>https://idvork.in/7h-concepts</link>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Adds a podcast RSS feed at `https://idvork.in/podcast.xml` so Igor's narrated essays are subscribable in Overcast / Apple Podcasts / Pocket Casts / etc.

## Changes

- `podcast.xml` — RSS 2.0 with iTunes namespace tags. Channel: "Igor's Reading List". Cover art: `apple-touch-icon-precomposed.png`. Episodic feed type.
- `_d/podcast.md` — adds a "My own audio feed: Igor's Reading List" section to the existing /podcast page with a one-tap subscribe link.

## First episode

The 7 Habits of Highly Effective People — Igor's Take:
- 2h 13m 03s
- 60.9 MB MP3, mono 64 kbps
- Charon voice via Gemini 3.1 Flash TTS (`gen-tts` skill default)
- Hosted in the [`blob`](https://github.com/idvorkin/blob) repo, companion PR #22 there

## Subscribe

Paste `https://idvork.in/podcast.xml` into Overcast (or any podcast app) once this merges + the blob PR merges.

— Keeping my human friend @idvorkin in the loop!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched "Igor's Reading List," a new AI-narrated podcast featuring curated episodes with rich audio content.
  * First episode available: "The 7 Habits of Highly Effective People — Igor's Take."
  * Subscribe via RSS feed or direct podcast app integration for seamless access to new episodes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/idvorkin.github.io/pull/623)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->