### PR TITLE
hyper-personal: new intro — Bezos vignette + TL;DR baked into prose

### DIFF
--- a/_d/hyper-personal.md
+++ b/_d/hyper-personal.md
@@ -9,14 +9,17 @@ tags:
   - ai
 ---
 
-Useful writing tells people something true and important they didn't already know — in a way that leaves no doubt. The problem: everyone is different. Reader's frame, jargon, blind spots all differ. Either you write for a vague average and lose almost everyone, or you write for one specific person and lose everyone else. AI breaks the tradeoff.
+Jeff Bezos has always had a personal chef who knows he hates capers but loves dill. A butler. A tailor with his measurements. A physician who's known his family for years. None of this is new — Vanderbilts had the same staff a century ago. The desire was universal; what gated it was cost. Human attention scales 1:1 with each customer, so personalization stayed scarce — concentrated where the money was, thin everywhere else.
 
-TL;DR:
+**The big shift is the price.** AI dropped the marginal cost of personal attention through the floor. The world Bezos paid for is becoming the everyone-default — same staff, at the cost of a query. And the AI version goes further than Bezos's staff ever could: even his chef didn't know how his blood sugar responded to last week's pasta, his trainer didn't see his HRV trend, his physician couldn't pattern-match across a decade of journal-and-location data. Hyper-personalization isn't just democratizing the old kind. It's reaching into dimensions that didn't exist at any price.
 
-- **Hyper-personalization isn't new.** Jeff Bezos has a butler, a personal chef, a private tutor for his kids, an in-house physician — bespoke everything. The rest of us had crumbs — a tailor who knew our sleeve, a barber who knew our part. It was always there; it was just bound by human attention scaling 1:1 with each person.
-- **AI breaks the cost curve.** Free intelligence means everyone gets the Bezos staff — personal coach, personal chef, personal tutor — at the marginal cost of a query. Democratization, not invention.
-- **AI also breaks the kind.** Even Bezos doesn't have continuous glucose response feeding his chef, HRV + sleep telemetry titrating his trainer's plan, or a decade of journal-and-location history available to his physician. AI personalization sees signals no human butler ever could. And it spills out of the language modality — your hyper-personal output isn't just words. It's images, podcasts, songs, TikToks, your own personalized YouTube channel-of-one.
-- **The extreme endpoint: agent-to-agent.** Every piece of content explained to you by an agent that knows _you_, negotiating with an agent that knows the author's intent. Infinite tailored explanations, each fidelity-checked against the source.
+It's also not just words. The same machinery hyper-personalizes images, podcasts, songs, TikToks — your own personalized YouTube channel-of-one. Whatever medium you consume, AI can build a version of it tuned to you alone.
+
+Where does all that newly-cheap personal attention go? **Learning is the headline win.** A student — or any adult trying to pick up a new skill — used to be stuck with the average textbook plus whatever attention they could get from a teacher splitting time across 30 kids. Now: a tutor who knows the specific prior misconception blocking *you*, who already understands what you've grokked, who explains the next concept in vocabulary you ground in. The kid who couldn't get past chapter 4 and the kid who's three chapters ahead get different explanations from the same source, each pitched to where they actually are. That's a step-function improvement in how fast humans can learn anything.
+
+Then **coaching** — a life coach who's read your journal, knows your sleep, sees what you're actually struggling with this season. **Experiences** — a children's book starring your kid, a podcast that walks you through the 7 Habits in your own dialect, a workout titrated to today's HRV. **Entertainment** — jokes in your specific sense of humor, memes that hit because they're tuned to your taste.
+
+And the unlock for creators is enormous. The publisher-reader transaction inverts. Today: one book, every reader, the same words. Tomorrow: one source, infinite tailored explanations, each fidelity-checked against intent. A 14-year-old reads one version, a CEO reads another, a domain expert reads a third — all from the same canonical artifact you wrote once. The author scales without losing signal. Your audience isn't readers anymore; it's people for whom the system rewrites your work, with you as the source of truth and an author-agent guarding the fidelity. Make something true once; it lands a thousand different ways without you having to write it a thousand times.
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
@@ -67,9 +70,9 @@ The same arc already played out in the online world before generative AI showed 
 
 1. **Everyone saw the same thing.** Print newspaper, broadcast TV, the front page of Yahoo in 1998. One ordering for everyone.
 2. **Sorted by popularity.** Top stories of the day, trending now, most-viewed videos. Same content set, but ranked once globally — still no personalization, just a popularity prior.
