### PR TITLE
chore: update backlinks

### DIFF
--- a/back-links.json
+++ b/back-links.json
@@ -35,6 +35,8 @@
         "/ai-love": "/ai-optimism",
         "/ai-native-em": "/ai-native-manager",
         "/ai-open-questions": "/ai-faq",
+        "/ai-optimisim": "/ai-optimism",
+        "/ai-optimisit": "/ai-optimism",
         "/ai-papers": "/ai-paper",
         "/ai-philosophy": "/ai-faq",
         "/ai-questions": "/ai-faq",
@@ -111,6 +113,7 @@
         "/eat-that-frog": "/frog",
         "/effectiveness": "/balance",
         "/emotional-health-practices": "/emotional-health",
+        "/emotional-lives-of-teenagers": "/emotional-lives",
         "/emotional-states": "/emotions",
         "/enabling-environment": "/enable",
         "/enemies": "/enemy",
@@ -354,7 +357,7 @@
     "url_info": {
         "/22": {
             "description": "In 2019 I created a program for 15 fantastic interns! A program highlight was my talk titled “What I wish I knew at 22, and so might you”. The talk received a 94% overall rating from over 15 interns, 10 SDE-IIs, and 1 senior developer. Even though the talk focuses on how to live the good life, a big chunk of life is work, so there’s good coverage on how to optimize your career.\n\n",
-            "doc_size": 16000,
+            "doc_size": 17000,
             "file_path": "_site/22.html",
             "incoming_links": [
                 "/chapters",
@@ -1132,11 +1135,11 @@
             "url": "/ai-operator"
         },
         "/ai-optimism": {
-            "description": "Sergio wants to open a store. A small one — his own corner of his city, with his name on the front, his taste on the shelves. A year ago this dream would have stayed a dream. Today he can actually do it.\n\n",
-            "doc_size": 24000,
+            "description": "Let me tell you about Sergio, and why I’m incredibly optimistic about AI. But first, one of the things I really hate: the homogenization of everything. It doesn’t matter where you go — every strip mall is the same five tenants, every main street the same chains. Once in a while I find a gem — a typewriter store, a tiny bookstore with one specific aesthetic, a shop that exists because one person with taste decided it should. And every time, I think: why don’t we have more of these?\n\n",
+            "doc_size": 29000,
             "file_path": "_site/ai-optimism.html",
             "incoming_links": [],
-            "last_modified": "2026-05-14T14:57:03.222085+00:00",
+            "last_modified": "2026-05-15T07:45:40-07:00",
             "markdown_path": "_d/ai-optimism.md",
             "outgoing_links": [
                 "/ai-second-brain",
@@ -1327,6 +1330,7 @@
                 "/awareness",
                 "/be-proactive",
                 "/depression",
+                "/emotional-lives",
                 "/fail",
                 "/gtd",
                 "/happy",
@@ -1530,7 +1534,7 @@
         },
         "/bc": {
             "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-            "doc_size": 22000,
+            "doc_size": 23000,
             "file_path": "_site/bc.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T03:02:44+00:00",
@@ -1555,6 +1559,7 @@
                 "/agency",
                 "/anxiety",
                 "/d/habits",
+                "/emotional-lives",
                 "/emotions",
                 "/end-in-mind",
                 "/frog",
@@ -1563,6 +1568,7 @@
                 "/raccoon-history",
                 "/regrets",
                 "/siy",
+                "/untangled",
                 "/words-we-dont-have"
             ],
             "last_modified": "2026-05-11T07:16:52-07:00",
@@ -2516,7 +2522,7 @@
         },
         "/day-in-the-life": {
             "description": "A running journal of days that actually worked - the ones where health habits stuck, family time hit different, or I remembered what it feels like to be fully alive. Not every day needs to be Instagram-worthy, but some days deserve a bookmark. This is that bookmark collection.\n\n",
-            "doc_size": 18000,
+            "doc_size": 19000,
             "file_path": "_site/day-in-the-life.html",
             "incoming_links": [],
             "last_modified": "2025-10-04T18:43:51-07:00",
@@ -2554,7 +2560,7 @@
         },
         "/debug": {
             "description": "Igor's Blog",
-            "doc_size": 23000,
+            "doc_size": 24000,
             "file_path": "_site/debug.html",
             "incoming_links": [],
             "last_modified": "2025-03-16T16:15:36+00:00",
@@ -2788,6 +2794,25 @@
             "title": "Emotional Health Practices",
             "url": "/emotional-health"
         },
+        "/emotional-lives": {
+            "description": "Mental health isn’t feeling good. It’s having the right feelings at the right time and being able to manage them effectively. Lisa Damour’s follow-up to Untangled is a manual for that distinction. The wellness industry sold us a lie — that calm is the goal and discomfort is malfunction. Discomfort is the curriculum. Your job isn’t to chase your teen’s bad feelings away. It’s to help her ride them and learn from them.\n\n",
+            "doc_size": 78000,
+            "file_path": "_site/emotional-lives.html",
+            "incoming_links": [
+                "/untangled"
+            ],
+            "last_modified": "2026-05-16T14:06:25-07:00",
+            "markdown_path": "_d/emotional-lives.md",
+            "outgoing_links": [
+                "/anxiety",
+                "/be-proactive",
+                "/emotions",
+                "/untangled"
+            ],
+            "redirect_url": "",
+            "title": "The Emotional Lives of Teenagers",
+            "url": "/emotional-lives"
+        },
         "/emotions": {
             "description": "Ever notice how emotions are like that one friend who shows up uninvited and fucks up your perfectly planned party? Sometimes they bring cake and make everything awesome, other times they’re drunk and knocking over your carefully arranged furniture while screaming “YOLO!” Well, here’s your guide to that emotional party crasher living rent-free in your head, because let’s face it - they’re not moving out anytime soon.\n\n",
             "doc_size": 24000,
@@ -2795,6 +2820,7 @@
             "incoming_links": [
                 "/act",
                 "/build-life-you-want",
+                "/emotional-lives",
                 "/siy",
                 "/slow",
                 "/strengths"
@@ -2985,7 +3011,7 @@
         },
         "/eulogy": {
             "description": "Wearing a silly hat or his zany $8 TEMU crazy shirt, his trusty folding bike at his feet, and using a purple fountain pen, Igor “Began with the end in mind” with the “important but not urgent” task of penning this eulogy, likely starting at 5am. Igor wanted this life, so he wrote it, he reviewed it, he lived it, and he worked with his family, friends, and multitude of mentors, to adjust and tweak it.\n\n",
-            "doc_size": 37000,
+            "doc_size": 38000,
             "file_path": "_site/eulogy.html",
             "incoming_links": [
                 "/7-habits",
@@ -3466,7 +3492,7 @@
         },
         "/grammerly": {
             "description": "\n\n",
-            "doc_size": 12000,
+            "doc_size": 13000,
             "file_path": "_site/grammerly.html",
             "incoming_links": [],
             "last_modified": "2025-08-24T09:03:19-07:00",
@@ -4147,7 +4173,7 @@
         },
         "/learn-code": {
             "description": "Coding is way easier than people think. Here’s some pointers.\n\n",
-            "doc_size": 13000,
+            "doc_size": 14000,
             "file_path": "_site/learn-code.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T02:47:07+00:00",
@@ -4402,7 +4428,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 14000,
+            "doc_size": 15000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",
@@ -4426,7 +4452,7 @@
         },
         "/mind-at-work": {
             "description": "I have a problem, an addiction, an addiction so detrimental to quality of life, it should be described as a disease. This disease is not being present. There are many symptoms of the disease, but today I’m going to talk about my most frequent symptoms, my body at home, but my mind at work.\n\n",
-            "doc_size": 19000,
+            "doc_size": 20000,
             "file_path": "_site/mind-at-work.html",
             "incoming_links": [
                 "/act",
@@ -5760,6 +5786,7 @@
                 "/slow",
                 "/timeoff",
                 "/timeoff-2020-03",
+                "/untangled",
                 "/walking-with-god",
                 "/y26"
             ],
@@ -6106,7 +6133,7 @@
         },
         "/synergize": {
             "description": "We’ve all got stuff we’re good at and stuff we’re bad at. Combine them right and the system is greater than the sum of the parts — sometimes a lot greater. Synergy is the payoff for everything that came before: independence, Win/Win, and seeking first to understand all converge here. These are my insights from 7 habits Chapter 6.\n\n",
-            "doc_size": 28000,
+            "doc_size": 29000,
             "file_path": "_site/synergize.html",
             "incoming_links": [
                 "/7-habits",
@@ -6189,7 +6216,7 @@
         },
         "/td/back_ref": {
             "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
-            "doc_size": 13000,
+            "doc_size": 14000,
             "file_path": "_site/td/back_ref.html",
             "incoming_links": [],
             "last_modified": "2022-04-16T15:22:43-07:00",
@@ -7036,14 +7063,20 @@
             "url": "/tribe"
         },
         "/untangled": {
-            "description": "Remember when your daughter was little and you could fix almost anything with a hug and a Band-Aid? Those days feel like a different lifetime now. Parenting a teenage girl means navigating a completely new terrain – one where the problems are more complex, the emotions run deeper, and your old playbook doesn’t quite work anymore.\n\n",
-            "doc_size": 68000,
+            "description": "Your daughter isn’t breaking — she’s running seven developmental strands at once. Each strand tells you what’s normal, what’s not, and where dads keep getting it wrong. These are my notes from Lisa Damour’s Untangled, filtered through what’s actually mattered raising a teenage girl.\n\n",
+            "doc_size": 93000,
             "file_path": "_site/untangled.html",
-            "incoming_links": [],
-            "last_modified": "2025-11-29T15:04:06+00:00",
+            "incoming_links": [
+                "/emotional-lives"
+            ],
+            "last_modified": "2026-05-16T14:10:54-07:00",
             "markdown_path": "_d/untangled.md",
             "outgoing_links": [
-                "/kettlebell"
+                "/be-proactive",
+                "/emotional-lives",
+                "/just-listen",
+                "/kettlebell",
+                "/siy"
             ],
             "redirect_url": "",
             "title": "Untangled: Guiding Teenage Girls Through the Seven Transitions into Adulthood",
@@ -7169,7 +7202,7 @@
         },
         "/walking-with-god": {
             "description": "Someone important to me has been reading a daily devotional. Even though I’m not religious, I’m studying with them to be able to have conversations about the insights - whether in a secular or religious context. This is my attempt to bridge two worlds: honoring the spiritual wisdom they’re finding while translating it into language that works for my engineer brain.\n\n",
-            "doc_size": 81000,
+            "doc_size": 82000,
             "file_path": "_site/walking-with-god.html",
             "incoming_links": [
                 "/greek-orthodox",
@@ -7299,7 +7332,7 @@
         },
         "/win-win": {
             "description": "Win/Win is a constantly seeking mutual benefit in all interactions. Win/Win means that agreements or solutions are mutually beneficial, mutually satisfying. With a Win/Win solution, all parties feel good about the decision and feel committed to the action plan. Win/Win sees life as a cooperative, not a competitive arena. Most people tend to think in terms of dichotomies: strong or weak, hardball or softball, win or lose. But that kind of thinking is fundamentally flawed. It’s based on power and position rather than on principle. Win/Win is based on the paradigm that there is plenty for everybody, that one person’s success is not achieved at the expense or exclusion of the success of others.\n\n",
-            "doc_size": 47000,
+            "doc_size": 48000,
             "file_path": "_site/win-win.html",
             "incoming_links": [
                 "/7-habits",


### PR DESCRIPTION
Routine backlinks refresh after /ai-optimism (#633) merged.

New permalinks registered:
- `/ai-optimism` (with redirects `/ai-optimisim`, `/ai-optimisit`)
- `/emotional-lives` (with redirect `/emotional-lives-of-teenagers`)

Inbound link entries updated for `/anxiety`, `/be-proactive`, `/emotions`, `/just-listen`, `/kettlebell`, `/siy`, `/untangled` (now picking up the new posts).

Generated locally via `just update-backlinks` (Ruby 3.1 workaround for Jekyll build on Ruby 4.x dev VM).