### PR TITLE
words-we-dont-have: add 'Words for a New World' section with 'dark factory'

### DIFF
--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -31,14 +31,68 @@ For context on why I take time off: [/time-off](/time-off).
 
 All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are just us. We meet up with the Saffitzes in Stockholm on the evening of Jul 3 and travel together through Amsterdam — separate booking units, overlapping itinerary.
 
-## What I'm looking forward to
+## Things we want to do (by leg)
 
-- **Iceland stopover** — Icelandair's free stopover program makes a 2-day Reykjavík stop nearly free. First time in Iceland for everyone. Mid-size SUV, the Blue Lagoon-or-not call still TBD.
-- **Copenhagen with Ammon** — 2 days hanging with [Ammon](/ammon-quotes). His own quote when I floated 2 days: "Yeah 2 days works. There's not much to see in Copenhagen." Treating that as both confirmation and an upper bound.
-- **Norway in a Nutshell** — Oslo → Flåm via the Bergen Railway (one of the world's most scenic), then fjord cruise through Nærøyfjord (UNESCO).
-- **Aurland fjord days** — fjord-view apartment, RIB safaris on Aurlandsfjord, Viking Village in Gudvangen.
-- **Bergen** — Bryggen UNESCO district, Fløibanen funicular up Mt. Fløyen.
-- **Amsterdam** — bikes, Anne Frank House (pre-booked!), Rijksmuseum, canal cruise.
+### 🇮🇸 Iceland (Jun 28–30) — Reykjavík stopover
+
+- Pick up the rental SUV at KEF airport
+- Reykjavík city walk + Hallgrímskirkja
+- Blue Lagoon or Sky Lagoon (decide day-of based on weather + crowds)
+- Possible Golden Circle drive if energy permits — Þingvellir, Geysir, Gullfoss
+- Eat a hot dog at Bæjarins Beztu (mandatory tourist obligation)
+
+### 🇩🇰 Copenhagen (Jun 30 – Jul 3) — with [Ammon](/ammon-quotes)
+
+- Hang with Ammon — 2 days, no fixed agenda. His quote: "Yeah 2 days works. There's not much to see in Copenhagen." Treating that as both confirmation and upper bound.
+- Walk Nyhavn + canals
+- One nice meal as a family
+
+### 🇸🇪 Stockholm (Jul 3–7) — meet the Saffitzes
+
+- Gamla Stan + fika in Stortorget square (arrival recovery)
+- **Vasa Museum** — preserved 17th-century warship
+- **ABBA Museum** + Fotografiska
+- **City kayak tour** (private, ~2h, archipelago)
+- **Evening Wildlife Safari** with Swedish midsummer meal (~4h, van)
+- Södermalm street art + vintage shops
+- **Vain Vikings of Runriket** — rune-stone trail (4h, private + driver)
+- **Skansen** open-air museum on the way out
+
+### 🇳🇴 Oslo (Jul 7–10)
+
+- Vigeland Sculpture Park, Aker Brygge waterfront
+- **National Museum**
+- **Authentic Oslo Bike Tour** — Bjørvika → Akerselva → Mathallen → Grünerløkka (3h, 11 km)
+- **Holmenkollen ski jump** — zipline! (kids will love)
+- Munch Museum + Grünerløkka neighborhood
+- **Oslofjord hike** to Vettakollen summit (3.5h, 5.4 km) + dinner cruise
+
+### 🏔️ Aurland + Voss (Jul 10–13) — the fjords
+
+- **Bergen Railway** Oslo → Flåm — one of the world's most scenic train rides (dep Oslo 9:18 AM)
+- **Fjordsafari RIB** on Aurlandsfjord + UNESCO Nærøyfjord (2h 15m, suits supplied)
+- Fjord cruise Flåm → Gudvangen
+- **Viking Village Njardarheimr** (Gudvangen) — Viking lunch, axe-throwing, archery
+- **Voss Gondola** to 820m summit (1.5h return)
+
+### 🌉 Bergen (Jul 13–16)
+
+- **Bryggen** (UNESCO) walking tour
+- **Fløibanen funicular** + Mt. Fløyen hike (2.5h, moderate grade)
+- Mostraumen fjord fast boat OR Mt. Ulriken cable car
+- **Flavours of Bergen** food tour (2h)
+- **Islets kayak tour** (~4h 15m)
+- Morning fish market before flying out
+
+### 🇳🇱 Amsterdam (Jul 16–19)
+
+- Rent bikes + roam **Jordaan** neighborhood
+- **Anne Frank House** (PRE-BOOK!)
+- Canal cruise
+- **Rijksmuseum** + Vondelpark
+- **Foodhallen** (covered food market)
+- **A'DAM Lookout** rooftop swing
+- NDSM Wharf or Zaanse Schans windmills before flying home (KL 6038, 3:10 PM Jul 19)
 
 ## Goals for the trip
 

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -1,0 +1,58 @@
+---
+layout: post
+title: Time off July 2026 - Scandinavian Whirlwind Tour
+permalink: /timeoff-2026-07
+redirect_from:
+  - /eu-2026
+  - /europe-2026
+  - /scandi-2026
+---
+
+22 days, 5 countries, 4 Dvorkins, one whirlwind tour. From Reykjavík to Amsterdam by way of Stockholm, Oslo, and the Norwegian fjords. This is the first time we've attempted a trip of this scope as a family — the kids are 16 and 14, both still home, and the window for "all four of us on the road together" closes faster than I'd like.
+
+For context on why I take time off: [/time-off](/time-off).
+
+## At a Glance
+
+| Leg                                      | Dates           | Nights | Country     |
+| ---------------------------------------- | --------------- | ------ | ----------- |
+| 🇮🇸 **Iceland** (Reykjavík stopover)      | Jun 28 – Jun 30 | 2      | Iceland     |
+| 🇩🇰 **Copenhagen** (with Ammon)           | Jun 30 – Jul 3  | 3      | Denmark     |
+| 🇸🇪 **Stockholm** (meet the Saffitzes)    | Jul 3 – Jul 7   | 4      | Sweden      |
+| 🇳🇴 **Oslo**                              | Jul 7 – Jul 10  | 3      | Norway      |
+| 🏔️ **Aurland** (fjords)                   | Jul 10 – Jul 12 | 2      | Norway      |
+| ⛰️ **Voss**                                | Jul 12 – Jul 13 | 1      | Norway      |
+| 🌉 **Bergen**                             | Jul 13 – Jul 16 | 3      | Norway      |
+| 🇳🇱 **Amsterdam**                          | Jul 16 – Jul 19 | 3      | Netherlands |
+
+**Total**: 22 days, 5 countries (Iceland → Denmark → Sweden → Norway → Netherlands), back home Jul 19 via KLM AMS→SEA.
+
+## Who's coming
+
+All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are just us. We meet up with the Saffitzes in Stockholm on the evening of Jul 3 and travel together through Amsterdam — separate booking units, overlapping itinerary.
+
+## What I'm looking forward to
+
+- **Iceland stopover** — Icelandair's free stopover program makes a 2-day Reykjavík stop nearly free. First time in Iceland for everyone. Mid-size SUV, the Blue Lagoon-or-not call still TBD.
+- **Copenhagen with Ammon** — 2 days hanging with [Ammon](/ammon-quotes). His own quote when I floated 2 days: "Yeah 2 days works. There's not much to see in Copenhagen." Treating that as both confirmation and an upper bound.
+- **Norway in a Nutshell** — Oslo → Flåm via the Bergen Railway (one of the world's most scenic), then fjord cruise through Nærøyfjord (UNESCO).
+- **Aurland fjord days** — fjord-view apartment, RIB safaris on Aurlandsfjord, Viking Village in Gudvangen.
+- **Bergen** — Bryggen UNESCO district, Fløibanen funicular up Mt. Fløyen.
+- **Amsterdam** — bikes, Anne Frank House (pre-booked!), Rijksmuseum, canal cruise.
+
+## Goals for the trip
+
+- **Live the Father role from the eulogy**: quality time over mere presence. Both kids are home together; the window narrows.
+- **Balloon while traveling** — long-standing eulogy goal ("ballooning while traveling"). Bring the kit; deploy in parks and airports.
+- **Disconnect from work** — Meta mid-year PSC feedback is due Jul 8 (mid-Oslo) and calibration runs Jul 16–28 (Bergen → home). The protocol: do PSC work in the morning, trust the team for the rest of the day, do not let the [Calibration Collapse](/y26) eat the trip.
+- **No death-march optimizing** — see [optimizing vs satisfying](/42#optimizing-vs-satisfying). The goal isn't to maximize sights per day; it's to enjoy this with the people we're with.
+
+## Related
+
+- [Time off](/time-off) — why I take time off
+- [Goals 2026 — Summer Vacation](/y26#summer-vacation)
+- [Gap year for Igor](/gap-year-igor) — the bigger version of this
+- [Chapters](/chapters) — why the 40s are the right window for trips like this
+- [42](/42) — what I wish I knew
+
+_Written ~6 weeks pre-trip. Will write the actual recap when we're back._

--- a/_d/words-we-dont-have.md
+++ b/_d/words-we-dont-have.md
@@ -29,6 +29,8 @@ The words you use don't just describe your thinking. They shape it. Change "I ha
 - [The Dark Side: Newspeak and Deliberate Manipulation](#the-dark-side-newspeak-and-deliberate-manipulation)
   - [How Newspeak Works](#how-newspeak-works)
   - [Doublethink: The Mental Gymnastics](#doublethink-the-mental-gymnastics)
+- [Words for a New World](#words-for-a-new-world)
+  - [Dark factory](#dark-factory)
 - [What This Means for How I Think](#what-this-means-for-how-i-think)
   - [Building Better Mental Models](#building-better-mental-models)
 - [Related Frameworks](#related-frameworks)
@@ -157,6 +159,18 @@ War is Peace. Freedom is Slavery. Ignorance is Strength.
 Doublethink works _because_ of linguistic manipulation. When words lose their fixed meanings, when "freedom" can mean its opposite, when "peace" describes permanent war, the mind loses its ability to reason clearly. Everything becomes slippery.
 
 You can't build logical arguments when the words keep shifting under you. You can't spot contradictions when contradiction itself becomes normalized. You can't think clearly when language is deliberately crafted to prevent clear thinking.
+
+## Words for a New World
+
+Language doesn't only fail us when we look backward at concepts older cultures named better — it also struggles to keep up with the world we're building. New realities arrive faster than vocabulary, and for a while we live with them un-named. Here's a growing list of words we needed before we had them.
+
+### Dark factory
+
+A **dark factory** (also called *lights-out manufacturing*) is a fully-automated production facility that runs without humans on-site — and therefore without lights, climate control, or any of the conditions humans need. Robots, AI vision systems, sensors, and autonomous mobile platforms handle every step. The "dark" is literal: the machines don't need to see in our spectrum, so there's no reason to turn the lights on.
+
+The word matters because it carves out a category of place that didn't meaningfully exist before. A factory used to imply humans — assembly lines, lunch rooms, shift changes, parking lots. A dark factory implies none of that. It is a *facility* in the architectural sense without being a *workplace* in the human sense. The economic, political, and moral weight of that distinction is enormous, and we don't yet have the language for it.
+
+Fully-dark facilities are still rare (FANUC's robot-building plant in Japan is the famous case), but the term lets us think about a thing that is otherwise hard to discuss: production decoupled from labor. Without the word, the conversation defaults to "automation" — a softer concept that hides how complete the decoupling can become.
 
 ## What This Means for How I Think
 

--- a/_d/y2026.md
+++ b/_d/y2026.md
@@ -16,7 +16,7 @@ I like to begin with the end in mind, so let's write a report for 2026. This has
 <!-- vim-markdown-toc-start -->
 
 - [Major Projects](#major-projects)
-  - [What I wished I knew at 32 and what I knew at 32](#what-i-wished-i-knew-at-32-and-what-i-knew-at-32)
+  - [What I wished I knew at 42 and what I knew at 32](#what-i-wished-i-knew-at-42-and-what-i-knew-at-32)
   - [Content Creation](#content-creation)
     - [EM Handbook: TikTok Edition](#em-handbook-tiktok-edition)
   - [AI Projects](#ai-projects)
@@ -33,6 +33,7 @@ I like to begin with the end in mind, so let's write a report for 2026. This has
   - [Weekly Review](#weekly-review)
   - [Monthly Dragon Council](#monthly-dragon-council)
   - [Quarterly Strategic Review](#quarterly-strategic-review)
+    - [Work](#work)
 - [Stuff I'm really proud of](#stuff-im-really-proud-of)
 - [Artifacts I created](#artifacts-i-created)
   - [Code and Blogs I wrote](#code-and-blogs-i-wrote)
@@ -45,7 +46,7 @@ I like to begin with the end in mind, so let's write a report for 2026. This has
 
 ## Major Projects
 
-### What I wished I knew at 32 and what I knew at 32
+### What I wished I knew at 42 and what I knew at 32
 
 Carried forward from 2024 and 2025. This year I'll be 48. Time to actually capture and share these lessons.
 
@@ -101,7 +102,9 @@ Like the Hair Club for Men: I'm not only building it, I'm also a client. Meet La
 
 ### Summer Vacation
 
-Another memorable family vacation.
+Another memorable family vacation. This year it's a **whirlwind tour**: 22 days, 5 countries, all 4 Dvorkins — Iceland → Denmark → Sweden → Norway → Netherlands.
+
+Full plan: [Time off July 2026 — Scandinavian Whirlwind Tour](/timeoff-2026-07)
 
 ## Health & Personal Goals
 


### PR DESCRIPTION
## Summary

Per your Telegram (msg 3789): research "dark factory" and add to "Words for a New World" on the blog.

The "Words for a New World" section didn't exist yet in \`words-we-dont-have.md\` — created it as a new top-level section between the Newspeak section and "What This Means for How I Think." Framed it as vocabulary lag: words for realities the world is building faster than we can name.

## First entry: Dark factory

- Defined as fully-automated production facility (lights-out manufacturing) — robots, AI vision, no humans on-site, no need for lights
- FANUC robot-building plant in Japan as canonical real-world example
- The framing argument: the word lets us think about *production decoupled from labor*, whereas the generic word "automation" softens / hides how complete that decoupling can become

## Sources (from web research)

- [Lights out (manufacturing) — Wikipedia](https://en.wikipedia.org/wiki/Lights_out_(manufacturing))
- [Dark Factory: Definition, Technologies and Industrial Use Cases — Tractian](https://tractian.com/en/glossary/dark-factory)
- [Inside China's Dark Factories — Open Magazine](https://openthemagazine.com/world/inside-chinas-dark-factories-where-robots-produce-one-smartphone-per-second)

## Files changed

- \`_d/words-we-dont-have.md\` — new section + TOC update

## Test plan

- [ ] Render at /words-we-dont-have
- [ ] TOC links resolve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published travel blog post documenting a comprehensive Scandinavian whirlwind tour with detailed itinerary and travel objectives.

* **Documentation**
  * Introduced new section on contemporary vocabulary and linguistic concepts.
  * Enhanced vacation planning documentation with expanded itinerary details and resource links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/idvorkin.github.io/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->