### PR TITLE
fix(justfile): load Ruby compat shim in jekyll-rebuild & worktree-init

### DIFF
--- a/justfile
+++ b/justfile
@@ -215,6 +215,9 @@ jekyll-clean:
 # Clean and rebuild Jekyll site from scratch
 jekyll-rebuild: jekyll-clean
     #!/usr/bin/env sh
+    # Load the Ruby 3.2+/4.0 compat shim (tainted?/pathutil) the old
+    # github-pages gems need. Mirrors jekyll-serve; no-op on older Ruby.
+    export RUBYOPT="-r$(pwd)/_ruby_compat.rb"
     echo "🔨 Rebuilding Jekyll site from scratch..."
     # Update git branch info for dev banner
     echo '{"branch": "'$(git branch --show-current)'"}' > _data/git.json
@@ -235,6 +238,8 @@ jekyll-rebuild: jekyll-clean
 worktree-init:
     #!/usr/bin/env sh
     set -eu
+    # Load the Ruby 3.2+/4.0 compat shim — see jekyll-rebuild. No-op on older Ruby.
+    export RUBYOPT="-r$(pwd)/_ruby_compat.rb"
     # Sanitize branch name for filesystem (e.g. claude/foo -> claude-foo)
     # Otherwise nohup writes to a non-existent parent dir and the build
     # fails silently while we still print "Background build fired".


### PR DESCRIPTION
## Problem

On Linux with Ruby 3.2+/4.x, `just jekyll-rebuild` and `just worktree-init` fail with the `tainted?` error (the method was removed in Ruby 3.2) before producing `_site/`. The repo already ships `_ruby_compat.rb` to patch this — but only `jekyll-serve` loaded it via `RUBYOPT`; the two build recipes did not. So on a fresh Ruby-4.x checkout, "just use the just commands" silently fails unless `RUBYOPT` already happens to be in your shell.

## Fix

Export `RUBYOPT="-r$(pwd)/_ruby_compat.rb"` at the top of both `jekyll-rebuild` and `worktree-init`, mirroring `jekyll-serve`. The shim self-guards (`unless Object.method_defined?(:tainted?)` / `if RUBY_VERSION >= '4.0'`), so it's a no-op on older Ruby and on macOS (which routes through homebrew Ruby anyway).

## Verification

`env -u RUBYOPT just jekyll-rebuild` → builds `_site/` in ~5s on Ruby 4.0.3 (previously failed before producing any output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Ruby compatibility handling in build workflows to ensure consistent behavior across all development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->