### PR TITLE
timeoff + meta: Related as summarize-page, rename Facebook->Meta, add AI Lab section

### DIFF
--- a/_d/facebook.md
+++ b/_d/facebook.md
@@ -279,9 +279,9 @@ In 2022, Lord of the Rings. How do we solve this sim the real world? Identity an
 
 In May 2026 I got flattened (M→IC) and moved into Meta's AI training org. Not severance — they kept me, just moved me. Arguably I'm going to a frontier lab, and we're going to figure out how training works, which I'm kind of excited for.
 
-The role is very undefined. One part of it is building training data, which sounds pretty boring but should be fun for the first few rounds. Teams form by July — for now I'm ramping up.
+The role is very undefined. As you'd expect when you load 7000 people into a new org on a critical investment — how to make a frontier model.
 
-I'm holding two scenarios pretty calmly. There's a chance that within three more vests I'll be laid off, and that's certainly okay, I don't mind. It's also possible we're successful at this, and if we are, my god, we could make a killing on the stock price.
+Scary. Ambiguous. Chaos. Wonder. So many choices... I'm leaning in.
 
 My day job now lines up with what I'd been doing on the side anyway — [CHOP](/chop), vibe coding, AI projects. Bigger sandbox, no manager hat. More once the teams shake out.
 