-3. **Cohort-personalized via collaborative filtering.** "People like you also liked." Netflix's early recommender, Amazon's "customers who bought this." Personalization through similarity to a group, not to *you* — but a big step up from "the most popular."
+3. **Cohort-personalized via collaborative filtering.** "People like you also liked." Netflix's early recommender, Amazon's "customers who bought this." Personalization through similarity to a group, not to _you_ — but a big step up from "the most popular."
 4. **Per-user personalization.** TikTok's For You page is the canonical example: the feed is reranked for each user from a global pool, every session, in real time. The cohort dissolves; the rank is just-for-you.
-5. **Per-user generation.** Stop pulling from a global pool and start *generating* the content per user. This is the AI step — the feed becomes a personal radio station that doesn't repeat, the explanation rewrites itself for your context, the workout plan is a fresh artifact each week.
+5. **Per-user generation.** Stop pulling from a global pool and start _generating_ the content per user. This is the AI step — the feed becomes a personal radio station that doesn't repeat, the explanation rewrites itself for your context, the workout plan is a fresh artifact each week.
 
 Each step removes a constraint. (1)→(2) needs a popularity counter. (2)→(3) needs collaborative-filtering math + lots of users to find similar cohorts. (3)→(4) needs deep learning + real-time inference at user scale. (4)→(5) needs cheap-enough generation that you can pay-per-user instead of pay-once-per-asset. Each constraint loosened, hyper-personalization advanced a notch.
 
@@ -77,7 +80,7 @@ The online progression and the physical-world progression are the same story tol
 
 ### It's everywhere once you start looking
 
-It's like a fish noticing water. Once you've named the pattern — *desire is constant, cost is the gate* — you see it spilling out in every direction.
+It's like a fish noticing water. Once you've named the pattern — _desire is constant, cost is the gate_ — you see it spilling out in every direction.
 
 - **Choice count over time.** 1 TV channel → 30 cable channels → 300 → 1000 YouTube channels → a million TikToks. Each step is more personalization per viewer-hour. Ice cream went 3 flavors (Neapolitan) → Baskin-Robbins' 31 → today's gelato bars where you build any combination → at-home machines that mix to your preference profile.
 - **Continuous, not discrete.** It's not 3 levels of personalization, it's a slider that has been quietly moving for centuries. Mass-market goods at one end; bespoke-by-AI at the other; everything in between is a stop along the same axis.
@@ -106,7 +109,7 @@ Old hyper-personalization was _more human attention paid to fewer people_. New h
 - Send you memes formatted in the visual language you actually engage with.
 - Adjust today's content to your mood — high-energy when your HRV says you've got it, low-stim when you're depleted, contemplative when your morning journal entry trended that way.
 
-Old hyper-personalization was tailored to your *measurements*. New hyper-personalization is tailored to your *taste* — and your taste shows up in signals you didn't know you were sending.
+Old hyper-personalization was tailored to your _measurements_. New hyper-personalization is tailored to your _taste_ — and your taste shows up in signals you didn't know you were sending.
 
 **And not just in language.** You can personalize into images, videos, songs, podcasts, TikToks, a YouTube channel-of-one. Want the eulogy as a pop song? [Done](/podcast). Want a children's book starring your kid? Done. Want a podcast where the host explains today's news in your specific dialect of nerd? Done. Hyper-personalization spills out of the language modality and into every medium humans consume.
 
