### PR TITLE
42: add neuroplasticity angle to progressive lenses

### DIFF
--- a/_d/42.md
+++ b/_d/42.md
@@ -120,6 +120,8 @@ The prep is worse than the procedure. You'll drink a gallon of liquid that taste
 
 **Personal note:** I knew I'd need reading glasses for a long time, but I kept putting it off. When I finally got progressive lenses, it was life-changing! I forgot how much I enjoyed reading and writing. I hadn't stopped doing those things, but I'd unconsciously cancelled them out by being effectively blind at reading distance. Suddenly books and screens were crisp again. Get the glasses. You'll thank yourself.
 
+And don't put it off the way I did - the earlier the better, because your brain is more pliable. Progressives demand a neural rewire to handle three prescriptions at once, and the younger you start, the faster and easier your brain wires it in. Wait until you're older and stubborn, and that drunk-giraffe phase gets longer and meaner. Push through early while your gray matter still bends.
+
 Around 40-45, your eyes will betray you. Presbyopia happens to everyone - even people who never needed glasses before.
 
 The signs:


### PR DESCRIPTION
Adds the angle Igor asked for to the **Vision: Welcome to the Arm's Length Club** section of `/42`: **the earlier the better, because your brain is more pliable.**

The section already made the willpower/"push through the adjustment" point implicitly (the "drunk giraffe on a tightrope" line) but never made the age/neuroplasticity argument. This folds it in — don't put progressives off or fight the adjustment; a younger brain rewires for the three-prescription blend faster and easier.

**What changed:** one paragraph (2 sentences) integrated right after the personal note in the Vision section. Riffs on the existing "drunk giraffe" line rather than overwriting it. No new subsection (per the "Distill, Don't Accrete" rule). No headings, links, or TOC changes — Vision section only.

The added text:

> And don't put it off the way I did - the earlier the better, because your brain is more pliable. Progressives demand a neural rewire to handle three prescriptions at once, and the younger you start, the faster and easier your brain wires it in. Wait until you're older and stubborn, and that drunk-giraffe phase gets longer and meaner. Push through early while your gray matter still bends.

Feature image and other sections untouched (separate task handles imagery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vision section with guidance on progressive lenses, emphasizing the benefits of early adoption for optimal brain adaptation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->