### PR TITLE
Podcast: migrate feed to dedicated repo + update /podcast page

### DIFF
--- a/_d/podcast.md
+++ b/_d/podcast.md
@@ -9,13 +9,19 @@ redirect_from:
 
 To my amazement, I listen to podcasts. I think they're pretty interesting, here are my notes on them.
 
-## My own audio feed: Igor's Reading List
+## My own audio feed: Igor's Podcast
 
-I now narrate some of my essays as audio episodes via AI voiceover (Gemini 3.1 Flash TTS, Charon voice). The first episode is my full take on the [7 Habits of Highly Effective People](/7h-concepts) — about two and a quarter hours, solo narration.
+I now narrate some of my essays as audio episodes via AI voiceover (Gemini 3.1 Flash TTS, Charon voice). First episode: my full take on the [7 Habits of Highly Effective People](/7h-concepts) — about two and a quarter hours, solo narration, with embedded chapter markers.
 
-**Subscribe**: paste `https://idvork.in/podcast.xml` into your podcast app of choice (Overcast, Apple Podcasts, Pocket Casts), or one-tap subscribe with [`podcast://idvork.in/podcast.xml`](podcast://idvork.in/podcast.xml).
+**Subscribe**: paste this into Overcast / Apple Podcasts / Pocket Casts:
 
-The voiceover is AI; the words are mine. Audio is hosted in the [`blob`](https://github.com/idvorkin/blob/tree/master/podcast) repo; the toolchain is the `gen-tts` skill in [chop-conventions](https://github.com/idvorkin/chop-conventions).
+```
+https://idvorkin-ai-tools.github.io/podcast/feed.xml
+```
+
+Or one-tap: [`podcast://idvorkin-ai-tools.github.io/podcast/feed.xml`](podcast://idvorkin-ai-tools.github.io/podcast/feed.xml).
+
+The voiceover is AI; the words are mine. Feed + audio + cover art all live in the [`idvorkin-ai-tools/podcast`](https://github.com/idvorkin-ai-tools/podcast) repo; the toolchain is the `gen-tts` skill in [chop-conventions](https://github.com/idvorkin/chop-conventions).
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->

--- a/podcast.xml
+++ b/podcast.xml
@@ -29,6 +29,7 @@
     </image>
     <itunes:type>episodic</itunes:type>
     <managingEditor>idvorkin@gmail.com (Igor Dvorkin)</managingEditor>
+    <itunes:new-feed-url>https://idvorkin-ai-tools.github.io/podcast/feed.xml</itunes:new-feed-url>
 
     <item>
       <title>The 7 Habits of Highly Effective People — Igor's Take</title>


### PR DESCRIPTION
The podcast lives in its own dedicated repo now: [idvorkin-ai-tools/podcast](https://github.com/idvorkin-ai-tools/podcast). Audio, RSS, cover art, and chapter sidecars all live there; served via GH Pages at \`https://idvorkin-ai-tools.github.io/podcast/feed.xml\`.

## Changes

### 1. Add \`<itunes:new-feed-url>\` to \`podcast.xml\`

Apple Podcasts, Overcast, Pocket Casts, and most modern apps read this tag on next feed refresh and silently move existing subscribers to the new URL. Migration is automatic — anyone who subscribed at \`idvork.in/podcast.xml\` doesn't need to do anything.

### 2. Update \`_d/podcast.md\`

The /podcast page now advertises the new feed URL and the new show name ("Igor's Podcast", up from "Igor's Reading List"), pointing at the dedicated repo.

## Subscribe (new URL)

\`https://idvorkin-ai-tools.github.io/podcast/feed.xml\`

Or one-tap subscribe: \`podcast://idvorkin-ai-tools.github.io/podcast/feed.xml\`

— Keeping my human friend @idvorkin in the loop!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated podcast feed to new hosting location
  * Episodes now feature AI voiceover narration
  * Added quick-subscribe podcast link for listeners

* **Updates**
  * iTunes podcast directory now points to updated feed URL

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/idvorkin.github.io/pull/625)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->