### PR TITLE
podcast: embed voice catalog selector under /podcast

### DIFF
--- a/_d/podcast.md
+++ b/_d/podcast.md
@@ -23,6 +23,19 @@ Or one-tap: [`podcast://idvorkin-ai-tools.github.io/podcast/feed.xml`](podcast:/
 
 The voiceover is AI; the words are mine. Feed + audio + cover art all live in the [`idvorkin-ai-tools/podcast`](https://github.com/idvorkin-ai-tools/podcast) repo; the toolchain is the `gen-tts` skill in [chop-conventions](https://github.com/idvorkin/chop-conventions).
 
+### Pick your narrator
+
+Gemini Flash TTS ships 30 prebuilt voices. The current default is **Charon** (deep storyteller baritone) — but if you want to hear how the other voices land before subscribing, the catalog below is the same one I use to pick. Tap any name to hear that voice read a short sample.
+
+<iframe src="https://idvorkin-ai-tools.github.io/larry-voice-samples/"
+        width="100%" height="640"
+        loading="lazy"
+        title="Gemini TTS voice catalog — Larry voice samples"
+        style="border: 1px solid var(--bs-border-color, #ddd); border-radius: 8px;">
+</iframe>
+
+Standalone page: [larry-voice-samples](https://idvorkin-ai-tools.github.io/larry-voice-samples/) · Soprano-iteration hill-climb: [soprano-iteration.html](https://idvorkin-ai-tools.github.io/larry-voice-samples/soprano-iteration.html) (using a Gemini Pro model-as-judge to make Charon sound like Tony Soprano — see [/hill-climbing](/hill-climbing#soprano-tune-a-voice-prompt-with-a-model-as-judge) for the write-up).
+
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 


### PR DESCRIPTION
Adds a "Pick your narrator" subsection to /podcast that lets visitors hear all 30 Gemini Flash TTS voices via an embedded iframe of [larry-voice-samples](https://idvorkin-ai-tools.github.io/larry-voice-samples/).

## Why

The current /podcast page mentions Charon (the default voice) by name but gives readers no way to hear it — or any of the other 29 voices — before deciding whether to subscribe. The catalog already exists as a standalone GH Pages site; embedding it here gives /podcast visitors a self-contained way to audition.

## What changes

- `_d/podcast.md` — adds a "### Pick your narrator" section under "My own audio feed". The iframe is `loading="lazy"` so it doesn't impact /podcast TTFB.
- Also surfaces the soprano-iteration link and `/hill-climbing#soprano-…` cross-link for readers who want the prompt-tuning story.

No changes to the catalog itself; it stays in [`idvorkin-ai-tools/larry-voice-samples`](https://github.com/idvorkin-ai-tools/larry-voice-samples). Improvements there propagate automatically.

— Keeping my human friend @idvorkin in the loop!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added narrator voice selection feature to the podcast page, allowing users to choose from Gemini Flash TTS voice options (defaulting to Charon).
  * Included an embedded voice sample catalog with links to additional voice options and voice customization documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/idvorkin.github.io/pull/626)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->