@@ -140,15 +143,15 @@ This is hyper-personalization at the extreme: not "the book recommends itself fo
 
 ### From discovery to creation
 
-The recommender-system era was about *discovery*: AI helps you find what you'd like from a finite catalog. Netflix surfacing a film you'd otherwise miss. Amazon nudging you toward the book that fits your shelf.
+The recommender-system era was about _discovery_: AI helps you find what you'd like from a finite catalog. Netflix surfacing a film you'd otherwise miss. Amazon nudging you toward the book that fits your shelf.
 
-The generation era is about *creation*: AI doesn't just find it — it *makes* it. Want a song version of your eulogy? Generate it. Want a children's book starring your kid, in the style of Mo Willems? Generate it. Want a 22-minute podcast that walks you through the 7 Habits in your own voice? [Generated.](/podcast)
+The generation era is about _creation_: AI doesn't just find it — it _makes_ it. Want a song version of your eulogy? Generate it. Want a children's book starring your kid, in the style of Mo Willems? Generate it. Want a 22-minute podcast that walks you through the 7 Habits in your own voice? [Generated.](/podcast)
 
 Discovery says "the right thing exists somewhere; let me find it for you." Generation says "the right thing doesn't exist yet; let me make it for you." Discovery is bound by what the world has already produced. Generation is bound only by how clearly you can describe what you want.
 
 ### Hyper-personalization to your group or tribe
 
-It doesn't have to be just *you*. The same machinery personalizes to a pair (you and your partner — "what should we cook tonight given both our preferences and Tuesday's slow-carb constraint?"), a family ("a movie everyone will sit through"), a team ("a code-review style our whole squad will accept"), a tribe ("a sermon for *this* congregation given *this* week's news").
+It doesn't have to be just _you_. The same machinery personalizes to a pair (you and your partner — "what should we cook tonight given both our preferences and Tuesday's slow-carb constraint?"), a family ("a movie everyone will sit through"), a team ("a code-review style our whole squad will accept"), a tribe ("a sermon for _this_ congregation given _this_ week's news").
 
 The unit of personalization is whoever the second brain has context on. Couple, family, team — each is a valid target.
 


### PR DESCRIPTION
Orphan-commit recovery. PR #627 merged before this commit landed on its branch, so the Bezos-vignette intro Igor explicitly asked for ("Yeah, I like a. Work in more of the TLDR points...") never made it to main.

This is the third-round intro that landed in the previous PR's branch as a follow-up commit. Cherry-picked onto current main and re-PR'd here.

## What changes

The current opener on `_d/hyper-personal.md` is:
> Useful writing tells people something true and important they didn't already know — in a way that leaves no doubt. The problem: everyone is different. ...

That's a writing-tradeoff framing. Igor's note in PR #627: "Maybe the intro isn't writing based, it's based on Jeff Bezos was always able to afford to hyper personalize, blah blah blah."

This PR replaces the opener with the Bezos-vignette + TL;DR-as-prose version:

- 5 paragraphs of flowing prose carrying the full thesis
- Drops the explicit TL;DR bullet list (intro IS the TL;DR)
- Opens on the Bezos-staff vignette (chef, butler, tailor, physician)
- Bolds the headline: **"The big shift is the price."**
- Modality spread (text/audio/video/songs/TikTok)
- Learning-as-headline-win + coaching/experiences/entertainment
- Creator unlock — publisher-reader transaction inverts

Approved by Igor in Telegram before the orphan-merge happened (msgs 3618-3622).

— Keeping my human friend @idvorkin in the loop!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hyper-personalization article with enhanced explanations of AI-enabled personalization scaling and cost efficiency.
  * Refined ML ranking progression section with clearer stage descriptions.
  * Improved content on discovery, generation, and community-based personalization examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/idvorkin.github.io/pull/629)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->