### PR TITLE
hyper-personal: add Gilded-Age hero illustration (raccoon butler/chef/tailor)

### DIFF
--- a/_d/hyper-personal.md
+++ b/_d/hyper-personal.md
@@ -11,6 +11,8 @@ tags:
 
 Jeff Bezos has always had a personal chef who knows he hates capers but loves dill. A butler. A tailor with his measurements. A physician who's known his family for years. None of this is new — Vanderbilts had the same staff a century ago. The desire was universal; what gated it was cost. Human attention scales 1:1 with each customer, so personalization stayed scarce — concentrated where the money was, thin everywhere else.
 
+{% include blob_image_float_right.html src="blog/hyper-personal-hero.webp" %}
+
 **The big shift is the price.** AI dropped the marginal cost of personal attention through the floor. The world Bezos paid for is becoming the everyone-default — same staff, at the cost of a query. And the AI version goes further than Bezos's staff ever could: even his chef didn't know how his blood sugar responded to last week's pasta, his trainer didn't see his HRV trend, his physician couldn't pattern-match across a decade of journal-and-location data. Hyper-personalization isn't just democratizing the old kind. It's reaching into dimensions that didn't exist at any price.
 
 It's also not just words. The same machinery hyper-personalizes images, podcasts, songs, TikToks — your own personalized YouTube channel-of-one. Whatever medium you consume, AI can build a version of it tuned to you alone.

--- a/_d/hyper-personal.md
+++ b/_d/hyper-personal.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Hyper Personalization"
 permalink: "/hyper-personal"
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/hyper-personal-hero.webp
 redirect_from:
   - /hyper-personalization
   - /bespoke-everything


### PR DESCRIPTION
Adds the hero illustration to /hyper-personal — the transparent LHS-only crop of concept 1 (Gilded-Age scene: butler, chef, tailor raccoons serving the rich top-hat raccoon, gas-lamp library, warm light).

Igor picked this from the picker-board options yesterday (msg 3639: "Let's do 1 only the LHS transparent background"). Cropped to the left half, Recraft-stripped to transparent, ready to float.

## Changes

- `_d/hyper-personal.md` — adds `{% include blob_image_float_right.html src="blog/hyper-personal-hero.webp" %}` after the opening paragraph (placement-aware: keeps the first-paragraph excerpt intact per CLAUDE.md's "Opening Paragraphs" rule).

## Asset

Hosted at [idvorkin/blob#25](https://github.com/idvorkin/blob/pull/25) — `blog/hyper-personal-hero.webp`, 688×768 RGBA, 119 KB. Once that merges, the include here resolves.

## Order to merge

Blob PR #25 first (so the image is reachable), then this one.

— Keeping my human friend @idvorkin in the loop!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added support for a right-floated hero image on the blog post via a front-matter image URL, improving visual presentation and readability. Authors can now specify an image to appear alongside the post header. No other content changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/idvorkin.github.io/pull/630)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->