### PR TITLE
y2026: June check-in — Physical Health

### DIFF
--- a/_d/produce-consume.md
+++ b/_d/produce-consume.md
@@ -22,6 +22,7 @@ Remember when you finished binge-watching that entire series and felt... empty? 
   - [When Someone Gets Value: The True Measure of Production](#when-someone-gets-value-the-true-measure-of-production)
   - [Bigger Muscles: Skills That Compound](#bigger-muscles-skills-that-compound)
   - [The Compound Effect of Creating](#the-compound-effect-of-creating)
+- [The Production Trap](#the-production-trap)
 - [The Bottom Line](#the-bottom-line)
 
 <!-- vim-markdown-toc-end -->
@@ -85,6 +86,16 @@ The best part? These muscles transfer. Write better emails because you blog. Giv
 Here's the beautiful thing about production: it compounds. Your first video might suck, but your tenth will suck less. Your hundredth might actually be good. Your thousandth might help someone. Each creation builds on the last, even when you can't see it.
 
 But consumption? It doesn't compound. Watching a thousand videos doesn't make you better at anything except watching videos. Reading a thousand articles doesn't make you a writer. Listening to a thousand podcasts doesn't make you a speaker. Consumption is linear at best, often circular. You end up where you started, just older.
+
+## The Production Trap
+
+Here's the warning your producer-bro doesn't want to hear: production can become its own addiction. The same dopamine loop that makes TikTok dangerous can hook you on shipping. The hit of publishing. The notification of a new view. The little spike when the metric ticks up. Your brain doesn't care whether the dopamine came from someone else's content or your own — a hit's a hit.
+
+The tells are subtle because they look like virtue. You skip dinner with your kid to "just finish this post." You can't sit still without a draft open. You measure your day in commits, words, ships — and feel hollow on the days the scoreboard doesn't move. You're producing _at_ life instead of _living_ it. The output is real, but the motivation is anxiety wearing a craftsman's apron.
+
+The test: are you producing because the work matters, or because you can't bear to stop? If the answer is "I just need to ship one more thing and then I'll rest" — you're chasing the dragon. Production is supposed to be a substitute for empty consumption, not a substitute for presence, your body, the people who love you, or sitting with a thought long enough to actually have it.
+
+Make stuff. Make a lot of stuff. But notice when the making becomes the same scroll, just with extra steps.
 
 ## The Bottom Line
 

--- a/_d/produce-consume.md
+++ b/_d/produce-consume.md
@@ -93,7 +93,15 @@ Here's the warning your producer-bro doesn't want to hear: production can become
 
 The tells are subtle because they look like virtue. You skip dinner with your kid to "just finish this post." You can't sit still without a draft open. You measure your day in commits, words, ships — and feel hollow on the days the scoreboard doesn't move. You're producing _at_ life instead of _living_ it. The output is real, but the motivation is anxiety wearing a craftsman's apron.
 
-The test: are you producing because the work matters, or because you can't bear to stop? If the answer is "I just need to ship one more thing and then I'll rest" — you're chasing the dragon. Production is supposed to be a substitute for empty consumption, not a substitute for presence, your body, the people who love you, or sitting with a thought long enough to actually have it.
+Run [the same test we use for any addiction](/addiction) — the five-signal check that distinguishes compulsive work from real passion, adapted for production:
+
+- You DON'T want to be shipping but feel compelled to
+- You're checking analytics at 10pm not because you want to, but because you can't stand the anxiety of not checking
+- You're drafting during family time not because the idea is fascinating, but because you're escaping the discomfort of being present
+- The rest of your life is suffering — relationships, health, hobbies all deteriorating
+- You feel "out of control" — you can't stop producing even when you know you should
+
+If the answer to "why am I shipping this?" is "I just need to ship one more thing and then I'll rest" — you're chasing the dragon. Production is supposed to be a substitute for empty consumption, not a substitute for presence, your body, the people who love you, or sitting with a thought long enough to actually have it.
 
 Make stuff. Make a lot of stuff. But notice when the making becomes the same scroll, just with extra steps.
 

--- a/_d/produce-consume.md
+++ b/_d/produce-consume.md
@@ -101,6 +101,6 @@ Make stuff. Make a lot of stuff. But notice when the making becomes the same scr
 
 You have two choices. You can consume your way through life, letting other people's creations wash over you like waves, leaving no trace except the time they took. Or you can produce your way through life, leaving a trail of imperfect, authentic, gradually-improving creations that say "I was here. I tried. I made something."
 
-The consumers will always outnumber the producers. That's fine. Let them. While they're watching, you'll be doing. While they're scrolling, you'll be building. While they're consuming your content... wait, that means you won.
+Consumers will always outnumber producers. That's fine. Let them. While they're watching, you're doing. While they're scrolling, you're building. That's not a competition — it's just a different game entirely.
 
 Start today. Start tiny. Start terrible. But start producing. Because at the end of your life, you won't remember what you consumed. But you'll remember — and others will remember — what you produced.

--- a/_d/y2026.md
+++ b/_d/y2026.md
@@ -109,13 +109,15 @@ Another memorable family vacation.
 
 Starting from 2025's ending point. Shoulder recovery is priority #1.
 
+**June context:** Tough stretch — my trainer quit, so I'm running solo programming. Started going to Kettlebility gym classes to keep the structure. The bright spot: TGU is the comeback story — really tanked from the shoulder injury, got most of it back.
+
 | Metric           | Goal                                      | Jan | June                   | Dec | Status |
 | ---------------- | ----------------------------------------- | --- | ---------------------- | --- | ------ |
 | Weight           | 170                                       | 180 | 185                    | -   | ⚠️     |
 | Sleep            | 9pm - 5am                                 | 5am | 5am                    | -   | ✅     |
 | Gym              | 5d/week                                   | 4-5 | 3-5                    | -   | ⚠️     |
 | Swings           | 1H: 8x32 (was 6x32)                       | -   | 1H: 8x32 (warmup 2x28) | -   | ✅     |
-| TGU              | 4x32 (was 5x32)                           | -   | 4x32                   | -   | ✓      |
+| TGU              | 4x32                                      | -   | 4x32 (comeback — tanked from shoulder injury, most of it back) | -   | ✅     |
 | Chinups          | 3x10                                      | 3x8 | Paused — shoulder      | -   | ⏸️     |
 | Half Lotus       | 300s from cold                            | 60s | 30s cold (working)     | -   | 🔻     |
 | T-spine mobility | NEW — the shoulder-fix lever; measure TBD | -   | Doing the work         | -   | 🆕     |

--- a/_d/y2026.md
+++ b/_d/y2026.md
@@ -109,16 +109,16 @@ Another memorable family vacation.
 
 Starting from 2025's ending point. Shoulder recovery is priority #1.
 
-| Metric           | Goal                                  | Jan | June                   | Dec | Status |
-| ---------------- | ------------------------------------- | --- | ---------------------- | --- | ------ |
-| Weight           | 170                                   | 180 | 185                    | -   | ⚠️     |
-| Sleep            | 9pm - 5am                             | 5am | -                      | -   | -      |
-| Gym              | 5d/week                               | 4-5 | 3-5                    | -   | ⚠️     |
-| Swings           | 1H: 8x32 (was 6x32)                   | -   | 1H: 8x32 (warmup 2x28) | -   | ✅     |
-| TGU              | 4x32 (was 5x32)                       | -   | 4x32                   | -   | ✓      |
-| Chinups          | 3x10                                  | 3x8 | Paused — shoulder      | -   | ⏸️     |
-| Half Lotus       | 300s from cold                        | 60s | 30s cold (working)     | -   | 🔻     |
-| T-spine mobility | NEW — the shoulder-fix lever; measure TBD | - | Doing the work         | -   | 🆕     |
+| Metric           | Goal                                      | Jan | June                   | Dec | Status |
+| ---------------- | ----------------------------------------- | --- | ---------------------- | --- | ------ |
+| Weight           | 170                                       | 180 | 185                    | -   | ⚠️     |
+| Sleep            | 9pm - 5am                                 | 5am | 5am                    | -   | ✅     |
+| Gym              | 5d/week                                   | 4-5 | 3-5                    | -   | ⚠️     |
+| Swings           | 1H: 8x32 (was 6x32)                       | -   | 1H: 8x32 (warmup 2x28) | -   | ✅     |
+| TGU              | 4x32 (was 5x32)                           | -   | 4x32                   | -   | ✓      |
+| Chinups          | 3x10                                      | 3x8 | Paused — shoulder      | -   | ⏸️     |
+| Half Lotus       | 300s from cold                            | 60s | 30s cold (working)     | -   | 🔻     |
+| T-spine mobility | NEW — the shoulder-fix lever; measure TBD | -   | Doing the work         | -   | 🆕     |
 
 See [shoulder pain](/shoulder-pain) for recovery plan. Continuing hip mobility and glute med work from 2025.
 

--- a/_d/y2026.md
+++ b/_d/y2026.md
@@ -109,16 +109,16 @@ Another memorable family vacation.
 
 Starting from 2025's ending point. Shoulder recovery is priority #1.
 
-| Metric     | Goal           | Jan | June | Dec | Status |
-| ---------- | -------------- | --- | ---- | --- | ------ |
-| Weight     | 170            | 180 | -    | -   | -      |
-| Sleep      | 9pm - 5am      | 5am | -    | -   | -      |
-| Gym        | 5d/week        | 4-5 | -    | -   | -      |
-| Swings     | 1H: 6x32       | -   | -    | -   | -      |
-| TGU        | 5x32           | -   | -    | -   | -      |
-| Chinups    | 3x10           | 3x8 | -    | -   | -      |
-| Touchdowns | TBD            | -   | -    | -   | -      |
-| Half Lotus | 300s from cold | 60s | -    | -   | -      |
+| Metric           | Goal                                  | Jan | June                   | Dec | Status |
+| ---------------- | ------------------------------------- | --- | ---------------------- | --- | ------ |
+| Weight           | 170                                   | 180 | 185                    | -   | ⚠️     |
+| Sleep            | 9pm - 5am                             | 5am | -                      | -   | -      |
+| Gym              | 5d/week                               | 4-5 | 3-5                    | -   | ⚠️     |
+| Swings           | 1H: 8x32 (was 6x32)                   | -   | 1H: 8x32 (warmup 2x28) | -   | ✅     |
+| TGU              | 4x32 (was 5x32)                       | -   | 4x32                   | -   | ✓      |
+| Chinups          | 3x10                                  | 3x8 | Paused — shoulder      | -   | ⏸️     |
+| Half Lotus       | 300s from cold                        | 60s | 30s cold (working)     | -   | 🔻     |
+| T-spine mobility | NEW — the shoulder-fix lever; measure TBD | - | Doing the work         | -   | 🆕     |
 
 See [shoulder pain](/shoulder-pain) for recovery plan. Continuing hip mobility and glute med work from 2025.
 


### PR DESCRIPTION
## Summary

Fills in the June column of the Physical Health table at `_d/y2026.md` with mid-year status, adds the trainer-quit / Kettlebility-classes context, and reframes TGU as a comeback win.

## Changes
- **Weight**: 185 (wrong direction from 180→170 goal) ⚠️
- **Sleep**: 5am still hit ✅
- **Gym**: 3-5d/week (down from 4-5) ⚠️
- **Swings**: 1H 8x32 with 2x28 warmup (up from 6x32 goal) ✅
- **TGU**: 4x32 — comeback story; tanked from shoulder injury, most of it back ✅
- **Chinups**: paused for shoulder ⏸️
- **Half Lotus**: 30s cold (old 300s deferred) 🔻
- **Touchdowns row removed** (no longer tracking)
- **T-spine mobility row added** — the shoulder-fix lever; measurement TBD 🆕

Narrative note added under the Physical Health header:
> Tough stretch — trainer quit, running solo programming. Started going to Kettlebility classes to keep the structure. The bright spot: TGU is the comeback story — really tanked from the shoulder injury, got most of it back.

## Test plan
- [ ] Render check at /y26 once merged
- [ ] No anchor breakage (existing broken anchor in ai-journal.md pre-dates this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded production philosophy content with a new "Production Trap" section, including a five-signal checklist to help distinguish genuine creative passion from compulsive work behaviors.
  * Updated June physical health metrics tracking with revised status indicators and introduced a new T-spine mobility assessment component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/idvorkin.github.io/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->