### PR TITLE
Podcast follow-up: add podcast:chapters sidecar to RSS

### DIFF
--- a/podcast.xml
+++ b/podcast.xml
@@ -2,7 +2,8 @@
 <rss version="2.0"
   xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
   xmlns:content="http://purl.org/rss/1.0/modules/content/"
-  xmlns:atom="http://www.w3.org/2005/Atom">
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:podcast="https://podcastindex.org/namespace/1.0">
   <channel>
     <title>Igor's Reading List</title>
     <link>https://idvork.in/podcast</link>
@@ -37,7 +38,8 @@
       <itunes:duration>02:13:03</itunes:duration>
       <itunes:explicit>false</itunes:explicit>
       <itunes:episodeType>full</itunes:episodeType>
-      <enclosure url="https://github.com/idvorkin/blob/raw/master/podcast/seven-habits.mp3" length="63866568" type="audio/mpeg"/>
+      <enclosure url="https://github.com/idvorkin/blob/raw/master/podcast/seven-habits.mp3" length="63932507" type="audio/mpeg"/>
+      <podcast:chapters url="https://github.com/idvorkin/blob/raw/master/podcast/seven-habits.chapters.json" type="application/json+chapters"/>
       <guid isPermaLink="false">igor-7habits-2026-05-12</guid>
       <pubDate>Tue, 12 May 2026 00:00:00 -0700</pubDate>
       <link>https://idvork.in/7h-concepts</link>


### PR DESCRIPTION
Follow-up to merged #623. Adds the Podcasting 2.0 chapters sidecar reference to the RSS feed so newer apps can fetch chapter navigation as JSON.

## Changes

1. Add `xmlns:podcast="https://podcastindex.org/namespace/1.0"` to the `<rss>` element.
2. Add `<podcast:chapters url=".../seven-habits.chapters.json" type="application/json+chapters"/>` inside the episode `<item>`.
3. Bump enclosure length from 63,866,568 → 63,932,507 bytes (~65 KB ID3 CHAP overhead added to the MP3 in the companion blob PR).

## Belt + suspenders

The MP3 itself now carries 8 ID3 CHAP frames (universal: Overcast, Apple Podcasts, Pocket Casts, Castro). The sidecar is for clients that prefer Podcasting 2.0 (Fountain, PodVerse, Castamatic). Either should work; both together is the safest path.

## Companion PR

[idvorkin/blob#23](https://github.com/idvorkin/blob/pull/23) — the chapter-markers MP3 + chapters.json sidecar.

— Keeping my human friend @idvorkin in the loop!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added podcast chapters support for episodes, enabling listeners to navigate specific segments within featured content.
  * Enhanced podcast feed infrastructure with namespace declarations for improved metadata management and platform compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/idvorkin.github.io/pull/624)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->