--- a/_d/facebook.md
+++ b/_d/facebook.md
@@ -46,6 +46,7 @@ Facebook is a ‘social’ company; we value 1-1 time, fostering trust-driven re
   - [Bonus learnings at Facebook](#bonus-learnings-at-facebook)
 - [From Facebook to Meta and the metaverse](#from-facebook-to-meta-and-the-metaverse)
   - [Why is the metaverse taking so long](#why-is-the-metaverse-taking-so-long)
+- [Moving to Meta's AI Lab (2026)](#moving-to-metas-ai-lab-2026)
 - [Core Values (LP's)](#core-values-lps)
   - [Focus on Impact](#focus-on-impact)
   - [Move Fast](#move-fast)
@@ -271,6 +272,14 @@ In 2022, Lord of the Rings. How do we solve this sim the real world? Identity an
 ### Why is the metaverse taking so long
 
 <https://www.matthewball.vc/all/why-vrar-gets-farther-away-as-it-comes-into-focus>
+
+## Moving to Meta's AI Lab (2026)
+
+In May 2026, in a layoff round, I was flattened (M→IC) and moved into Meta's AI training org. Internal redirect, not severance. The role is "very undefined" — building training data initially, teams form by July.
+
+This is a frontier-lab pivot inside Meta. The org change is the real signal; the M→IC title change is cosmetic. Two scenarios I'm holding calmly: three more vests and out, or we ship and the stock pops.
+
+Personal note: my day job now lines up with what I'd been building on the side ([CHOP](/chop), vibe coding, AI tools). Bigger sandbox in exchange for the manager hat. I'll write more once teams form.
 
 ## Core Values (LP's)
 

--- a/_d/facebook.md
+++ b/_d/facebook.md
@@ -1,13 +1,15 @@
 ---
 layout: post
-title: "My thoughts on Facebook"
-permalink: /facebook
+title: "My thoughts on Meta"
+permalink: /meta
 redirect_from:
-  - /meta
+  - /facebook
   - /fb
 ---
 
-Facebook is a ‘social’ company; we value 1-1 time, fostering trust-driven relationships, and providing skip-level escalations and support. Here are my notes on Facebook
+Meta is a ‘social’ company; we value 1-1 time, fostering trust-driven relationships, and providing skip-level escalations and support. Here are my notes on Meta.
+
+_(\* When I started this was still Facebook.)_
 
 <!-- prettier-ignore-start -->
 
@@ -275,11 +277,13 @@ In 2022, Lord of the Rings. How do we solve this sim the real world? Identity an
 
 ## Moving to Meta's AI Lab (2026)
 
-In May 2026, in a layoff round, I was flattened (M→IC) and moved into Meta's AI training org. Internal redirect, not severance. The role is "very undefined" — building training data initially, teams form by July.
+In May 2026 I got flattened (M→IC) and moved into Meta's AI training org. Not severance — they kept me, just moved me. Arguably I'm going to a frontier lab, and we're going to figure out how training works, which I'm kind of excited for.
 
-This is a frontier-lab pivot inside Meta. The org change is the real signal; the M→IC title change is cosmetic. Two scenarios I'm holding calmly: three more vests and out, or we ship and the stock pops.
+The role is very undefined. One part of it is building training data, which sounds pretty boring but should be fun for the first few rounds. Teams form by July — for now I'm ramping up.
 
-Personal note: my day job now lines up with what I'd been building on the side ([CHOP](/chop), vibe coding, AI tools). Bigger sandbox in exchange for the manager hat. I'll write more once teams form.
+I'm holding two scenarios pretty calmly. There's a chance that within three more vests I'll be laid off, and that's certainly okay, I don't mind. It's also possible we're successful at this, and if we are, my god, we could make a killing on the stock price.
+
+My day job now lines up with what I'd been doing on the side anyway — [CHOP](/chop), vibe coding, AI projects. Bigger sandbox, no manager hat. More once the teams shake out.
 
 ## Core Values (LP's)
 

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -14,18 +14,20 @@ For context on why I take time off: [/time-off](/time-off).
 
 ## At a Glance
 
-| Leg                                      | Dates           | Nights | Country     |
-| ---------------------------------------- | --------------- | ------ | ----------- |
-| 🇮🇸 **Iceland** (Reykjavík stopover)      | Jun 28 – Jun 30 | 2      | Iceland     |
-| 🇩🇰 **Copenhagen** (with Ammon)           | Jun 30 – Jul 3  | 3      | Denmark     |
-| 🇸🇪 **Stockholm** (meet the Saffitzes)    | Jul 3 – Jul 7   | 4      | Sweden      |
-| 🇳🇴 **Oslo**                              | Jul 7 – Jul 10  | 3      | Norway      |
-| 🏔️ **Aurland** (fjords)                   | Jul 10 – Jul 12 | 2      | Norway      |
-| ⛰️ **Voss**                                | Jul 12 – Jul 13 | 1      | Norway      |
-| 🌉 **Bergen**                             | Jul 13 – Jul 16 | 3      | Norway      |
-| 🇳🇱 **Amsterdam**                          | Jul 16 – Jul 19 | 3      | Netherlands |
+| Leg                                   | Dates           | Nights | Country     |
+| ------------------------------------- | --------------- | ------ | ----------- |
+| 🇮🇸 **Iceland** (Reykjavík stopover)   | Jun 28 – Jun 30 | 2      | Iceland     |
+| 🇩🇰 **Copenhagen** (with Ammon)        | Jun 30 – Jul 3  | 3      | Denmark     |
+| 🇸🇪 **Stockholm** (meet the Saffitzes) | Jul 3 – Jul 7   | 4      | Sweden      |
+| 🇳🇴 **Oslo**                           | Jul 7 – Jul 10  | 3      | Norway      |
+| 🏔️ **Aurland** (fjords)               | Jul 10 – Jul 12 | 2      | Norway      |
+| ⛰️ **Voss**                           | Jul 12 – Jul 13 | 1      | Norway      |
+| 🌉 **Bergen**                         | Jul 13 – Jul 16 | 3      | Norway      |
+| 🇳🇱 **Amsterdam**                      | Jul 16 – Jul 19 | 3      | Netherlands |
 
 **Total**: 22 days, 5 countries (Iceland → Denmark → Sweden → Norway → Netherlands), back home Jul 19 via KLM AMS→SEA.
+
+📍 [See the full route on Google Maps](https://www.google.com/maps/dir/Reykjav%C3%ADk/Copenhagen/Stockholm/Oslo/Aurland/Voss/Bergen/Amsterdam) — 8 stops in one view.
 
 ## Who's coming
 
@@ -33,7 +35,7 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are j
 
 ## Things we want to do (by leg)
 
-### 🇮🇸 Iceland (Jun 28–30) — Reykjavík stopover
+### 🇮🇸 Iceland (Jun 28–30) — Reykjavík stopover · [📍 map](https://www.google.com/maps/place/Reykjav%C3%ADk)
 
 - Pick up the rental SUV at KEF airport
 - Reykjavík city walk + Hallgrímskirkja
@@ -41,13 +43,13 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are j
 - Possible Golden Circle drive if energy permits — Þingvellir, Geysir, Gullfoss
 - Eat a hot dog at Bæjarins Beztu (mandatory tourist obligation)
 
-### 🇩🇰 Copenhagen (Jun 30 – Jul 3) — with [Ammon](/ammon-quotes)
+### 🇩🇰 Copenhagen (Jun 30 – Jul 3) — with [Ammon](/ammon-quotes) · [📍 map](https://www.google.com/maps/place/Copenhagen)
 
 - Hang with Ammon — 2 days, no fixed agenda. His quote: "Yeah 2 days works. There's not much to see in Copenhagen." Treating that as both confirmation and upper bound.
 - Walk Nyhavn + canals
 - One nice meal as a family
 
-### 🇸🇪 Stockholm (Jul 3–7) — meet the Saffitzes
+### 🇸🇪 Stockholm (Jul 3–7) — meet the Saffitzes · [📍 map](https://www.google.com/maps/place/Stockholm)
 
 - Gamla Stan + fika in Stortorget square (arrival recovery)
 - **Vasa Museum** — preserved 17th-century warship
@@ -58,7 +60,7 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are j
 - **Vain Vikings of Runriket** — rune-stone trail (4h, private + driver)
 - **Skansen** open-air museum on the way out
 
-### 🇳🇴 Oslo (Jul 7–10)
+### 🇳🇴 Oslo (Jul 7–10) · [📍 map](https://www.google.com/maps/place/Oslo)
 
 - Vigeland Sculpture Park, Aker Brygge waterfront
 - **National Museum**
@@ -67,7 +69,7 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are j
 - Munch Museum + Grünerløkka neighborhood
 - **Oslofjord hike** to Vettakollen summit (3.5h, 5.4 km) + dinner cruise
 
-### 🏔️ Aurland + Voss (Jul 10–13) — the fjords
+### 🏔️ Aurland + Voss (Jul 10–13) — the fjords · [📍 Aurland](https://www.google.com/maps/place/Aurland) · [📍 Voss](https://www.google.com/maps/place/Voss)
 
 - **Bergen Railway** Oslo → Flåm — one of the world's most scenic train rides (dep Oslo 9:18 AM)
 - **Fjordsafari RIB** on Aurlandsfjord + UNESCO Nærøyfjord (2h 15m, suits supplied)
@@ -75,7 +77,7 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are j
 - **Viking Village Njardarheimr** (Gudvangen) — Viking lunch, axe-throwing, archery
 - **Voss Gondola** to 820m summit (1.5h return)
 
-### 🌉 Bergen (Jul 13–16)
+### 🌉 Bergen (Jul 13–16) · [📍 map](https://www.google.com/maps/place/Bergen,+Norway)
 
 - **Bryggen** (UNESCO) walking tour
 - **Fløibanen funicular** + Mt. Fløyen hike (2.5h, moderate grade)
@@ -84,7 +86,7 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are j
 - **Islets kayak tour** (~4h 15m)
 - Morning fish market before flying out
 
-### 🇳🇱 Amsterdam (Jul 16–19)
+### 🇳🇱 Amsterdam (Jul 16–19) · [📍 map](https://www.google.com/maps/place/Amsterdam)
 
 - Rent bikes + roam **Jordaan** neighborhood
 - **Anne Frank House** (PRE-BOOK!)

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -31,7 +31,7 @@ For context on why I take time off: [/time-off](/time-off).
 
 ## Who's coming
 
-All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are just us. We meet up with the Saffitzes in Stockholm on the evening of Jul 3 and travel together through Amsterdam — separate booking units, overlapping itinerary.
+All 4 Dvorkins (Igor, Tori, Zach, Amelia). Iceland and Copenhagen legs are just us; Stockholm onward we're traveling with friends.
 
 ## Things we want to do (by leg)
 
@@ -49,7 +49,7 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are j
 - Walk Nyhavn + canals
 - One nice meal as a family
 
-### 🇸🇪 Stockholm (Jul 3–7) — meet the Saffitzes · [📍 map](https://www.google.com/maps/place/Stockholm)
+### 🇸🇪 Stockholm (Jul 3–7) · [📍 map](https://www.google.com/maps/place/Stockholm)
 
 - Gamla Stan + fika in Stortorget square (arrival recovery)
 - **Vasa Museum** — preserved 17th-century warship

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -103,10 +103,9 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are j
 
 ## Related
 
-- [Time off](/time-off) — why I take time off
-- [Goals 2026 — Summer Vacation](/y26#summer-vacation)
-- [Gap year for Igor](/gap-year-igor) — the bigger version of this
-- [Chapters](/chapters) — why the 40s are the right window for trips like this
-- [42](/42) — what I wish I knew
+{% include summarize-page.html src="/time-off" %}
+{% include summarize-page.html src="/gap-year-igor" %}
+{% include summarize-page.html src="/chapters" %}
+{% include summarize-page.html src="/42" %}
 
 _Written ~6 weeks pre-trip. Will write the actual recap when we're back._

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -100,7 +100,7 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). The Iceland and Copenhagen legs are j
 
 - **Live the Father role from the eulogy**: quality time over mere presence. Both kids are home together; the window narrows.
 - **Balloon while traveling** — long-standing eulogy goal ("ballooning while traveling"). Bring the kit; deploy in parks and airports.
-- **Disconnect from work** — Meta mid-year PSC feedback is due Jul 8 (mid-Oslo) and calibration runs Jul 16–28 (Bergen → home). The protocol: do PSC work in the morning, trust the team for the rest of the day, do not let the [Calibration Collapse](/y26) eat the trip.
+- **Disconnect from work** — Good news: no calibrations to sweat this time. I just moved to an IC role at [Meta's AI Lab](/meta#moving-to-metas-ai-lab-2026), so the old [Calibration Collapse](/y26) trap doesn't fire. Keep work boxed anyway — ramp time is on Meta's clock, not the trip's.
 - **No death-march optimizing** — see [optimizing vs satisfying](/42#optimizing-vs-satisfying). The goal isn't to maximize sights per day; it's to enjoy this with the people we're with.
 
 ## Related


### PR DESCRIPTION
## Summary

Two related blog updates:

**`_d/time-off-2026-07.md`** — swap the Related section from plain links to `{% include summarize-page.html %}` includes (matches the y26 pattern). `/y26#summer-vacation` dropped from the target list since /y26 is what links here.

**`_d/facebook.md`** — three changes on the Meta post:
1. **Rename**: title `My thoughts on Facebook` → `My thoughts on Meta`. Permalink swap: `/meta` becomes canonical; `/facebook` and `/fb` now `redirect_from`.
2. **Footnote**: small italic note under the intro that the company was still Facebook when Igor started.
3. **New section**: "Moving to Meta's AI Lab (2026)" between the metaverse section and Core Values. Notes the May 2026 layoff-round redirect into the AI training org. Written in Igor's voice (pulled phrasing from his 5/22 journal: "got flattened," "arguably," "kind of excited," "I don't mind," "my god, we could make a killing").

## Test plan

- [ ] `/meta` resolves canonically; `/facebook` and `/fb` redirect to `/meta`
- [ ] Trip post Related section renders 4 summary cards
- [ ] AI Lab section appears in TOC and renders correctly
- [ ] No broken-anchor warnings in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated page content to reflect transition from Facebook to Meta with new URL structure and redirects
  * Added new section detailing move to Meta's AI Lab (2026)
  * Enhanced related pages section with dynamic template-driven links

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/idvorkin.github.io/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->