### PR TITLE
Untangled: rewrite in Igor 7h-c1 style — 1174 → 534 lines

### DIFF
--- a/_d/untangled.md
+++ b/_d/untangled.md
@@ -11,1163 +11,524 @@ redirect_from:
   - /untangled-book
 ---
 
-Remember when your daughter was little and you could fix almost anything with a hug and a Band-Aid? Those days feel like a different lifetime now. Parenting a teenage girl means navigating a completely new terrain – one where the problems are more complex, the emotions run deeper, and your old playbook doesn't quite work anymore.
+Your daughter isn't breaking — she's running seven developmental strands at once. Each strand tells you what's normal, what's not, and where dads keep getting it wrong. These are my notes from Lisa Damour's _Untangled_, filtered through what's actually mattered raising a teenage girl.
 
 {% include amazon.html asin="0553393073" %}
 
-If you've ever felt lost watching your daughter navigate friendship drama, mood swings, or her first heartbreak – you're not alone. Lisa Damour's "Untangled" breaks down the teenage years into seven key developmental strands, helping fathers (and all parents) understand what's happening beneath the surface. This isn't just about surviving the teenage years – it's about staying connected with your daughter as she grows into the person she's becoming.
-
-As a father myself, I've found this book invaluable. While much of the parenting advice out there focuses on the mother-daughter relationship, these notes highlight insights particularly relevant for dads. Whether you're wondering if her behavior is normal (it usually is), concerned about when to step in (less often than you think), or just trying to figure out how to talk to her anymore (you're not alone), this guide offers practical, research-based answers.
+{% include ai-slop.html percent="60" %}
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
-- [The Seven Developmental Strands](#the-seven-developmental-strands)
-  - [1. Parting with Childhood](#1-parting-with-childhood)
-  - [2. Joining a New Tribe](#2-joining-a-new-tribe)
-  - [3. Harnessing Emotions](#3-harnessing-emotions)
-  - [4. Contending with Adult Authority](#4-contending-with-adult-authority)
-  - [5. Planning for the Future](#5-planning-for-the-future)
-  - [6. Entering the Romantic World](#6-entering-the-romantic-world)
-  - [7. Caring for Herself](#7-caring-for-herself)
-- [Key Insights](#key-insights)
-  - [When to Worry](#when-to-worry)
-  - [Common Patterns](#common-patterns)
-  - [Self-Reflection Questions for Dads:](#self-reflection-questions-for-dads)
-- [Practical Applications](#practical-applications)
-  - [Communication Strategies](#communication-strategies)
-  - [Setting Boundaries](#setting-boundaries)
-  - [Building Trust](#building-trust)
+- [1. Parting with Childhood](#1-parting-with-childhood)
+  - [The cold shoulder is the announcement](#the-cold-shoulder-is-the-announcement)
+  - [Be the pool wall, not the swimmer](#be-the-pool-wall-not-the-swimmer)
+  - [Allergic to questions — drop the small talk](#allergic-to-questions--drop-the-small-talk)
+  - [Polite, not respectful](#polite-not-respectful)
+  - [Surprisingly mean — she knows where it hurts](#surprisingly-mean--she-knows-where-it-hurts)
+  - [Competent except when she's not](#competent-except-when-shes-not)
+  - [Puberty as mutiny, not blossoming](#puberty-as-mutiny-not-blossoming)
+  - [Smoke without fire](#smoke-without-fire)
+  - [Worry when: the Female Peter Pan](#worry-when-the-female-peter-pan)
+- [2. Joining a New Tribe](#2-joining-a-new-tribe)
+  - [Popular = powerful, not liked](#popular--powerful-not-liked)
+  - [Quality of tribe beats quantity](#quality-of-tribe-beats-quantity)
+  - [Frenemies — the friendship that keeps drawing blood](#frenemies--the-friendship-that-keeps-drawing-blood)
+  - [Be her "crazy rules" alibi](#be-her-crazy-rules-alibi)
+  - [When the tribe needs an elder](#when-the-tribe-needs-an-elder)
+  - [Online drama is real drama, just with receipts](#online-drama-is-real-drama-just-with-receipts)
+  - [Teach assertion, not nice](#teach-assertion-not-nice)
+  - [Worry when: isolated, bullied, or bullying](#worry-when-isolated-bullied-or-bullying)
+- [3. Harnessing Emotions](#3-harnessing-emotions)
+  - [You're the dumping ground (it's a compliment)](#youre-the-dumping-ground-its-a-compliment)
+  - [Don't fix it, sit with it](#dont-fix-it-sit-with-it)
+  - [I'm upset, now you're upset](#im-upset-now-youre-upset)
+  - [Befriend distress](#befriend-distress)
+  - [Catalytic reactions — distract, don't only discuss](#catalytic-reactions--distract-dont-only-discuss)
+  - [Don't become the accidental helicopter](#dont-become-the-accidental-helicopter)
+  - [Posting isn't coping](#posting-isnt-coping)
+  - [Worry when: mood disorders, self-harm](#worry-when-mood-disorders-self-harm)
+- [4. Contending with Adult Authority](#4-contending-with-adult-authority)
+  - [Curtain comes down on "because I said so"](#curtain-comes-down-on-because-i-said-so)
+  - [Frame the danger, not the rule](#frame-the-danger-not-the-rule)
+  - [Rupture and repair beats no rupture](#rupture-and-repair-beats-no-rupture)
+  - [Own your crazy spots](#own-your-crazy-spots)
+  - [Adults with faults — including you](#adults-with-faults--including-you)
+  - [Hold the line on the few rules that matter](#hold-the-line-on-the-few-rules-that-matter)
+  - [Worry when: too good, constantly contending, or you vs spouse](#worry-when-too-good-constantly-contending-or-you-vs-spouse)
+- [5. Planning for the Future](#5-planning-for-the-future)
+  - [She drives, you sit shotgun](#she-drives-you-sit-shotgun)
+  - [The internet records the impulses](#the-internet-records-the-impulses)
+  - [Grades are feedback, not worth](#grades-are-feedback-not-worth)
+  - [Tense about tests](#tense-about-tests)
+  - [Disappointment is the curriculum](#disappointment-is-the-curriculum)
+  - [Plan next week, not next decade](#plan-next-week-not-next-decade)
+  - [Worry when: all plan no play, or no plan in sight](#worry-when-all-plan-no-play-or-no-plan-in-sight)
+- [6. Entering the Romantic World](#6-entering-the-romantic-world)
+  - [A dream deferred — earlier than you think](#a-dream-deferred--earlier-than-you-think)
+  - [Marketing tells her what to want](#marketing-tells-her-what-to-want)
+  - [Offering some perspective](#offering-some-perspective)
+  - [Inner compass beats outside scorecard](#inner-compass-beats-outside-scorecard)
+  - [Dating for status isn't dating](#dating-for-status-isnt-dating)
+  - [Stay askable, not preachy](#stay-askable-not-preachy)
+  - [Being gay — the slur and the reality](#being-gay--the-slur-and-the-reality)
+  - [Worry when: tributaries vs the lake](#worry-when-tributaries-vs-the-lake)
+  - [Worry when: April–June romances](#worry-when-apriljune-romances)
+- [7. Caring for Herself](#7-caring-for-herself)
+  - [Nodding isn't listening](#nodding-isnt-listening)
+  - [Sleep loses to the phone every time](#sleep-loses-to-the-phone-every-time)
+  - [Food and weight are landmines — defuse them](#food-and-weight-are-landmines--defuse-them)
+  - [Getting real about drinking](#getting-real-about-drinking)
+  - [Straight talk about drugs](#straight-talk-about-drugs)
+  - [Sex and its risks](#sex-and-its-risks)
+  - [Worry when: eating disorders, failure to launch](#worry-when-eating-disorders-failure-to-launch)
+- [Dad-specific notes](#dad-specific-notes)
 - [Resources](#resources)
-- [Appendix: About These Notes](#appendix-about-these-notes)
+- [Appendix: the kettlebell analogy](#appendix-the-kettlebell-analogy)
 
 <!-- vim-markdown-toc-end -->
-  <!-- prettier-ignore-end -->
+<!-- prettier-ignore-end -->
 
-## The Seven Developmental Strands
+## 1. Parting with Childhood
 
-### 1. Parting with Childhood
+She has to get from "holds your hand in public" to "leaves home in five years" — and her unconscious mind does the math early. The rejection isn't personal, it's developmental. She's not pushing _you_ away, she's pushing _childhood_ away, and you're cast as Childhood.
 
-**Your daughter will:**
+### The cold shoulder is the announcement
 
-- Start rejecting childhood activities she once loved ("That's for little kids!")
-- Suddenly need more privacy (closed doors become the new normal)
-- Feel embarrassed by family traditions or public affection
-- Test independence while still needing your support
-- Swing between mature moments and childlike needs
+When she retreats to her room and answers in monosyllables, she's announcing "I'm a teenager now." Treat the closed door as a feature, not a rule violation. Most girls behind closed doors are doing exactly what they used to do with the door open — texting, reading, listening to music, daydreaming. The door is symbolic, not evidence of contraband.
 
-**You'll find this hard because:**
+The withdrawal is also strategic. From her perspective, an abrupt break gives her years of practice at being away before she actually has to leave home. It's the psychological equivalent of training wheels for independence — she gets to rehearse the dorm-room version of her life while still enjoying the safety net of yours. Don't take the rehearsal personally.
 
-- Her rejection of childhood activities feels personal (it's not)
+The fix isn't to chase her back into the open. It's to maintain reliable contact at points she'll show up for — meals, car rides, the occasional one-on-one outing. Anna Freud noted that teenagers live in the family "in the attitude of a boarder, usually a very inconsiderate one" — and that observation is from 1958. This isn't new. It's not even bad. It's the work.
 
-  - "But you used to love when I read to you..."
-  - "Remember when we always used to...?"
-  - Feeling hurt when she rolls her eyes at family traditions
-  - What specific rejections hurt the most?
-  - Am I reacting to current rejection or remembering my own childhood?
-  - How might she see this differently than I do?
+### Be the pool wall, not the swimmer
 
-- The special closeness of childhood is changing
+She's the swimmer, you're the pool, the world is the water. She swims out, gets dunked, comes back to the wall to catch her breath, then shoves off — sometimes with a fight she picks just to get back into the water. Don't take the shove personally. Be there next time. Walls don't chase swimmers.
 
-  - "I miss when you would tell me everything"
-  - Lingering in her doorway hoping to chat
-  - Scrolling through baby photos late at night
-  - Which moments of closeness do I miss the most?
-  - What new forms of connection might be possible?
+The shove-off is the part that hurts. She's been warm and close for an hour, and then suddenly she's picking a fight about your shoes or your tone or the way you breathe. What just happened? Lingering too long would feel babyish to her, and "babyish" is the worst possible feeling at this age. So she manufactures the friction she needs to push off and swim back out. That's the move. It hurts. It's also developmentally necessary.
 
-- You're unsure about new boundaries and roles
+Your job is to remain the wall. Some parents take the pushes personally enough to disengage — and that's the worst outcome, because now she has nowhere to come back to. Other parents try to be the swimmer with her, which doesn't work either; she needs a stable thing to push against, not another body in the water. Stand strong, anticipate the push-off, don't allow rudeness to go unchallenged, and have your own support system so you don't need her to come back warm to feel okay.
 
-  - "How do I step in anymore?"
-  - "Am I being too strict? Too lenient?"
-  - Hovering outside her room, unsure whether to knock
-  - Which parts of my parenting role am I most afraid to let go?
-  - How can I redefine my role while staying connected?
+### Allergic to questions — drop the small talk
 
-- Watching your little girl grow up brings grief
+"How was your day?" is the wrong question. Ask the specific thing you actually want to know: "Last week algebra was killing you — still bad?" Honest questions get honest answers. Generic conversation-starters trigger generic stonewall replies, because she correctly reads them as filler rather than real interest.
 
-  - "Where did my little girl go?"
-  - Tearing up while packing away childhood toys
-  - "It's all happening so fast"
-  - What specific childhood moments am I grieving?
-  - How might this grief be affecting my parenting decisions?
+When she does start to volunteer something, follow _her_ lead. If she mentions a band teacher is being weird, the next move is "really, what kind of weird?" — not the carefully crafted question you had queued up. Honest questions get honest answers; tracked-down preplanned questions get exhausted shrugs. And sometimes the right move is no question at all — let her control the sound system in the car and just drive.
 
-- You worry about losing your close connection
-  - "Will she still need me?"
-  - "What if we grow apart?"
-  - Trying too hard to stay relevant in her life
-  - What specific aspects of our connection worry me most?
-  - How might we build new forms of connection?
-  - What would make me feel more secure about our relationship?
+Carpooling other people's daughters is better intel than a hundred dinner-table questions. Once a group of girls has been talking for ten minutes, the chauffeur becomes invisible and they forget you're there. You'll learn more about her social world from a single carpool than from three weeks of asking how things are going. The trick: never join the conversation, never ask questions while driving, never reference what you overheard. Break those rules once and the spell is permanently broken.
 
-**You should not:**
+### Polite, not respectful
 
-- Take it personally when she says "you're embarrassing me!"
+Respect is too abstract to enforce. Polite is concrete. "You don't have to like my question, but you need to find a polite way to answer." The word "polite" works because she knows what it means; "respectful" sets an unreasonably high bar and turns every disagreement into a referendum on whether she's a good person.
 
-  - "But we always used to dance together in public..."
-  - "Why are you ashamed of our family traditions?"
-  - Guilt-tripping about rejected affection
+The leverage point: optional good deeds. The mall run, the ride to a friend's, the request that you cover for her with grandma — these are favors, not entitlements, and they're contingent on polite treatment. "I love you and want to help you, but you've been snarky for days and I'm not going to reinforce that. Warm it up several degrees and try again later." That's not blackmail; it's how the rest of the world works. People don't do nice things for people who are mean to them, and better she learn this lesson at home than discover it the hard way when she's an adult.
 
-- Force her to maintain childhood traditions she's outgrown
+### Surprisingly mean — she knows where it hurts
 
-  - "You WILL sit on Santa's lap for our annual photo!"
-  - "This is what we've always done as a family"
-  - Insisting on childhood nicknames she hates
+The meanness is exquisitely targeted because she knows your soft spots better than anyone. The kid who comments on your weight, your hair, your career, your relationship — she's not picking at random, she's drawing from years of close observation. And the meanness is retaliation-proof: she'll wrap it in "I'm just being helpful" or "I'm just kidding," leaving you with nothing concrete to name.
 
-- Share childhood stories or photos without permission
+When she crosses the line, name it anyway, calmly: "Ouch." "That's hurtful." "We don't talk to each other like that." If she gets defensive or stomps off, you're doing your job — she needs to hear that no self-respecting person will enjoy her company when she treats people the way she just treated you. Don't escalate, don't retaliate. The point is to make the line visible.
 
-  - Posting baby photos on social media
-  - Telling embarrassing stories to her friends
-  - Showing childhood videos to guests
+Sometimes the meanness is actually teasing — pulling close and pushing away at the same time. That's harder to read but also harder to take personally. If you're not sure which it is, ask yourself whether the moment had warmth in it. Real teasing usually does. Genuine meanness doesn't.
 
-- Tease her about changing interests
+### Competent except when she's not
 
-  - "Oh, NOW you care about your hair?"
-  - "Remember when you said boys were gross?"
-  - Making fun of her new mature interests
+The girl who navigates public transit can't put in her own contacts. The kid who organizes the school fundraiser can't return overdue library books. The competent young woman who runs the household when you're traveling cannot, somehow, make her own pediatrician appointment. Her skills don't develop evenly — they sprint forward in some areas while staying frozen in others, especially around interacting with adults outside the family.
 
-- Compare her to her younger self
-  - "You used to be such a happy child..."
-  - "What happened to my sweet little girl?"
-  - Constantly referencing past behaviors
+The fix isn't to demand that she catch up by force. Same approach as toddler progression: do it _for_ her → _with_ her → _stand by to admire_ → _let her do it alone_. The girl who can't put in contacts probably needs you to put them in with her this weekend, narrating each step, then have her do step one while you do the rest, and gradually hand over the whole task. Don't shame the gap. Don't be exasperated that someone who can wield a power drill can't operate a stove. The unevenness is normal; the path through is patient.
 
-**You should:**
+The thing _not_ to do: tell her that if she can program a computer she should be able to call the doctor. The logic is irrelevant. The phone-call thing isn't a skill issue, it's a fear-of-adults thing, and shaming her into it just makes the fear worse. Walk through one call with her, then let her make the next one with you in the room, then let her make the next one on her own.
 
-- Respect her growing need for privacy
+### Puberty as mutiny, not blossoming
 
-  - Knocking before entering her room
-  - Asking before sharing her stories
-  - Giving her space to change and grow
+Adults pitch puberty as a "joyous blossoming." Girls hear: smelly armpits, pimples, breasts to be compared, blood. She wants to part with childhood on _her_ schedule — and most girls have a clever schedule that lets them advance in some areas while retreating to dolls and old books in others. Puberty marches ahead regardless of her preferences. To her, her body is mutinying against the careful pace she set.
 
-- Find new, more "mature" ways to connect
+The fix isn't to sell her on how exciting it is. It's to give her information without making her perform her relationship with it. Hand her an age-appropriate book about puberty. Put it in her room with a casual note ("found this while browsing"). Don't ask whether she's read it. Don't quiz her on what's in it. The point is to make accurate information available so she can consult it without having to ask anyone, including you.
 
-  - "Want to get coffee and chat?"
-  - "I'd love your opinion on this..."
-  - Treating her more like a young adult
+If she opens the door a crack — "Mom, how old were you when you got your period?" — answer the question and stop there. Don't barge through with the entire conversation you've been saving. Talking to a teenager about a delicate topic is like talking through a door she's holding partly open. Work in the space she's given you, and she'll open it wider next time. Push too hard and she'll slam it and bolt it.
 
-- Keep routines but be flexible about participation
+### Smoke without fire
 
-  - "The door's always open if you want to join"
-  - "We'd love to have you, but it's your choice"
-  - Maintaining traditions without pressure
+Dressing or posting like she's twenty-five doesn't mean she's acting twenty-five. _Looking_ sexy and _being_ sexual are different — same as the four-year-old who tries on lipstick has no interest in being an adult. The teenager who hikes up her skirt for the dance may simply be trying on a sophisticated look, not signaling sexual availability. Before reacting, ask: "Is this all smoke, or might there be fire?"
 
-- Store childhood memorabilia (she'll want it later)
+If it's smoke (and most of the time it is), don't call her cheap or a tramp. She doesn't hear "you're sending a signal you don't intend"; she hears "I think you're a tramp." Better: "You've captured a look meant for adults — it's not appropriate at thirteen. That outfit will draw attention that frankly no one in this family is ready for." Same point, no character assassination.
 
-  - Creating memory boxes together
-  - Preserving special items without pressure
-  - Letting her choose what to keep
+Online, the equivalent of the racy outfit is the post that doesn't match the girl you know — the foul-mouthed swagger from a kid who's actually quiet, the boast about hookups that didn't happen. Use the Grandma rule: if Grandma can't see it, don't post it. And have the underlying conversation: what was she hoping to accomplish with that post? Often the answer reveals more than punishment would surface.
 
-- Let her revisit childhood activities on her terms
-  - "Your old stuffed animals are here if you want them"
-  - Keeping favorite childhood books accessible
-  - Welcoming occasional regression without comment
+### Worry when: the Female Peter Pan
 
-**As a dad, you'll face unique challenges:**
+She refuses to grow up at all — clings to childhood routines, terrified of independence, no interest in any adolescent task. The signs: late-adolescent retreat to little-kid pursuits at the expense of age-appropriate ones, anxiety attacks at the idea of leaving home, no movement toward the basic markers of adolescence (interest in peers, privacy, self-determination). Not a phase. Get help.
 
-- She might prefer "girl time" with mom
+## 2. Joining a New Tribe
 
-  - "Maybe mom should handle this..."
-  - Feeling awkward during "girl talk"
-  - Stepping back when you used to step in
-  - How can I stay involved without being intrusive?
-  - What unique father-daughter moments can I create?
+Family was her tribe. Now she has to build a new one — and tribelessness feels like death. Most "drama" makes sense if you remember she's not picking friends, she's negotiating tribe membership.
 
-- Physical affection becomes more complicated
+### Popular = powerful, not liked
 
-  - "Do you still want a hug goodnight?"
-  - Unsure about appropriate boundaries
-  - Missing casual affection
-  - How do I respect her changing boundaries while showing love?
-  - What new ways of showing affection might work better?
+Research splits popularity in two: _sociometric_ (well-liked, kind, fun) and _perceived_ (powerful, feared, often disliked). When teens say "popular" they almost always mean the second. The girl her class identifies as popular is typically described by those same classmates as domineering, aggressive, and stuck-up — but feared, indulged, and surrounded by a court of girls who don't want to become her target.
 
-- Emotional discussions might feel unfamiliar
+The intervention is verbal: separate "powerful" from "liked" when she uses the word. "Is she popular or just powerful? Do kids like her, or are they scared of her?" Naming the distinction repeatedly is the only way to break the loop where she idealizes meanness as social currency. There's a third group — liked-_and_-popular — but those girls have a specific skill: they're both friendly _and_ assertive. They're not willing to be cruel and they're not willing to be pushed around. That's the model worth pointing at.
 
-  - "Should I pretend I didn't notice she's crying?"
-  - Feeling tongue-tied during deep conversations
-  - Defaulting to problem-solving mode
-  - What makes these conversations uncomfortable for me?
-  - How can I get better at emotional discussions?
-  - What would help me feel more confident in these talks?
+### Quality of tribe beats quantity
 
-- Traditional father-daughter activities get rejected
-  - "We used to love our Saturday adventures..."
-  - Trying to hide disappointment at cancelled plans
-  - Feeling replaced by friends and phones
-  - What new activities might interest us both?
-  - How can I adapt our old activities to feel more mature?
+The happiest teens have one or two strong friendships, not the biggest social network. Popularity is _work_ — loyalty conflicts, sleepover politics, constant social calculation about who gets invited to what. A girl at the center of a big tribe has to make complex decisions about every interaction; a girl with one or two close friends can lean on her small tribe and skip the calculation entirely.
 
-**Dads should ask themselves:**
+Research on adolescent happiness consistently finds the supportive-friendship variable dwarfs the popularity variable. One excellent friendship beats five mediocre ones. When she's pulled by the popular crowd and at risk of dropping a longtime good friend in the process, name what's happening: "I can tell you're psyched about your new friends, but you seem tense all weekend waiting to hear from them. Sara may not be as fun, but you seemed more relaxed when you were spending time with her." Don't ban the popular crowd; just keep pointing at the data she's collecting on herself.
 
-- How can I maintain connection as she pulls away from "daddy's girl" activities?
-- What new ways of bonding could replace our old routines?
-- How do I balance respecting her independence with staying close?
-- Which changes in our relationship feel most threatening?
-- How can I show I'm still "her dad" while respecting her growth?
+### Frenemies — the friendship that keeps drawing blood
 
-**Worry when:**
+If she keeps complaining about the same peer and keeps going back, telling her to drop the friendship will fail. Adolescent tribes are sticky — leaving one frenemy can cost the whole tribe. Often the math is "if I cut her off, I lose all the other friendships in this group too" — and that's a real, not imagined, cost.
 
-- She completely isolates from family
-- Shows aggressive rejection of all childhood connections
-- Never shows playful or childlike moments
-- Expresses extreme anxiety about growing up
-- Shows persistent sadness about leaving childhood
+Better script when she keeps coming back: "Real friends don't do mean stuff to each other. If you stay, be careful when she's being nice — it may not last." Or: "It sounds like she can be fun — I see why you guys hang out. But real friends don't behave the way she does when she turns." You're not banning the friendship; you're naming the pattern so she'll see it the third time it repeats, instead of the tenth.
 
-### 2. Joining a New Tribe
+If she does want to step back, strategize about how to maintain polite distance without triggering tribal exile. She can be friendly when they cross paths, decline to be the closest confidante, and gradually invest more in other friendships. That's the slow exit. It's harder than yours-or-mine in your adult world, but the adolescent social web doesn't allow the clean cut.
 
-**Your daughter will:**
+### Be her "crazy rules" alibi
 
-- Become intensely focused on friendships ("My friends are my life!")
+The safest girls can blame their good behavior on you. "I'd smoke with you, but my mom has a bloodhound's nose." "I want to come, but my dad will throw me in rehab if he smells weed on me." For this to work, you must be boring, middle-aged, and slightly draconian _in front of her friends_ — even if you're warm and reasonable at home. The performance is the protection.
 
-  - "Can I go to Sarah's house? Everyone's going to be there!"
-  - Constantly texting and checking social media
-  - "You don't understand, this is IMPORTANT"
+The parents who play the cool kid — letting underage drinking happen at their house, serving alcohol to minors so the kids are "safe" — actually take this tool away from her. Now she can't blame her good behavior on you because her friends know you'd allow the bad behavior. The "safe" cool-parent strategy strips her of the alibi she needs at moments where she does, in fact, want out.
 
-- Get hypersensitive to peer opinions
+Pair the crazy-rules alibi with the no-questions-asked pickup: "Call me from anywhere, any time. We'll have a long talk over breakfast about how you ended up at a strange party fifteen miles away. But you'll never regret asking for the ride." Some families even pre-arrange a code — a flatiron she didn't turn off, or some other plausible domestic emergency — so she can save face with her friends while you scream into the phone like an unreasonable parent. Be the bad guy. It's a useful role.
 
-  - "I can't wear that, everyone will laugh"
-  - Changing outfits multiple times before school
-  - "Nobody else's parents make them..."
+### When the tribe needs an elder
 
-- Form intense, close friendships
+She comes to you because a friend is cutting, drinking dangerously, in an abusive relationship, talking about suicide — and was sworn to secrecy. This is one of the highest-stakes parental moments, and the temptation is to immediately call the friend's parents. Don't. Going around her on something she told you in confidence permanently burns her willingness to bring you sensitive information again.
 
-  - "Sarah is my absolute best friend forever!"
-  - Sharing secrets and inside jokes
-  - Dramatic ups and downs in friendships
+Coach her instead. "I'm glad you told me. Your friend needs more help than either of us can give. Two options: she tells her parents and confirms it with you, or you go together to a trusted adult at school and ask them to inform her parents." If the friend refuses both, your daughter has a third move: "An adult needs to know what's going on. If you don't want to tell anyone, I will. I know you'll be mad, but I care more about your safety than about you being happy with me." That's the script. Hand it to her.
 
-- Navigate complex social dynamics
+The only override is immediate life-or-death. If your daughter shares that the friend is right now in danger — actively suicidal, in the middle of an overdose, being beaten — call the friend's parents (or 911) yourself, and explain to your daughter afterward why this one had to be different. The teaching value of respecting her confidence is enormous, but it doesn't apply when the cost of waiting is a body.
 
-  - "The popular girls said I could sit with them..."
-  - Trying to figure out where she fits in
-  - Dealing with shifting friend groups
+### Online drama is real drama, just with receipts
 
-- Try on different identities and roles
-  - Suddenly interested in new music/fashion/activities
-  - "That's not who I am anymore"
-  - Experimenting with different friend groups
+danah boyd: "Teens aren't addicted to social media. They're addicted to each other." Same friendships, same dynamics, now permanent. The kid who would have spent two hours on the family phone with a friend in 1990 is doing the same thing on a phone in her bedroom now — only the receipts persist and the audience scales.
 
-**You'll find this hard because:**
+Phone rules: ban devices from dinner, family night, and short car rides — anywhere humans practice in-person social skills. Begin strict, then loosen. The "Don't smile till December" model that teachers use works: it's much easier to relax rules later than to impose new ones once things are out of control. If she already has a phone with no rules, walk it back: "I gave you total privacy and I'm thinking that was a mistake. I'll be checking your phone and social accounts from time to time."
 
-- Feeling replaced by her friend group
+Monitoring is paying for the phone, not surveillance — and you can be transparent about the rationale. "If the whole world can see what you're doing digitally, I should have access too." Some families negotiate that an older cousin or trusted older sibling does the monitoring instead, which preserves dignity around things like crushes that the kid doesn't want her parents to know about. The point isn't to catch her doing something wrong; it's to keep her from making a permanent record of a momentary impulse.
 
-  - "Remember when I was her favorite person?"
-  - Watching her prioritize friends over family
-  - Missing your special connection
-  - What role do I fear losing most?
-  - How can I support her social growth while staying connected?
+### Teach assertion, not nice
 
-- Worrying about negative influences
+Culture trains girls to be either a doormat or cruel — the Cinderella binary, with no middle option. Assertion — "standing up for yourself while respecting the rights of others" — is the missing middle, and we mostly don't teach it. Adult women still struggle with this; you can bet adolescent girls do too.
 
-  - "Who are these new friends?"
-  - Seeing concerning behavior in friend group
-  - Fear of peer pressure
-  - Which specific influences worry me most?
-  - How do I distinguish normal teen behavior from real concerns?
+The intervention starts with validating the feeling _separately_ from the action. "What she did was awful. You have a right to be angry. But you can't act on it that way." Bad feelings inform; they shouldn't dictate. Then Monday-morning-quarterback the better version of what she could have said or texted: a dispassionate, assertive sentence that defends her position without escalating. "I'm hurt that you shared my personal stuff at school. If you were mad at me, you could've let me know in a different way." Few teenagers will actually deliver that line in the moment — but having walked through what it would have sounded like prepares her for next time.
 
-- Losing control of her social world
+The same lesson applies sideways. When she tells you a group of girls is excluding someone, that's another teaching opportunity: "They may have a reason, but they need to find a kinder way to express it. What would you do if you were in their shoes?" Use peer drama as a training rig — but sparingly. Girls clam up around adults who treat every conversation as a teachable moment.
 
-  - "I don't even know these parents"
-  - Anxiety about social media
-  - Fear of unsafe situations
-  - What aspects of her social life trigger my anxiety?
-  - How can I stay informed without hovering?
+### Worry when: isolated, bullied, or bullying
 
-- Watching her navigate social pain
-  - Seeing her excluded or hurt
-  - Wanting to fix friendship problems
-  - Feeling helpless during social struggles
-  - How do I support without overstepping?
-  - When should I intervene versus let her handle it?
+- **Isolated** — one good friend is enough. Zero is trouble. Loneliness and depression are tangled and self-reinforcing; the longer she goes friendless, the worse she'll feel and the harder building new friendships becomes. Take aggressive measures: ask trusted adults at school about her social situation, look for summer or after-school environments where she can build new connections with a clean slate, get her in front of a therapist if it persists.
+- **Bullied** — repeated mistreatment by peers who outnumber or outpower her, distinct from common conflict. Step in _carefully_. Talk to the school, not to the other kids' parents. Calling the bully's parents almost always makes it worse — they'll defend their kid and the bullying intensifies. Bullying ≠ conflict; treating conflict as bullying is its own harm, but treating real bullying as conflict can be catastrophic.
+- **Bullying** — own it, don't externalize it. Don't deny what your daughter is doing or blame it on her victims. Studies tracking bullies into adulthood show elevated rates of depression, anxiety, substance abuse, and antisocial behavior. Get her into therapy. The intervention is for her benefit, not just her targets'.
 
-**You should not:**
+## 3. Harnessing Emotions
 
-- Criticize her friends
+Teen emotions feel out of control because they kind of are — the brain's socio-emotional system runs ahead of its regulatory system for years. Your job isn't to lower the volume. It's to help her tolerate the volume.
 
-  - "I don't like that Sarah girl..."
-  - Making judgmental comments about her social choices
-  - Banning friendships without good reason
+### You're the dumping ground (it's a compliment)
 
-- Share her social struggles with others
+She holds it together at school all day, then explodes at you the second she walks in. The temptation is to take it as evidence she doesn't like you. The truth is the opposite: you're the safest place for the meltdown, which is why it lands at your door.
 
-  - Gossiping about friend drama
-  - Discussing her social life with other parents
-  - Posting about her friendship challenges
+The cat she kicks is the cat she feels safest with. Receiving the emotional discharge is a service you provide; she's externalizing — handing off the trash so she can lighten the load and move on. By the time she's dumped it on you, she's already most of the way through. Your job is to absorb without escalating and without retaliating.
 
-- Try to manage her social life
+### Don't fix it, sit with it
 
-  - Calling other parents to resolve conflicts
-  - Forcing friendships with "better" kids
-  - Making her invite certain people
+Reaching for solutions before she's done venting shuts her down. Validate first: "That sounds really hard." Most of the time she doesn't want a fix — she wants someone to confirm the feeling is real. Fix-mode is the dad trap, especially because dads are usually pretty good at fixing things and the impulse to deploy the skill is strong.
 
-- Dismiss the importance of peer relationships
-  - "It's just middle school drama"
-  - "You'll have different friends next year"
-  - Minimizing social conflicts
+The cost of jumping to solutions: she stops bringing problems to you because she correctly predicts you'll respond with a checklist instead of a hug. Listen first. If, after listening, she _asks_ for advice — "what should I do?" — then advise. If she doesn't ask, she didn't want the advice. Holster it. The relationship value of being heard usually exceeds the practical value of any solution you could offer.
 
-**You should:**
+### I'm upset, now you're upset
 
-- Create a welcoming space for friends
+If her storm pulls you into your own storm, you've doubled the problem. Now she has her original distress _plus_ a destabilized parent to manage. Equanimity is contagious — so is panic. [Calm the mind](/be-proactive) — your job is to be the steady thing in the room. {% include summarize-page.html src='/siy' %}
 
-  - Having snacks ready for visitors
-  - Making your home the hangout spot
-  - Getting to know her friends naturally
+The mechanism is real and physiological. Co-regulation: when she's spinning up, your nervous system can either match hers (which doubles the chaos) or stay regulated (which gives her a steady reference point to return to). Building this muscle in yourself is one of the highest-leverage parenting investments available — every storm becomes easier if you can be the lighthouse. The eight-second pause before responding is worth more than whatever you would have said.
 
-- Listen without judgment
+### Befriend distress
 
-  - "Tell me more about what happened"
-  - Validating feelings without taking sides
-  - Being a safe sounding board
+Bad feelings aren't a malfunction. They're information. The goal isn't to eliminate them — it's to know what they mean and ride them out. The girl who learns this in adolescence becomes the adult who doesn't fall apart at the first piece of bad news. The wellness industry has done teenagers no favors by reframing every uncomfortable feeling as a problem to be solved with a candle or an app.
 
-- Help her process social situations
+Model this with your own discomfort. When you're stressed about work, name it without performing crisis. When you're disappointed, let her see what that looks like at room temperature. She's learning her relationship with hard feelings from yours — make sure yours is "this is uncomfortable and survivable" rather than "this is unbearable and must be made to go away."
 
-  - "What do you think you could do?"
-  - Discussing friendship skills
-  - Teaching conflict resolution
+### Catalytic reactions — distract, don't only discuss
 
-- Balance family and friend time
-  - Creating flexible family schedules
-  - Including friends in family activities
-  - Respecting both relationships
+Girls discuss feelings; boys distract. Done in moderation, both work. Done past the helpful mark, discussion becomes rumination — focused, repetitive attention on distress that fuels depression and anxiety rather than resolving them. Research is clear: rumination predicts onset of mood and anxiety disorders, and girls are more prone to it than boys.
 
-**As a dad, you'll face unique challenges:**
+If she's been hashing the same problem for an hour and seems to be sinking rather than rising, suggest a distraction: a run, a walk, a chore, the dog, an old favorite movie. Don't frame it as "stop talking about it" — frame it as "let's try a different angle." Wordless gestures (her favorite snack on the seat when you pick her up, a quiet invitation to watch a movie) do real work without forcing more talking.
 
-- Worry about male friends and dating
+There's a secondary effect to watch for: vicarious distress. When her friend is suffering, _she_ suffers. Girls do this much more than boys, and tribes amplify it. If she's losing sleep over a friend's problem, give her permission to set the worry down for an evening. "You're a great friend, and you're upset because Tia is. But not getting your homework done doesn't help Tia feel better. Push pause on the worry for tonight."
 
-  - "I know how teenage boys think..."
-  - Remembering your own teen years
-  - Protective instincts in overdrive
-  - How do I balance protection with trust?
-  - What healthy boundaries can I model?
+### Don't become the accidental helicopter
 
-- Understanding "girl drama"
+The phone makes you reachable every minute of every snag. She texts "starving, lunch is gross" — you problem-solve. Next week she texts about a missing book. Year three she can't pack her own bag. Helicopter parents are usually _grown_, not chosen — daughter asks, parent provides, daughter loses the skill, repeat. The pattern compounds slowly, and by the time you notice, she's a high schooler who can't handle ordinary friction without you.
 
-  - "I don't get why this is such a big deal"
-  - Feeling lost in emotional complexities
-  - Missing male friendship straightforwardness
-  - How can I better understand her social world?
-  - What questions help me connect with her experiences?
+Wait before you reply. The latency is a feature, not a flaw — it gives her time to come up with a solution that doesn't involve you. By the time you respond, she may have already handled it. If you can't bear the silence, reply with cheerleading, not solutions: "Bummer — but definitely a challenge you can handle. xoxo." That tells her you saw the text and trust her to handle it.
 
-- Managing protective instincts
-  - Wanting to shield her from social pain
-  - Concern about online dangers
-  - Balancing safety with independence
-  - When should I step in versus step back?
-  - How can I protect while empowering?
+The trap is loving and easy to fall into. Every "fix it" you do _for_ her looks like good parenting in the moment. But the cumulative effect of years of fixes is a young adult who can't fix anything. The hard thing to remember is that competence is built through doing — and you only build it by letting her do.
 
-**Worry when:**
+### Posting isn't coping
 
-- She completely isolates from peers
-- Shows signs of being bullied or bullying
-- Can't maintain any friendships
-- Experiences extreme social anxiety
-- Consistently chooses harmful relationships
+Venting to followers feels like processing but isn't. The audience changes what gets said — she'll perform a more extreme version because that's what gets reactions. The record is permanent. The algorithm rewards the most inflammatory version. And the response from followers is usually either validation (which prolongs the feeling) or escalation (which intensifies it). Real processing happens in conversation with someone who knows her — not in front of an audience.
 
-### 3. Harnessing Emotions
+The case study: a teen who responds to every bad feeling by going on the offensive online. She picks a fight, attacks someone publicly, posts a screenshot with snide commentary. In the short term, her distress drops because she's converted shame or hurt into rage and watching the social explosion. In the long term, she's trained herself to attack instead of feel, and she's racked up real social damage that will be waiting when the energy drops. The fix isn't a lecture; it's making sure she has other channels (journaling, a private conversation, a creative outlet) that aren't the public broadcast.
 
-**Your daughter will:**
+### Worry when: mood disorders, self-harm
 
-- Experience intense, volatile emotions
+Persistent low mood (weeks, not days), sleep collapse, withdrawal from things she used to love, cutting or other self-harm, suicidal language. Don't wait it out — get a clinician. Adolescent depression and anxiety are highly treatable when caught early, and the cost of waiting is real. If she's mentioned suicide even casually, ask directly: "Are you having thoughts about hurting yourself, or are you telling me how upset you feel?" Asking doesn't put the idea in her head; research is unambiguous on this. If anything, the question relieves the burden of being alone with it.
 
-  - "You just don't understand how I feel!"
-  - Crying over seemingly small things
-  - Rapid mood shifts within minutes
+## 4. Contending with Adult Authority
 
-- Struggle to understand complex feelings
+She used to think you were a wizard. Now she sees behind the curtain. Good — that's the job. The question is whether you can survive losing the wizard role and become the next thing: a reasoning adult she chooses to listen to.
 
-  - "I don't know why I'm crying..."
-  - Mixed emotions about growing up
-  - "Everything just feels overwhelming"
+### Curtain comes down on "because I said so"
 
-- Try to manage overwhelming emotions
+When she questions a rule, that's the upgrade, not the rebellion. Her growing ability to challenge authority is the same skill she'll use in a year to refuse a bad boy's pressure, in five years to push back on a manipulative boss, in twenty years to advocate for herself in a hard marriage. You _want_ this capacity to develop. The fact that she's pointing it at you first is the price of admission.
 
-  - Slamming doors during arguments
-  - Needing alone time to decompress
-  - Using music/art to process feelings
+Rules without reasoning teach her to follow only when watched. Rules with reasoning teach her the underlying values, which travel with her wherever she goes. Take the time to explain. Not every rule, every time — but the load-bearing ones, repeatedly: why this curfew, why this rule about cars, why this expectation about how you treat people.
 
-- Question her emotional reactions
+### Frame the danger, not the rule
 
-  - "Why am I so sensitive about everything?"
-  - "Is it normal to feel this way?"
-  - Comparing her reactions to peers
+"Be home by midnight" loses to "I worry about drunk drivers after midnight." Frame the underlying concern and she can negotiate within it. "What if I'm at Sarah's, not driving anywhere?" becomes a reasonable counter, not a rebellious one. The rule was a proxy for the worry; if she can address the worry, the rule becomes negotiable in that specific case.
 
-- Build emotional resilience
-  - Learning from emotional challenges
-  - Finding personal coping strategies
-  - Growing awareness of emotional triggers
+This requires you to actually know what you're worried about, which isn't always obvious. "I want her home by midnight" sometimes turns out to be "I'm worried about drunk drivers," sometimes "I'm worried about her being alone late," sometimes "I want her to maintain reasonable sleep," sometimes "I want to know where she is." Each of those concerns has a different mitigation strategy. Naming the real worry — first to yourself, then to her — opens the negotiation that the rule was hiding.
 
-**You'll find this hard because:**
+### Rupture and repair beats no rupture
 
-- Her emotional intensity overwhelms you
+Fights aren't failure. The repair afterward is where the relationship gets stronger — apologizing, naming what went wrong, doing it differently. Couples therapists have long known that the predictor of a marriage's strength isn't conflict frequency but repair quality. Same in parent-teen relationships.
 
-  - "I can't handle another meltdown"
-  - Feeling drained by emotional storms
-  - Uncertainty about appropriate responses
-  - How do I stay calm when she's not?
-  - What triggers my own emotional reactions?
+Parents who avoid all conflict raise teens who can't repair anything. They've never seen the move modeled. They don't know that "I'm sorry, I overreacted, let me try that again" is something adults say. They grow into adults who escalate forever or stonewall forever, with no third option. Conflict and repair, repeated, is the curriculum.
 
-- You struggle to distinguish normal from concerning
+The repair has a structure worth following: name what happened, take responsibility for your part, apologize specifically, commit to a different move next time, ask for forgiveness. "I shouldn't have yelled. I was tired and stressed about work and you got the brunt. I'm sorry. I'm going to do better with that — and I'd like us to be okay." That model is what she'll carry into her own relationships.
 
-  - "Is this typical teen behavior?"
-  - Wondering when to seek help
-  - Comparing to your own teen years
-  - Which emotions signal real trouble?
-  - How do I know when to intervene?
+### Own your crazy spots
 
-- Your own teen emotional memories surface
+Every parent has a topic where reason leaves the room — academics, weight, that one ex of yours she reminds you of, the kind of friend who looks like the kid who hurt you in high school. Name your crazy spots out loud: "I know I overreact about grades. That's mine, not yours." Honesty about your distortion is more useful than pretending you don't have one.
 
-  - Remembering your own struggles
-  - Old hurts getting triggered
-  - Wanting to protect her from pain
-  - What past experiences color my responses?
-  - How can I use my experience helpfully?
+Naming the crazy spot serves two functions. First, it gives her a framework for not internalizing your distortion — when you're being unreasonable about grades, she now knows it's your issue, not a reflection of her worth. Second, it lowers the stakes of the discussion. "Dad's being a grade-crazy person again" is a manageable problem; "Dad is right and I am a failure" is not.
 
-- You feel helpless when you can't fix things
-  - Watching her struggle hurts
-  - Wanting to make everything better
-  - Missing simpler childhood solutions
-  - When should I step back?
-  - How do I support without fixing?
+The corollary: don't pretend your crazy spots don't exist. She can see them. She's been watching since she was three. Pretending they aren't there just makes her wonder what's wrong with her perception.
 
-**You should not:**
+### Adults with faults — including you
 
-- Minimize her emotions
+She'll meet a terrible teacher, a critical coach, a friend's awful parent. Don't switch her out of the class — _seize the chance_ to teach her how to play stupid rules for a good grade, work for a difficult boss, manage imperfect people. "There's no line on your transcript to explain that you didn't like Mr. Martin." Future-her will have unfair bosses, capricious clients, customers who are wrong about everything. The middle-school teacher is a low-stakes training run.
 
-  - "You're being too sensitive"
-  - "It's not that big a deal"
-  - Dismissing feelings as hormones
+Validate her read first (teens are clear-eyed about adult character, often more so than their parents), then point at the real lesson: "I take you at your word that Mrs. Clayton is difficult. That's not the question. The question is how you're going to handle it well enough to get the grade you want." Help her develop tactical workarounds — compare notes with classmates on what the assignments were, find an online tutorial for the grammar she's not catching, build relationships with the chaotic teacher's reasonable colleagues.
 
-- Use emotions against her later
+Step in only for real harm: bias, harassment, abuse, sexual misconduct. The line between "annoying" and "unsafe" is usually clear; if you're not sure, talk to a school counselor first before going scorched-earth at the teacher.
 
-  - "You always overreact like this"
-  - Bringing up past emotional moments
-  - Making her feel ashamed of feelings
+The corollary: when _you_ screw up, own it. Acknowledging your own faults to your daughter teaches her that adults are imperfect and you can still respect them. The girl who works with a coach who's a great trainer but says inappropriate things about her weight needs to learn how to take what's useful from imperfect adults and leave the rest. She'll learn that from how you handle being wrong in front of her.
 
-- Rush to fix emotional challenges
+### Hold the line on the few rules that matter
 
-  - Offering solutions before listening
-  - Trying to talk her out of feelings
-  - Making problems disappear
+Most rules should bend. A few — safety, honesty, how you treat people — don't. Pick the hill carefully. Negotiating everything trains a lawyer who litigates every decision; negotiating nothing trains a rebel who treats every rule as oppression.
 
-- Compare her to others
-  - "Your sister handles things better"
-  - "Other girls don't get so upset"
-  - Pointing out peers' emotional control
+The art is being deliberate about which rules are negotiable and which aren't, and being transparent about the difference. "Curfew is negotiable depending on what you're doing — let's talk about it. But the no-drinking-and-driving rule isn't negotiable, not now, not later, not ever." Knowing which category a given rule is in saves her the energy of trying to negotiate the unmovable ones, and frees her to negotiate the others productively.
 
-**You should:**
+### Worry when: too good, constantly contending, or you vs spouse
 
-- Create safe spaces for emotions
+- **Too good** — zero pushback in mid-adolescence is suspicious. Healthy separation requires some friction. The kid who never argues might be the kid who's perfectly aligned with you, or might be the kid who's keeping her real life entirely hidden because home doesn't feel safe enough to show it.
+- **Constantly contending** — every interaction is a fight. The kid who's at war with every rule, every limit, every conversation is signaling something — anxiety, depression, an external problem she can't name. Get outside eyes on it.
+- **Adults contending with each other** — you and your spouse arguing about her is its own developmental harm. Disagree privately, present united. The kid who hears mom and dad fighting about how to handle her absorbs the message that she's a problem to be managed, which lands badly.
 
-  - "I'm here to listen when you're ready"
-  - Making time for one-on-one talks
-  - Respecting her need to process
+## 5. Planning for the Future
 
-- Validate without fixing
+The shift from "what should I have for lunch" to "what should I do with my life" happens fast and badly. She wants the answer now, wants it to be perfect, and panics when it isn't. Your job is to slow her down and widen the time horizon — not to hand her the answer.
 
-  - "That sounds really hard"
-  - "It makes sense you'd feel that way"
-  - Being present through emotions
+### She drives, you sit shotgun
 
-- Model healthy emotional regulation
+She picks the destination. You hold the map and call out turns. The minute you grab the wheel — picking her classes, writing her essays, applying for her summer programs — she stops driving and you've taught her the wrong thing. Future-her needs to know how to do this. She only learns by doing.
 
-  - Showing how you handle stress
-  - Admitting and managing your own feelings
-  - Demonstrating recovery from upsets
+The temptation is intense, especially when the stakes feel high. College applications, summer programs, the difference between this school and that school — these feel like the difference between her thriving and her not thriving. They mostly aren't. The biggest factor in her trajectory isn't which school she gets into; it's whether she's developing the skill of making decisions for herself. Take that skill away in service of a marginally better school and you've made the wrong trade.
 
-- Teach coping strategies
-  - Breathing exercises together
-  - Suggesting healthy outlets
-  - Finding what works for her
+### The internet records the impulses
 
-**As a dad, you'll face unique challenges:**
+Teenage impulse + permanent record is new. Things she would have shouted across a parking lot in 1995 are now searchable in 2035. The angry post, the half-naked selfie sent to one boy who turned out not to be trustworthy, the cruel comment about a classmate — none of these used to follow you. Now they do.
 
-- Managing your own emotional discomfort
+This is less about scaring her than helping her notice the asymmetry. Future-her reads every post present-her writes. Future bosses Google her. Future romantic partners check her socials. Even content she "deletes" lives on in screenshots and archives. The point isn't to forbid posting — that's a losing battle — it's to make the asymmetry visible so her impulse to broadcast is met with even a half-second of "what would I think of this in five years?"
 
-  - "Should I leave this to her mother?"
-  - Feeling awkward with intense emotions
-  - Wanting to fix rather than feel
-  - How do I handle emotional situations?
-  - What makes me most uncomfortable?
+### Grades are feedback, not worth
 
-- Breaking traditional male stereotypes
+Grades measure how a specific test went on a specific day. They don't measure her. Anxiety about grades is contagious — be careful what you transmit. Discuss strategy, study habits, sleep — not catastrophe. The parent who can't talk about a B without their voice tightening teaches the kid that B is a catastrophe. She'll learn the calibration, and she'll calibrate the same way.
 
-  - Showing it's okay for men to feel
-  - Expressing emotions openly
-  - Being vulnerable with your daughter
-  - How do I model healthy male emotions?
-  - What messages did I receive growing up?
+The deeper move: notice what you actually care about. If you say "I just want you to be happy" but react more to grades than to anything else, she'll learn what you actually value from the reactions, not the words. Be honest with yourself about what you're transmitting. If you really do care about grades, name that openly — and then ask whether that's serving her.
 
-- Balancing strength with sensitivity
-  - Being both protector and emotional support
-  - Showing it's okay to be both strong and sensitive
-  - Finding the right emotional distance
-  - How do I maintain boundaries while staying connected?
-  - When should I share my own emotional experiences?
+### Tense about tests
 
-**Worry when:**
+Test anxiety is gendered — girls feel evaluative situations more sharply than boys do, and at high enough intensity the working memory shuts down. The cognitive resources that should be answering the questions are busy managing the panic. Score drops, which confirms the anxiety, which makes the next test worse. The loop is real and self-reinforcing.
 
-- She shows signs of depression or anxiety
-- You notice self-harm or suicidal thoughts
-- She can't regulate emotions after trying to calm down
-- Emotional swings severely disrupt daily life
-- She completely shuts down emotionally
+Three counters. _Normalize_ moderate anxiety — some tension is fuel, not malfunction. The girl who walks in expecting Zen-master calm and feels the first flicker of nerves will decide the anxiety has won; the girl who expects to feel some tension and uses it can perform. _Fix the studying_ — research is clear that rereading and highlighting are among the worst-performing study tactics, and practice testing under test-like conditions is the best. Most kids study with the worst method by default; help her switch.
 
-### 4. Contending with Adult Authority
+_Shrink the stakes_ — one test measures mastery on one day, not her future, her intelligence, or her worth. The catastrophizing voice ("if I bomb this, my whole college plan is gone") is doing as much damage as the test itself. Help her replace the line. Watch for stereotype threat: girls primed with "girls are bad at math" actually do worse on math tests, even strong female mathematicians. Don't prime it. If she's primed it herself, name it explicitly so she can see the mechanism.
 
-**Your daughter will:**
+### Disappointment is the curriculum
 
-- Question rules and authority
+She didn't make the team, didn't get the part, didn't get into the school. This is the actual training for adulthood. Don't try to make the disappointment go away — sit with her in it, and a week later ask what she learned. Resilience is built from rehearsed recovery, not from being protected.
 
-  - "But WHY is that even a rule?"
-  - "That rule doesn't make sense anymore"
-  - "Other parents let their kids..."
+The hardest version of this is the disappointment _you_ saw coming. The kid who didn't train and didn't make the team, who didn't study and got the bad grade. The urge is enormous to say "I told you so" or "if you'd just listened to me." Don't. The lesson she's learning in the wreckage is the lesson you wanted her to learn — and she'll learn it less well if you take credit for predicting it.
 
-- Test boundaries while seeking guidance
+Trust the discomfort. The breakup teaches her how to repair after heartbreak. The rejection teaches her she can survive rejection. The failed audition teaches her that risk-taking sometimes loses, and that's survivable. Each disappointment, ridden through with you present but not solving, is a deposit in the resilience account she'll draw on for the rest of her life.
 
-  - Breaking small rules to see what happens
-  - Negotiating for more privileges
-  - "I'm old enough to make my own decisions!"
+### Plan next week, not next decade
 
-- Develop critical thinking about authority
+"What do I want to be?" is unanswerable at fifteen. "What classes am I taking next year?" is answerable. Pull the horizon in close. Practice small decisions; the big ones get easier when she's logged a hundred small ones. The teenager paralyzed by "what's my career" can usually unfreeze when the question becomes "what summer thing should I sign up for."
 
-  - Pointing out inconsistencies in rules
-  - Questioning traditional practices
-  - "Just because you're the parent doesn't make you right"
+This is also the antidote to the social-media pressure to have a fully-formed life plan by sixteen. The kids who look like they have it figured out are mostly performing certainty they don't actually feel; meanwhile your daughter is panicking because she can't match the performance. Tell her: nobody knows. You're not supposed to know. Most adults are still figuring it out. The trick isn't to know the answer, it's to make the next decision well and keep adjusting.
 
-- Learn to advocate for herself
+### Worry when: all plan no play, or no plan in sight
 
-  - Making cases for new privileges
-  - Standing up for her viewpoint
-  - "Can we discuss this like adults?"
+- **All plan, no play** — every minute optimized, no friends, no fun, no rest. The high-achieving girl whose schedule has no slack is heading for either burnout, depression, or the kind of perfectionism that doesn't survive contact with adult life. Slack is necessary, not optional.
+- **No plan in sight** — total disengagement from her own future, not picking any direction, anxious indifference about every decision. Different from healthy uncertainty about a career path; this is paralysis. Both extremes — over-planning and complete disengagement — signal she's overwhelmed. Both need attention. One looks like ambition, one looks like apathy, but both are stress responses.
 
-- Balance independence with family values
-  - Testing which rules are flexible
-  - Finding her own moral compass
-  - "I know the rules, but..."
+## 6. Entering the Romantic World
 
-**You'll find this hard because:**
+Romance is being marketed to her constantly, and the market sells a script. Your job is to make sure she has an inner compass that doesn't run on the market's scorecard.
 
-- Her questioning feels like disrespect
+### A dream deferred — earlier than you think
 
-  - "She never used to talk back like this"
-  - Feeling your authority challenged
-  - Missing simpler times
-  - How do I distinguish disrespect from healthy questioning?
-  - What triggers my defensive reactions?
+She's been waiting for a romantic life since she was four and figured out her parents had a relationship that excluded her. The realization at three or four that there's a special bond between parents — one she's not part of — kicks off a years-long anticipation of having her own romantic partnership. By fifth or sixth grade, "going with" someone enters the lunch-table chatter — usually meaning class-wide acknowledgment they're a couple, almost no actual interaction.
 
-- You struggle with changing boundaries
+When she casually mentions she's "going with" someone in sixth grade, your impulse is panic. Don't. From her perspective, she's been waiting for this for six years. From yours, she's eleven. Both are true. The crisis-mode response (interrogation, calling the other kid's parents) closes the door for years. Be an anthropologist instead. Ask what the terms mean. What do couples do? What do they not do? How does someone become someone's boyfriend or girlfriend at her school?
 
-  - "I don't know where to draw the line anymore"
-  - Uncertainty about age-appropriate freedoms
-  - Fear of losing control
-  - Which rules are truly important?
-  - How do I adapt rules as she grows?
+The first time you treat her romantic life as a problem, you've trained her to never bring it to you. Six years later, when the stakes are real, she'll be navigating the hardest part on her own. The early conversations are practice — for both of you — at making the topic discussable.
 
-- Your own teen rebellion memories surface
+### Marketing tells her what to want
 
-  - Remembering your conflicts with authority
-  - Seeing yourself in her arguments
-  - Wanting to avoid past mistakes
-  - How do my teenage experiences influence my parenting?
-  - What can I learn from my past?
+Movies, music, social media — the romantic ideal she's absorbing was sold to her, not arrived at. Boy bands are engineered: the not-too-dangerous bad boy, the ethnic-but-not-too-ethnic one, the jock, the romantic. Each member is designed to be the crush of a different segment of the target audience. The lyrics are test-marketed to hit exactly what frustrated teenage girls want to hear — _you're beautiful, you're special, I'd be lucky to be with you_.
 
-- Power struggles drain everyone
-  - Constant negotiations exhaust you
-  - "Everything becomes a debate"
-  - Missing peaceful compliance
-  - When is it worth standing firm?
-  - How can I avoid unnecessary battles?
+The handlers are middle-aged music industry executives, and the entire system exists to extract billions of dollars from teenage emotional life. If her romantic energy is pointed at a packaged star, _be grateful_ — no breakups, no pregnancies, no relationship to manage. Negotiate the merch and concert tickets, but otherwise let her enjoy the safest possible love affair. Save the worries for when it's a real boy.
 
-**You should not:**
+The deeper lesson is to name the marketing once, then move on. "Notice how Hollywood always shows romance as a girl getting saved by a boy? That's not for the girl's benefit — it's a marketing pattern that sells movie tickets to teenagers." Once she sees the marketing, she can't unsee it. You don't need to hammer it.
 
-- Respond with "Because I said so"
+### Offering some perspective
 
-  - Refusing to explain rules
-  - Using power to end discussions
-  - Dismissing reasonable questions
+Mass media tells girls to be sexy-but-not-slutty, prude-is-bad-but-so-is-desire — the funhouse mirror leaves her unable to know what she wants. Compounded by an objectification effect that's measurable in lab experiments: women asked to take a math test in swimsuits score lower than women asked to take it in sweaters. (Men's scores are unaffected by what they're wearing.) The constant invitation to evaluate herself against unrealistic beauty ideals isn't ornamental; it taxes her cognitive bandwidth.
 
-- Take questioning as personal attacks
+Layer on internet porn (vastly more explicit than anything you'd imagine, and 2/3 of fourteen-year-old boys have seen it) and the calibration is genuinely warped. Boys now routinely text demands for nude photos or sexual acts, often starting around seventh grade. Girls who refuse get called prude, boring, or a bitch; girls who give in get socially leveraged. It's heads-I-win, tails-I-win for the boy.
 
-  - Getting defensive about challenges
-  - Making it about respect versus reasoning
-  - Punishing critical thinking
+Name the marketing out loud once: "Who is that outfit for? Does the girl actually want to wear that, or is that what someone selling something wants her to wear?" Name the porn-warped expectations directly: "Some boys text girls asking for nude photos, sometimes over and over. That's not normal, it's not flirting, and it's not okay. The right answer is no, every time — and let me know if it happens." Make clear once that this is a topic she can bring to you; she may roll her eyes but she's filed the door as open.
 
-- Engage in power struggles
+### Inner compass beats outside scorecard
 
-  - Turning everything into a battle
-  - Refusing to negotiate anything
-  - Making threats in the heat of moment
+The question isn't "does he like me?" — it's "do I like how I feel around him?" Most adolescent unhappiness in early dating comes from outsourcing the question entirely. The girl who's organized her whole emotional life around whether the boy texts back has handed him control of her mood — and most teenage boys aren't qualified to be put in that position.
 
-- Shame her for having different views
-  - "How dare you question me!"
-  - Making her feel bad for thinking differently
-  - Using guilt as a control tool
+Practice the inner-compass question on small things long before romance shows up. "Did you have fun with Sarah today? How are you feeling about that group?" The same question, applied to friendships first, becomes available when she actually needs it for romance. The girl who's been checking her inner compass since sixth grade has a built-in instrument by tenth.
 
-**You should:**
+The corollary: she has to know what she _doesn't_ want, and have language for it. The ninth-grader pressured by a boyfriend to do something she didn't want to do was paralyzed because she couldn't admit even to herself that she didn't want it. The inner-compass question — "do _you_ want to?" — was the only useful intervention. Most of the time, she knows. She just needs permission to act on what she already knows.
 
-- Explain reasoning behind rules
+### Dating for status isn't dating
 
-  - "Here's why this matters..."
-  - Sharing the thinking behind decisions
-  - Being open about your concerns
+If the relationship's purpose is social standing — bragging rights, group membership, the right Instagram couple — it's status work, not relationship work. The easy tell: she stops liking him when no one's watching. The kid who's spending all her dating-emotional energy on how the relationship looks to her tribe isn't actually in a relationship; she's in a public performance with him as a co-actor.
 
-- Create space for negotiation
+Don't lecture this. Ask. "What do you actually like about being with him?" If the answer is all about how it looks to others, she'll hear herself say it and the question lands. If the answer is full of specifics about him as a person, you can stop worrying. Either way, the question is more useful than the speech.
 
-  - "Let's hear your proposal"
-  - Teaching compromise skills
-  - Showing flexibility when appropriate
+### Stay askable, not preachy
 
-- Acknowledge her growing autonomy
+The conversation you want to have about sex, consent, and pressure happens _only_ if she still thinks you'll handle the answer well. One judgmental reaction closes the door for years. Be the safe ask. {% include summarize-page.html src="/just-listen" %}
 
-  - "I trust your judgment on this"
-  - Gradually increasing freedoms
-  - Celebrating mature decisions
+Practical rules: when she brings up a topic, follow her lead. Don't pivot from her question into your prepared lecture. Answer the question she asked, then stop. If she wants more, she'll ask more. The first time you turn a casual question into a sex-education seminar, she's filed you as "person who turns casual questions into seminars" and you won't get another one for months.
 
-- Model respectful disagreement
-  - "I understand your view, but..."
-  - Showing how to disagree productively
-  - Maintaining connection through conflict
+### Being gay — the slur and the reality
 
-**As a dad, you'll face unique challenges:**
+"Gay" gets thrown around as a slur at her school whether or not anyone in the conversation is gay. Separate the two: the slur is unacceptable, and the reality (her own orientation, or a friend's) is private, hers to name on her own timeline.
 
-- Managing traditional father authority role
+Don't push her to label. Don't push her to come out. Don't _fail to_ be a safe place for her to do either when she's ready. Make it clear without making a thing of it that you're a parent who would be unfazed by whatever orientation she lands on. The casual reference — "your friend's older sister has a girlfriend, right?" treated the same as "...has a boyfriend, right?" — does more than the explicit speech.
 
-  - "Dads are supposed to be strict"
-  - Pressure to be the disciplinarian
-  - Balancing firmness with flexibility
-  - How do I define my authority role?
-  - What authority style serves her best?
+### Worry when: tributaries vs the lake
 
-- Breaking generational patterns
+Healthy adolescent romance has tributaries (friends, family, school, hobbies) feeding the lake of her life. Worry when one relationship becomes the whole lake — when she drops everything else, when the relationship is secretive, when it's controlling. That's not love, that's a flag.
 
-  - "My dad would never have allowed this"
-  - Examining inherited parenting styles
-  - Finding your own approach
-  - What patterns do I want to change?
-  - How can I blend tradition with progress?
+Also worry when boys are the _only_ tributary feeding her self-worth. The girl who organizes her whole sense of value around attracting male attention will make terrible choices to keep that water flowing — accepting bad treatment to keep the relationship, providing sexual favors she later regrets, walking through unsafe neighborhoods at night because she couldn't get a ride. The fix isn't to forbid the boys; it's to build the other tributaries fast. School, jobs, volunteering, sports, anything that gives her a non-romance source of worth.
 
-- Handling perceived disrespect
-  - Taking challenges more personally
-  - Struggling with tone and attitude
-  - Missing daddy's girl compliance
-  - When is it disrespect versus independence?
-  - How can I maintain respect while allowing growth?
+### Worry when: April–June romances
 
-**Worry when:**
+Senior boys dating freshman girls. Tenth-grade boys pursuing seventh-grade girls. The girl who dates more than a grade up is statistically more likely to have sex younger, skip contraception, contract STIs, use drugs, get depressed. The rule of thumb: not more than a year older.
 
-- She consistently engages in dangerous behavior
-- Shows complete rejection of all authority
-- Can't follow any rules or structure
-- Defiance creates serious safety concerns
-- Develops pattern of lying or secretive behavior
+Bigger gap, bigger worry. The senior who pursues a freshman is signaling something about the maturity available to him among his own peers — and what's available to him there isn't going to her. And adult men meeting teen girls via apps is its own emergency: any teenage girl interacting with adult men online needs immediate intervention, not negotiation.
 
-### 5. Planning for the Future
+If she's hanging out with someone significantly older, ask the question that matters: "Is she truly an equal partner in this?" Equal-partner relationships look like both people having roughly equal say, roughly equal stakes, roughly equal social standing. Lopsided relationships at any age are a problem, and they're more lopsided when the age gap is wide.
 
-**Your daughter will:**
+## 7. Caring for Herself
 
-- Start thinking about her future
+This is the strand where she takes over the body and the schedule. Sleep, food, exercise, drinking, drugs, sex — every domain transfers from your hands to hers. The transfer goes badly when you either hold on too long or let go too fast.
 
-  - "What if I pick the wrong college?"
-  - Researching different careers online
-  - "I need to figure out my whole life NOW"
+### Nodding isn't listening
 
-- Test different interests and paths
+She'll nod through the safety talk and absorb none of it. Lectures don't work — the longer the speech, the more her veil of obedience descends. Behind the veil, she's nodding politely while waiting for it to end. Nothing gets through.
 
-  - Switching dream careers weekly
-  - Trying new activities and quitting others
-  - "But what if I'm not good enough at it?"
+Conversation does work. Short, specific, recurring, in cars or while doing something else. The car is the confessional — eyes forward, finite duration, no escape route for either of you. The walk is also good. The dishwasher is good. Anywhere your hands are busy and the topic can drift in naturally. Drop a single sentence, see if she picks it up. If she doesn't, leave it for next time.
 
-- Worry about decisions and consequences
+The model that works: many small conversations across years, each calibrated to the moment. The model that doesn't work: one big talk at fifteen, the way your parents did the sex talk with you. Times have changed; the medium has to change too.
 
-  - "This choice will affect my whole future!"
-  - Comparing herself to peers' plans
-  - Anxiety about making mistakes
+### Sleep loses to the phone every time
 
-- Build planning and decision skills
+Adolescent sleep need: ~9 hours. Adolescent reality: 6, if she's lucky. The phone is the cause — Snap streaks at midnight, group chats that don't sleep, the algorithm engineered to keep her scrolling. The simplest intervention with the biggest payoff: phone out of the bedroom at night. Charge it in the kitchen. Not negotiable.
 
-  - Learning from trial and error
-  - Starting to set personal goals
-  - "Can you help me think this through?"
+She'll resist. The "I use it as my alarm clock" excuse is universal; buy her an alarm clock and the excuse dissolves. The "what if there's an emergency" excuse is universal; you have the phone, she's two rooms away, she can come find you in the actual emergency. The "everyone else has theirs" excuse is universal; that's true and it's also true that everyone else is sleep-deprived.
 
-- Face uncertainty about capabilities
-  - "What am I actually good at?"
-  - Doubting her choices and abilities
-  - Seeking validation for decisions
+The downstream effects of sleep are massive — depression, anxiety, irritability, weight, school performance, illness — and most of them are reversible once she's sleeping again. If she's struggling and you're trying to figure out where to start, start here. It's the highest-leverage single move available in adolescent parenting.
 
-**You'll find this hard because:**
+### Food and weight are landmines — defuse them
 
-- Her future success feels like your responsibility
+Never comment on her body. Not approvingly, not concernedly, not at all. "You look thin in those jeans" lands the same as "you look big in those jeans" — both teach her that her body is something to be evaluated by you, and she'll then continue evaluating it that way long after you've stopped. The body-as-evaluable mindset is the soil eating disorders grow in.
 
-  - "Did I prepare her enough?"
-  - Worrying about missed opportunities
-  - Second-guessing your guidance
-  - What does success really mean to me?
-  - How do my own regrets affect my guidance?
+Talk about energy, strength, sleep — the inputs, not the silhouette. "How are you feeling? Are you eating enough to have energy for swim practice?" "Did you sleep okay?" These are functional questions about whether her body is supporting her life, not aesthetic questions about whether it's the right shape.
 
-- You want to protect her from mistakes
+Your own relationship with food and your body is the lesson she's actually learning. If you comment on your own weight, talk about food in moral terms ("I was bad and had dessert"), or perform a tense relationship with eating, she's learning that. The lesson you want her to absorb is that bodies are for living in, not for evaluating. Model it.
 
-  - "I can see where this is heading..."
-  - Wanting to prevent painful lessons
-  - Fighting urge to take control
-  - Which mistakes are okay to make?
-  - How do I let her learn from experience?
+### Getting real about drinking
 
-- Your own dreams surface
+80% of teens have tried alcohol by the end of high school. Parenting for the world we wish she lived in puts her in a corner — abstain and lose her social life, or drink and lie to you. Recognize reality. The kid who's been told "don't go anywhere alcohol is present" is mostly going anyway; she's just lying about it. And the kid who's lying about where she is can't call for help when something goes wrong.
 
-  - Remembering your abandoned dreams
-  - Wanting better for her
-  - Projecting your wishes
-  - What dreams am I trying to live through her?
-  - How do I separate my aspirations from hers?
+Talk about _context_. Most adult drinking happens around responsible companions, in safe places, with known limits — most teen drinking doesn't. The danger isn't the alcohol so much as the conditions around it. Frame the equation: bad party + creepy guys + ditched friends = bad regardless. Add alcohol to that equation and bad becomes catastrophic. Sober she has options; drunk she has fewer options. The point isn't to scare her off drinking forever — it's to make her think about the context, not just the substance.
 
-- The stakes feel impossibly high
-  - "These decisions affect her whole life"
-  - Fear of her limiting future options
-  - Pressure to guide perfectly
-  - How do I balance support with pressure?
-  - What really matters long-term?
+Make her safety unconditional: "Call me from any party, any time. We'll talk about it over breakfast — we'll talk about why you ended up at a party fifteen miles from home that you weren't supposed to be at. But you'll never regret asking." That promise has to be kept. The first time she calls and you're furious enough on the ride home that she regrets the call, you've lost the pickup option for the rest of her teen years.
 
-**You should not:**
+Frame heavy drinking specifically. The adolescent brain is more vulnerable to long-term damage from alcohol than the adult brain — binge drinking can leave permanent neurological marks on the developing prefrontal cortex and hippocampus. This is not anti-drinking rhetoric; this is what the research says. Share it.
 
-- Push your unfulfilled dreams
+### Straight talk about drugs
 
-  - "I always wanted to be a doctor..."
-  - Steering her toward your old ambitions
-  - Living vicariously through her choices
+Don't be the bad guy — make the drug the bad guy. Skip the threats. Deliver the facts. The teen-veil-of-obedience descends the moment she senses you're delivering propaganda instead of information. Be the trustworthy source, or lose the audience to the internet.
 
-- Compare her path to others
+Marijuana specifically: today's pot is up to 7× more potent than what you smoked in college. The Dunedin study followed New Zealand teens for forty years and found teen regular users lose IQ points permanently, even years after quitting. The same study found no IQ loss in adults who started using as adults — the damage is specific to the developing brain. Adult legal use is not the same as teen use, and saying so isn't hypocrisy, it's biology.
 
-  - "Your brother knew exactly what he wanted"
-  - Pointing out peers' achievements
-  - Making her feel behind or inadequate
+Stimulants (Adderall, etc.) as study aids cause psychiatric symptoms (paranoia, hallucinations, disorientation) and can also be hiding a real workload problem worth solving. The girl using Adderall to keep up with three AP classes plus varsity swim plus family dinners isn't lazy or a delinquent; her schedule is impossible. The fix is the schedule, not the punishment.
 
-- Take over the planning
+Opiates rewire pleasure centers for years. Teens who get addicted often start with prescription painkillers from a medicine cabinet, then move to heroin when the prescription dries up. Lock the medicine cabinet. Address the legal cost too — a drug arrest closes doors for life (college admissions, jobs, certain financial aid), and minority teens get arrested at much higher rates for the same behavior, which is its own injustice worth naming. Frame the question matter-of-factly: "Why would you put the only brain you'll ever have in the hands of a sketchy dealer making money off you?"
 
-  - Choosing her classes without input
-  - Making decisions she should make
-  - Controlling every detail
+### Sex and its risks
 
-- Rush her timeline
-  - "You need to figure this out now!"
-  - Creating artificial urgency
-  - Pushing decisions before she's ready
+Don't have "the talk" — have a series of conversations. Address her like the young adult you want her to become, not the kid you wish she still was. "Sex is for grown-ups, stay away" makes her _prove_ she's grown by having sex. Bad framing.
 
-**You should:**
+Focus on the risks she'll have to manage at any age: unwanted pregnancy, STIs, mismatched expectations, going past consent. Frame it as adult preparation, not childhood prohibition. "Whenever you decide to have sex, you'll need to be able to manage these. I know thirty-five-year-olds who can't, and I don't think they should be having sex either." The 16 and Pregnant study showed something striking: given honest information about consequences, girls actually change their behavior. Birth rates dropped one-third in the eighteen months after the show aired, concentrated in regions with the highest viewership. Honest information works.
 
-- Explore options without pressure
+Share your values — research shows your opinion does shift hers, even when she pretends to ignore it — but in the form of values, not enforceable rules. "We feel sex should happen in a loving, committed relationship because that's where it tends to go best" is more useful than "you may not have sex until you're twenty-one." Make sure she knows she can access contraception with or without your help, and that the local clinic options exist regardless of what's covered by insurance.
 
-  - "What interests you about that?"
-  - Sharing information without pushing
-  - Supporting exploration and changes
+The hardest part is consent and the pressure landscape. Boys raised on porn often have warped expectations about what's normal in a sexual encounter. Girls often don't have language for what they want and don't want — they were never taught to have it. The inner-compass conversation from chapter 6 lands here: "do _you_ want to?" is the most useful question she can ask herself. And the second: "could I tell my partner no, and would they hear it?" If the answer to the second is no, the relationship is unsafe regardless of what the first answer is.
 
-- Create safe space for uncertainty
+### Worry when: eating disorders, failure to launch
 
-  - "It's okay not to know yet"
-  - Normalizing doubt and questions
-  - Being patient with the process
+- **Eating disorders** — restricting, bingeing, purging, exercise compulsion, weight loss with body distortion, dramatic food rules, withdrawal from meals. Often hidden by the kid; bystanders see it first. Friends often see it before parents do — which is why the early-intervention model that asks classmates to anonymously flag concerns is so effective. Act fast. Early intervention is the single biggest predictor of recovery.
+- **Failure to launch** — late adolescence, no movement toward independence, no plans, no friction toward leaving. Different from the Peter Pan in chapter 1 — this is older, quieter, and often hidden under "she's just not ready yet." Look for the early signs: senior-year inertia, college plans that keep collapsing, refusal to engage with the practical work of separation. The fix is usually some combination of therapy, structured pressure to take the next step, and ruling out underlying depression or anxiety.
 
-- Share your journey, including changes
+## Dad-specific notes
 
-  - "Here's what I learned when..."
-  - Being honest about your path
-  - Including failures and redirections
+Most parenting advice talks to moms. A few things that matter specifically for dads:
 
-- Build practical skills
-  - Teaching decision-making tools
-  - Practicing problem-solving together
-  - Supporting small independent choices
-
-**As a dad, you'll face unique challenges:**
-
-- Balancing provider role with supporter
-
-  - "I should know how to guide her career"
-  - Pressure to have all the answers
-  - Wanting to ensure financial security
-  - How do I support without controlling?
-  - What financial wisdom should I share?
-
-- Breaking gender-based assumptions
-
-  - Examining career biases
-  - Supporting non-traditional paths
-  - Challenging old mindsets
-  - What assumptions am I making?
-  - How can I expand her view of possibilities?
-
-- Managing your own career regrets
-  - "I don't want her to make my mistakes"
-  - Processing unfulfilled ambitions
-  - Finding healthy perspective
-  - How do my regrets influence my advice?
-  - What lessons can I share constructively?
-
-**Worry when:**
-
-- She shows no interest in any future
-- Anxiety paralyzes her current functioning
-- She makes dangerous choices out of desperation
-- She can't learn from mistakes
-- She responds to setbacks destructively
-
-### 6. Entering the Romantic World
-
-**Your daughter will:**
-
-- Experience romantic feelings
-
-  - "I think I like someone..."
-  - Talking more about relationships
-  - New interest in romance movies/songs
-
-- Navigate attraction and crushes
-
-  - Changing her route to pass someone's locker
-  - Checking her phone constantly
-  - "Do you think they like me back?"
-
-- Explore relationship boundaries
-
-  - Questions about dating rules
-  - Testing limits with texting/social media
-  - "When can I start dating?"
-
-- Deal with heartbreak and rejection
-
-  - First crush doesn't work out
-  - Friend drama over romantic interests
-  - "I'll never feel better..."
-
-- Learn about consent and respect
-  - Setting personal boundaries
-  - Understanding healthy relationships
-  - Questions about physical intimacy
-
-**You'll find this hard because:**
-
-- Your baby girl is growing up
-
-  - "She's too young for this"
-  - Memories of her as a little girl
-  - Fear of her getting hurt
-  - How do I accept this transition?
-  - What boundaries are appropriate?
-
-- Dating brings new dangers
-
-  - Worrying about sexual pressure
-  - Fear of abusive relationships
-  - Concern about online risks
-  - Which fears are realistic?
-  - How do I protect without controlling?
-
-- Your own dating history affects you
-
-  - Remembering teenage heartbreak
-  - Past relationship mistakes
-  - Wanting to prevent pain
-  - What baggage am I bringing?
-  - How can my experience help her?
-
-- Conversations feel awkward
-  - Discomfort with intimate topics
-  - Uncertainty about what to share
-  - Fear of saying wrong things
-  - How do I start these talks?
-  - What does she need to know?
-
-**You should not:**
-
-- Share her romantic life with others
-
-  - Gossiping about her crushes
-  - Discussing her relationships without permission
-  - Making her love life family news
-
-- Mock her feelings
-
-  - "It's just puppy love"
-  - Making fun of her crushes
-  - Dismissing relationship drama
-
-- Set unrealistic restrictions
-
-  - "No dating until college"
-  - Making arbitrary rules
-  - Creating sneaky behavior
-
-- Use shame or fear
-  - Scary statistics about teen dating
-  - Making her feel bad about feelings
-  - Using guilt to control behavior
-
-**You should:**
-
-- Create safe space for questions
-
-  - "You can ask me anything"
-  - Being approachable about relationships
-  - Staying calm during awkward talks
-
-- Teach healthy relationship skills
-
-  - Discussing respect and boundaries
-  - Modeling good communication
-  - Supporting her judgment
-
-- Share values with respect
-
-  - Explaining your perspective
-  - Listening to her views
-  - Finding common ground
-
-- Support through heartbreak
-  - Being there when hurting
-  - Not minimizing feelings
-  - Helping her recover
-
-**As a dad, you'll face unique challenges:**
-
-- Managing protective instincts
-
-  - "No one is good enough"
-  - Remembering being a teenage boy
-  - Wanting to prevent harm
-  - How do I protect appropriately?
-  - When should I trust her judgment?
-
-- Discussing sensitive topics
-
-  - Feeling awkward about sex talks
-  - Uncertainty about boundaries
-  - Balancing honesty with privacy
-  - What's my role in these discussions?
-  - How do I stay approachable?
-
-- Modeling male respect
-  - Showing healthy male behavior
-  - Teaching about red flags
-  - Being a good example
-  - What am I teaching about men?
-  - How do my relationships influence her?
-
-**Worry when:**
-
-- She engages in risky sexual behavior
-- You notice signs of relationship abuse
-- She keeps everything completely secret
-- Relationships become obsessive
-- She accepts toxic treatment
-
-### 7. Caring for Herself
-
-**Your daughter will:**
-
-- Take charge of personal care
-
-  - "I can handle my own schedule"
-  - Making health choices independently
-  - "I know what works for me"
-
-- Navigate body changes
-
-  - Questions about development
-  - Comparing herself to peers
-  - "Is this normal?"
-
-- Develop health habits
-
-  - Experimenting with exercise
-  - Making food choices
-  - Managing sleep schedule
-
-- Build stress management
-
-  - Finding personal coping tools
-  - Setting boundaries
-  - "I need some me time"
-
-- Learn self-advocacy
-  - Speaking up about needs
-  - Making medical decisions
-  - "I can talk to the doctor myself"
-
-**You'll find this hard because:**
-
-- Letting go of caretaking
-
-  - "But I've always handled this"
-  - Missing nurturing role
-  - Fear of her choices
-  - When should I step back?
-  - How do I support without controlling?
-
-- Body image concerns surface
-
-  - Your own insecurities trigger
-  - Worry about eating disorders
-  - Fear of unhealthy habits
-  - What messages am I sending?
-  - How do I promote healthy body image?
-
-- Health choices worry you
-
-  - "Is she getting enough sleep?"
-  - Concern about nutrition
-  - Questioning her judgment
-  - Which worries are valid?
-  - How do I guide without nagging?
-
-- Independence brings risks
-  - Fear of poor decisions
-  - Worry about safety
-  - Missing simpler times
-  - What risks are acceptable?
-  - How do I let go gradually?
-
-**You should not:**
-
-- Criticize her body
-
-  - Comments about weight
-  - Focusing on appearance
-  - Comparing to others
-
-- Project your issues
-
-  - Sharing your body insecurities
-  - Pushing your health anxieties
-  - Making her responsible for your comfort
-
-- Micromanage self-care
-
-  - Constant reminders about basics
-  - Taking over when she struggles
-  - Refusing to let her learn from mistakes
-
-- Make appearance central
-  - Overemphasizing looks
-  - Praising only appearance
-  - Linking worth to beauty
-
-**You should:**
-
-- Model healthy habits
-
-  - Demonstrating self-care
-  - Showing balanced attitudes
-  - Living what you teach
-
-- Provide accurate information
-
-  - Sharing reliable resources
-  - Answering questions honestly
-  - Supporting informed choices
-
-- Respect privacy
-
-  - Knocking before entering
-  - Allowing personal space
-  - Maintaining boundaries
-
-- Celebrate whole person
-  - Praising efforts and character
-  - Noticing non-appearance wins
-  - Supporting all aspects of growth
-
-**As a dad, you'll face unique challenges:**
-
-- Navigating physical changes
-
-  - Feeling awkward about development
-  - Unsure about appropriate involvement
-  - Deferring to mom appropriately
-  - What's my role in these conversations?
-  - How do I stay supportive while respecting privacy?
-
-- Discussing sensitive topics
-
-  - Handling hygiene conversations
-  - Addressing body image
-  - Managing discomfort
-  - Which topics should I address?
-  - How do I maintain appropriate boundaries?
-
-- Modeling healthy masculinity
-  - Showing respect for bodies
-  - Demonstrating self-care
-  - Breaking stereotypes
-  - What examples am I setting?
-  - How do my attitudes affect her?
-
-**Worry when:**
-
-- You notice eating disorder signs
-- She shows severe body image issues
-- Sleep problems affect daily life
-- Self-care severely declines
-- Exercise becomes obsessive
-
-## Key Insights
-
-### When to Worry
-
-### Common Patterns
-
-### Self-Reflection Questions for Dads:
-
-Throughout these transitions, fathers often face some unique challenges:
-
-- Emotional Connection
-
-  - How comfortable am I showing my own emotions to my daughter?
-  - What messages did I receive growing up about men and emotional expression?
-  - How might my comfort with emotions affect my daughter's emotional development?
-
-- Physical Changes and Boundaries
-
-  - How do I navigate discussions about physical development respectfully?
-  - What role can I play in supporting my daughter through puberty?
-  - How do I balance being supportive while respecting privacy?
-
-- Being the Male Role Model
-
-  - What am I teaching my daughter about men through my actions?
-  - How do my relationships with women shape her expectations?
-  - What healthy masculine traits do I want to model?
-
-- Maintaining Connection
-  - How do I stay connected as she gravitates more toward her mother for certain issues?
-  - What unique perspectives or strengths can I bring as her father?
-  - How do I create safe spaces for difficult conversations?
-
-Remember: Your role as a father is irreplaceable. While some transitions might feel more natural for mothers to navigate, your presence, support, and perspective are crucial to your daughter's development.
-
-## Practical Applications
-
-### Communication Strategies
-
-### Setting Boundaries
-
-### Building Trust
+- **You're not the backup parent.** "Maybe mom should handle this" is the cop-out. The relationship she has with you teaches her what to expect from men. Stepping back from the hard conversations because they feel like mom-territory teaches her that men aren't available for the hard stuff. That's a lesson with long-term consequences.
+- **Physical affection changes, doesn't end.** Bear hugs and lap-sitting age out. A hand on the shoulder, a hug at the airport, sitting next to her on the couch — that channel stays open if you keep using it. The girl who has appropriate physical affection from her dad calibrates differently against the world than the girl who doesn't.
+- **Model the male you want her to date.** The way you talk about women, the way you treat her mother, the way you handle anger, the way you handle being wrong — that's her baseline calibration for "normal" in a partner. The bar she'll set for the men she dates is mostly the bar she observed at home growing up. Raise it.
+- **Don't outsource the hard conversations.** The sex talk, the drinking talk, the heartbreak talk — she should hear them from you too, not just from mom. Awkward is fine. Absent is not. The conversation she remembers thirty years from now about how to handle being treated badly might be the one you have with her at fifteen. Have it.
 
 ## Resources
 
-Want more? Check out Lisa Damour's excellent podcast ["Ask Lisa: The Psychology of Parenting"](https://drlisadamour.com/podcast/). Each episode tackles common parenting challenges with the same practical, research-based approach that makes her book so valuable.
-
-**A Note for Fellow Dads:** While this book wasn't written specifically for fathers, I've found its practical, research-based approach particularly helpful as a dad. It's helped me understand both what my daughter is going through and how to support her effectively. The concrete examples and clear explanations of "what's normal vs. what's concerning" have been especially valuable in building my confidence as a father of a teenage daughter.
+- Lisa Damour's podcast [Ask Lisa: The Psychology of Parenting](https://drlisadamour.com/podcast/) — same practical, research-based approach as the book.
+- Damour's follow-up, [The Emotional Lives of Teenagers](/emotional-lives) — companion volume, deeper on emotion regulation.
 
 {% include amazon.html asin="0553393073" %}
 
-## Appendix: About These Notes
+## Appendix: the kettlebell analogy
 
-### The Kettlebell Analogy
+_When I first wrote these notes I leaned on a kettlebell analogy. It doesn't work for everyone, but I'm keeping it for those who find it useful:_
 
-_When I first created these notes, I used an analogy that was very specific to my own interests – comparing parenting a teenage girl to mastering the Turkish Get-Up kettlebell movement. While this might not resonate with everyone, I'm keeping it here for those who find it helpful:_
+Parenting a teenage girl is like the [Turkish Get-Up](/kettlebell#tgus) — one of the most technically demanding kettlebell movements, with distinct phases that flow into each other. Just when you've got one position figured out, it's time to transition, all while keeping your form (and not dropping the weight on your head). Damour's book is the master coach breaking the movement into seven fundamentals.
 
-Parenting a teenage girl is like mastering the [Turkish Get-Up](/kettlebell#tgus) – one of the most technically challenging kettlebell movements that requires patience, balance, and careful progression through distinct phases. Just when you think you've got one position figured out, it's time to transition to the next, all while maintaining your stability and form (and not dropping a heavy weight on your head!). Lisa Damour's "Untangled" is like having a master coach by your side, breaking down these intricate transitions into seven fundamental movements that take your daughter from childhood to adulthood.
-
-As a father navigating this journey myself, I've found this book to be the perfect spotter – helping me understand when to provide support and when to step back, ensuring both safety and growth. Whether you're just starting this parenting progression or you're midway through the movement, this guide illuminates what's normal, what's concerning, and how to maintain your form through each phase of development.
-
-_(NOTE: The Turkish Get-Up analogy works for the complexity and care needed, but unlike a Turkish Get-Up where you progress through movements in sequence, these developmental strands are more like juggling – all seven balls are in the air at once, each at its own height and speed. Your daughter might be soaring in emotional development while still finding her footing in social transitions, or vice versa.)_
-
-### A Note on the Father's Perspective
-
-As fathers, we might feel less equipped to navigate some of these transitions with our daughters. The mother-daughter dynamic is different from our own experience, and many of the female-specific concerns can feel foreign. That's completely normal. This book has helped me understand that being present, supportive, and willing to learn is more important than having all the answers. Sometimes the best thing we can do is acknowledge our discomfort while staying engaged.
+The analogy mostly works. Where it breaks: a Turkish Get-Up is sequential. The seven strands aren't. They're more like juggling — all seven balls in the air at once, each at its own height and speed. She might be soaring in emotional development while still finding her footing socially, or vice versa. Don't expect them to advance in order.


### PR DESCRIPTION
## Summary

Rewrite of `/untangled` from the 1,174-line "Your daughter will / You should / You should not" bullet structure into the headline-driven format used in the [7-habits chapter notes](/7h-c1). All 7 developmental strands kept in a single file (matching how the book is organized) but compressed to 534 lines.

Structure:
- 7 H2 chapters (the seven strands)
- 5–9 H3 headline-sections per chapter, each 2–4 paragraphs
- Dad-specific notes section
- Kettlebell analogy moved to appendix
- `ai-slop` label at 60%
- Cross-link to companion post [/emotional-lives](/emotional-lives) (PR #634)

## Restored subsections

Ten subsections from the book that were missing from the prior summary:

| Chapter | Restored |
| --- | --- |
| 1. Parting with Childhood | Smoke Without Fire |
| 2. Joining a New Tribe | When the Tribe Needs an Elder, Teach Assertion |
| 3. Harnessing Emotions | Catalytic Reactions, Accidental Helicopter |
| 4. Contending with Adult Authority | Adults with Faults |
| 5. Planning for the Future | Tense About Tests |
| 6. Entering the Romantic World | A Dream Deferred, Offering Some Perspective, April–June Romances |
| 7. Caring for Herself | Split single "straight talk" into separate Drinking / Drugs / Sex |

## Stats

- **1,174 → 534 lines** (931 deletions, 292 insertions)
- 50+ H3 takeaway sections at 2–4 paragraphs each

![untangled top](https://gist.githubusercontent.com/idvorkin-ai-tools/6b1e025743901cb23a834a29ae15f057/raw/screenshot.jpg)

## Test plan

- [x] `prek` passes (anchor checker flags three pre-existing failures on upstream main in `ai-journal.md` / `ai-optimism.md`, none in this file)
- [x] Jekyll builds clean
- [x] Renders correctly at `/untangled` locally
- [x] TOC anchors all resolve

## Companion PR

This pairs with #634 (new `/emotional-lives` post). Together they cover both Damour books in the same single-file Igor-style format. Independent — they don't conflict, can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)