### PR TITLE
pre-commit: fix typos hook to actually exclude back-links.json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     hooks:
       - id: typos
         name: Check for typos
-        exclude: "^(assets|chop-logs|zz-chop-logs|cursor-logs|published-chop-logs|back-links.json|topics_data|images/.*\\.excalidraw|old_blog|static)/.*$|^topics\\.json$"
+        exclude: "^(assets|chop-logs|zz-chop-logs|cursor-logs|published-chop-logs|topics_data|images/.*\\.excalidraw|old_blog|static)/.*$|^(back-links|topics)\\.json$"
         args: []  # Uses .typos.toml for configuration
 
   # 🧪 Local hooks


### PR DESCRIPTION
The `typos` hook's `exclude` regex *tries* to skip `back-links.json`, but it's wedged inside the directory group suffixed with `/.*$`:

```
^(...|back-links.json|topics_data|...)/.*$|^topics\.json$
```

So it only matches `back-links.json/<path>` — never the file itself. `topics.json` is handled correctly right next to it as an anchored alternative (`^topics\.json$`); `back-links.json` should be too.

**Symptom:** whenever the generated `back-links.json` gets staged (e.g. the `update-backlinks-last-modified` hook bumps a timestamp), typos scans it and fails on intentional redirect aliases like `/ai-optimisim` — the deliberate-misspelling redirect for `/ai-optimism`. (`.typos.toml` lists `back-links.json` in `extend-exclude`, but typos ignores that for files passed explicitly on the CLI, which is how pre-commit invokes it — so the pre-commit `exclude` is the filter that matters.)

**Fix:** move it beside `topics.json` as an anchored file alternative:

```
...|old_blog|static)/.*$|^(back-links|topics)\.json$
```

**Verified:**
- `prek run typos --files back-links.json` → `(no files to check) Skipped`
- `prek run typos --files README.md` → `Passed` (normal files still scanned)