### PR TITLE
Rework /ai-training (engineering·science·alchemy) + add /ai-inference

### DIFF
--- a/_d/ai-inference.md
+++ b/_d/ai-inference.md
@@ -1,0 +1,114 @@
+---
+layout: post
+title: "AI Inference"
+permalink: /ai-inference
+redirect_from:
+  - /inference
+  - /serving-llms
+tags:
+  - ai
+  - machine-learning
+---
+
+[Training](/ai-training) is how a model gets made; inference is what you pay for every time you _use_ it. I don't build serving stacks — I pick a model, pick a provider, and pay per token — but it helps to carry a rough map of where that price comes from. The whole game is one question: **how do I serve tokens as cheaply as possible at a given level of intelligence?** You can always spend more compute and memory to go faster — the price just rises with it.
+
+{% include alert.html content="Everything here is public information and my own opinions. There's no internal Meta secret sauce in here, and nothing on this page represents the views of my employer." style="info" %}
+
+{% include ai-slop.html percent="70" %}
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [The triangle: cost, latency, throughput](#the-triangle-cost-latency-throughput)
+- [Prefill vs decode](#prefill-vs-decode)
+  - [The KV cache](#the-kv-cache)
+- [Knobs that lower the price](#knobs-that-lower-the-price)
+  - [Quantization](#quantization)
+  - [The model matters: MoE, speculative decoding, smaller models](#the-model-matters-moe-speculative-decoding-smaller-models)
+  - [Batching](#batching)
+- [Serving stacks](#serving-stacks)
+- [Hardware reality: bandwidth, not FLOPs](#hardware-reality-bandwidth-not-flops)
+- [Takeaways for a model consumer](#takeaways-for-a-model-consumer)
+- [What this post is not about](#what-this-post-is-not-about)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+## The triangle: cost, latency, throughput
+
+Every serving decision trades three things against each other:
+
+- **Latency** — how fast a single user feels it. Two pieces: _time-to-first-token_ (how long before anything shows up) and _tokens-per-second_ (how fast the text streams after that).
+- **Throughput** — total tokens (or requests) the box serves across _everyone_ at once.
+- **Cost** — $/token, which mostly tracks how well you keep expensive hardware busy.
+
+You don't get all three. Pack more users onto one GPU and throughput and $/token improve, but each user waits longer — their latency gets worse. Give one user a whole GPU and they get blazing latency at a terrible price. Most of what follows is just ways to bend this triangle: get more tokens out of the same hardware without wrecking latency.
+
+## Prefill vs decode
+
+The single most useful mental model. Inference runs in two phases that look nothing alike.
+
+- **Prefill** — read the whole prompt at once. Every token of the prompt goes through the model in parallel, so prefill is **compute-bound**: it's bottlenecked on raw GPU math (FLOPs). This sets your **time-to-first-token**. A huge prompt means a long prefill before the first word appears.
+- **Decode** — generate the answer one token at a time. Each new token depends on the previous one, so it's sequential — no parallelism to hide behind. For _every single token_, the GPU has to stream the entire model's weights (plus the cache below) out of memory. That makes decode **memory-bandwidth-bound**, not compute-bound. The GPU's math units sit mostly idle, waiting on memory.
+
+The payoff: **long outputs are decode-bound, and decode is gated by memory bandwidth.** That's why a long response feels slow even on a fast GPU — you're not short on math, you're short on how fast you can move weights. Almost every speedup trick below is really "move fewer bytes per token." ([A good prefill-vs-decode explainer](https://vllm.ai/blog/2023-06-20-vllm).)
+
+### The KV cache
+
+When the model reads your prompt, attention computes a key and value for each token. Recomputing those for the whole context on every new token would be insane, so they're cached — the **KV cache**. Decode then reuses it instead of re-reading the past.
+
+The catch: the cache grows with **context length × batch size**. Longer conversations and more simultaneous users both inflate it, and it lives in the same precious GPU memory as the weights. Eventually the KV cache, not the model, is what fills the card — which caps how many users you can batch and, by extension, your throughput and $/token. This is why long contexts cost more: you're renting memory for the whole conversation, every token.
+
+## Knobs that lower the price
+
+### Quantization
+
+Store weights in fewer bits — 16-bit down to ~4-bit or less. The [training post covers this for shrinking the file](/ai-training#deployment-quantization-and-serving); for inference the point is **speed**. Fewer bits per weight means fewer bytes to stream per token, and since decode is bandwidth-bound, less data moved = faster, cheaper decode. The cost is some quality loss, so you eval the damage.
+
+You can quantize the **KV cache** too, not just the weights — same idea, pointed at the cache that's eating your memory. It buys you longer contexts and bigger batches at some accuracy cost.
+
+### The model matters: MoE, speculative decoding, smaller models
+
+The cheapest token is the one a cheaper model serves. Three ways the model itself changes the bill:
+
+- **Mixture of Experts (MoE)** — split the network into many "expert" sub-networks and, per token, a router fires only a few of them. You get big-model quality at small-model _active_-parameter cost, because decode only streams the active slice. [DeepSeek-V3](https://arxiv.org/abs/2412.19437) is 671B total parameters but activates only **37B per token** (~1/18th); [Mixtral 8x7B](https://mistral.ai/news/mixtral-of-experts/) has 47B total and uses ~13B per token. You still pay to _hold_ all the weights in memory, but you only pay bandwidth for the active ones — which is the part that matters for decode speed. This is the main reason frontier-quality tokens have gotten cheap.
+- **Speculative decoding** — a small, fast _draft_ model proposes the next several tokens; the big model then verifies that whole batch in a single parallel forward pass. Because verification is parallel (and parallel is what GPUs are starved for during decode), you get multiple accepted tokens per expensive big-model pass. The output is provably identical to what the big model would've produced alone — it's a pure speedup, not a quality trade. ([How it works](https://bentoml.com/llm/inference-optimization/speculative-decoding).)
+- **Smaller / distilled models** — the boring, biggest win. Most tasks don't need the frontier. A distilled or just plain smaller model serves the same job at a fraction of the bandwidth and price.
+
+### Batching
+
+One user can't keep a GPU busy — decode leaves the math units idle waiting on memory, so you stuff more users through on the same weight-load. The trick is doing it without making everyone wait for the slowest request in the batch.
+
+**Continuous (in-flight) batching** does this: instead of waiting for a whole batch to finish, the scheduler adds and evicts requests token-by-token, so a finished request frees its slot immediately and a waiting one slides in. [vLLM](https://vllm.ai/blog/2023-06-20-vllm) pairs this with **PagedAttention**, which stores the KV cache in fixed-size pages (like OS virtual memory) instead of one big contiguous block — that cuts memory waste and pushes cache utilization from ~40% to ~96%, which means more users fit, which means more throughput. The tension never goes away though: bigger batches = better throughput and $/token, worse per-user latency.
+
+## Serving stacks
+
+What people actually run:
+
+- **[vLLM](https://github.com/vllm-project/vllm)** — the default open-source server; continuous batching + PagedAttention, high throughput.
+- **[TGI](https://github.com/huggingface/text-generation-inference)** (Text Generation Inference) — Hugging Face's production server.
+- **[TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM)** — NVIDIA's, squeezes the most out of NVIDIA hardware, fiddlier to drive.
+- **[llama.cpp](https://github.com/ggml-org/llama.cpp)** — run quantized models on a laptop or CPU; the engine under a lot of local setups.
+- **[Ollama](https://ollama.com)** — `brew install` it, `ollama run llama3`, done. Wraps llama.cpp for painless local use.
+
+The first three are for serving lots of users; the last two are for running a model on your own machine.
+
+## Hardware reality: bandwidth, not FLOPs
+
+The spec sheet number everyone quotes is FLOPs (raw math throughput). For decode, that's the wrong number. Decode is bottlenecked on **memory bandwidth** — how fast the GPU reads weights out of its own memory — so the figure that actually predicts your tokens-per-second is GB/s, not TFLOPs. It's why an H100 stomps a 4090 on serving even when the FLOP gap is smaller than you'd expect, and why "how much fast memory, how fast" is the question I'd ask first when someone picks a GPU. A card with more, faster memory serves more tokens.
+
+## Takeaways for a model consumer
+
+I'm paying per token, not building the stack. What the above means at the invoice:
+
+- **Long contexts cost more — usually more than you'd guess.** You're paying for prefill compute up front _and_ renting KV-cache memory for the whole conversation, every token after. Trim context that isn't earning its keep.
+- **Output length is the expensive part.** Decode is the slow, bandwidth-bound phase, so a model that rambles costs more than its $/token implies. Ask for concise output; cap `max_tokens`.
+- **Prefer MoE for quality-per-dollar.** When two models are close on quality, the MoE one is usually cheaper per token for the same smarts — that's the whole point of the architecture.
+- **Drop to a smaller model when the frontier is overkill.** Routing, classification, extraction, summarization — most of this doesn't need the biggest model. Match the model to the job; it's the single biggest lever on cost.
+- **Caching is free money.** Many providers cache prompt prefixes — reuse a stable system prompt or document prefix and you skip re-prefilling it. Structure prompts so the constant part comes first.
+
+## What this post is not about
+
+- **How the model gets made** — that's [/ai-training](/ai-training), the parent post here. Pre-training, post-training, fine-tuning, RAG vs the harness.
+- **Putting models to work in an agent loop** — the harness, tools, and orchestration live in [/chop](/chop) and [/how-igor-chops](/how-igor-chops). Inference is the layer underneath that; this post is about its cost.
+- **The basics** — "what even is an LLM" is [/ai-faq](/ai-faq).

--- a/_d/ai-training.md
+++ b/_d/ai-training.md
@@ -5,55 +5,145 @@ permalink: /ai-training
 redirect_from:
   - /training
   - /llm-training
+tags:
+  - ai
+  - machine-learning
 ---
 
-Generally, I don't deal with training or deeper tech, but might as well keep some notes on it.
+I don't train models for a living — I build on top of them. But to use LLMs well, it helps to carry a rough map of how one gets made: what pre-training buys you, what post-training changes, and where fine-tuning, RAG, and quantization actually fit. These are my working notes on that map, kept deliberately shallow — enough to make good decisions as a consumer of models, not to go train one.
+
+{% include alert.html content="Everything here is public information and my own opinions. There's no internal Meta secret sauce in here, and nothing on this page represents the views of my employer." style="info" %}
+
+{% include ai-slop.html percent="50" %}
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
-- [Training](#training)
-    - [RAG Grounding](#rag-grounding)
-    - [Fine Tuning](#fine-tuning)
-    - [Style transfer](#style-transfer)
-    - [Model Merging](#model-merging)
-    - [Awesome blog](#awesome-blog)
-- [Quantization](#quantization)
+- [Engineering, science, and alchemy](#engineering-science-and-alchemy)
+- [How a model gets made](#how-a-model-gets-made)
+  - [Pre-training](#pre-training)
+  - [Post-training](#post-training)
+  - [Fine-tuning methods](#fine-tuning-methods)
+  - [Deployment: quantization and serving](#deployment-quantization-and-serving)
+- [How does post-training differ from RAG and the harness?](#how-does-post-training-differ-from-rag-and-the-harness)
+- [See how it works](#see-how-it-works)
+- [What this post is not about](#what-this-post-is-not-about)
+- [Appendix: engineering, science, and alchemy](#appendix-engineering-science-and-alchemy)
+- [Appendix: AI inference](#appendix-ai-inference)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
 
-## Training
+## Engineering, science, and alchemy
 
-### RAG Grounding
+Training LLMs is three jobs at once. **Engineering** makes a system hit a target — _"how do I hit this number?"_ **Science** figures out a true fact about a model that already exists — _"why is this true?"_ And **alchemy** is everything that works before either of those catches up: recipes found by trial and error and kept because they work, not because anyone can say why. The twist with AI is that we built the thing first, so the science is still chasing the systems — which means a lot of what looks like science is really alchemy for now. [The full breakdown, with concrete pairs, is in the appendix ↓](#appendix-engineering-science-and-alchemy)
 
-### Fine Tuning
+## How a model gets made
 
-- Example using [Lllama 3](https://colab.research.google.com/drive/1efOx_rwZeF3i0YsirhM1xhYLtGNX6Fv3?usp=sharing#scrollTo=bDp0zNpwe6U_)
-- LORA - (Locally Optimized Rewiring Adjustment) is an algorithm used in the fine-tuning of neural network models, especially transformers. It introduces a low-rank decomposition of the weight matrices in transformers. By modifying only a small part of the model parameters during fine-tuning, LoRA allows for retaining most of the pre-trained model's knowledge while adapting to new tasks more efficiently. This approach can significantly reduce the number of parameters that need to be updated, leading to faster and more resource-efficient fine-tuning.
-  - Basically - stick a narrow matrix in front of the model, and only fine tune that.
-- What is GGUF? (GPT-Generated Unified Format)?
-  - file formats used for storing models. GGUF is GGML.vNext.
-- What is Quantization (Q4_0, IQ2_XXS)
-  - A [method to compress](https://www.reddit.com/r/LocalLLaMA/comments/1ba55rj/overview_of_gguf_quantization_methods/) the LLM from each node being 16 bits to maybe 4 bits, or less.
-  - A [scorecard of quantization compression methods](https://huggingface.co/datasets/christopherthompson81/quant_exploration)
-  - This is lossy compression, and you need to eval how well it works? A common approach is to compare the difference of the answers via embeddings.
-- RLHF - Reinforcement learning human feedback
-- RLAIF - Reinforcement learning AI feedback (aka LLM as judge)
-- DPO - [Direct Preference Optimization](https://arxiv.org/pdf/2305.18290.pdf?ref=hackernoon.com) - I don't quite understand but it seems like the RLHF v.Next with more simplicity. Phase still involves putting a human on the end who is given a choice of A/B and decides which they like better.
-- Alpaca - [A dataset](https://huggingface.co/datasets/yahma/alpaca-cleaned) for human preferences used in the early fine tuning efforts. What's clever is they used GPT-4 to generate the dataset to make it much cheaper. I'm assuming soon there will be even better sets.
+Three stages, and almost everything else is a footnote to them:
 
-### Style transfer
+1. **Pre-training** — show the model a huge pile of text and have it predict the next token, over and over. This is the expensive part — most of the compute and money — and it's where the model's _knowledge and raw capability_ come from. The output is a "base model" that has read the internet but isn't yet a helpful assistant. Prompt it with a question and it'll happily autocomplete ten more questions.
+2. **Post-training** — take that base model and shape its _behavior_: follow instructions, answer instead of autocomplete, refuse the obviously bad stuff, hold a format. Cheap compared to pre-training, and it's most of what makes a chat model feel like one.
+3. **Deployment** — shrink and serve the thing so it runs fast and cheap.
 
-### Model Merging
+The one intuition to keep: **pre-training installs knowledge; post-training shapes behavior.** That single line drives the whole [post-training vs RAG vs the harness](#how-does-post-training-differ-from-rag-and-the-harness) decision below.
 
-### Awesome blog
+### Pre-training
 
-[Fine-Tune Your Own Llama 2 Model in a Colab Notebook
-](https://mlabonne.github.io/blog/posts/Fine_Tune_Your_Own_Llama_2_Model_in_a_Colab_Notebook.html)
+- The objective is dumb and powerful: predict the next token. No labels, just text — which is why it scales, since raw text is basically free.
+- This is where facts, skills, and the model's "world model" come from. If a model doesn't know something, it usually didn't see enough of it here.
+- It's also where the cost lives. The headline "$X million to train" numbers are almost entirely pre-training.
+- Output is a **base / foundation model** — capable but not steerable. Not the thing you actually talk to.
 
-## Quantization
+### Post-training
 
-Not quite training but need to stuff this somewhere...
+Turning the base model into an assistant. Most of my old "fine-tuning" notes actually belong here — they're behavior changes, not knowledge.
 
-<https://mlabonne.github.io/blog/posts/Introduction_to_Weight_Quantization.html>
+- **SFT (supervised fine-tuning / instruction tuning)** — fine-tune on curated (prompt → good answer) pairs so the model answers instead of autocompletes. The first and biggest behavior shift.
+- **RLHF** — Reinforcement Learning from Human Feedback. Humans rank outputs, you train a reward model on those rankings, then optimize the LLM against the reward model.
+- **RLAIF** — same idea, but an AI does the ranking (LLM-as-judge). Cheaper, and it scales past what humans can label.
+- **DPO** — [Direct Preference Optimization](https://arxiv.org/pdf/2305.18290.pdf?ref=hackernoon.com). RLHF's simpler successor: skip the separate reward model and optimize the preference directly. There's still a human (or model) on the end picking A vs B.
+- **RLVR (RL from verifiable rewards)** — the reasoning-model frontier. Instead of "which answer do humans prefer," the reward is "did it get the right answer" on problems you can actually check — math, code, unit tests. This is the engine behind the o1-style reasoning models: let the model think longer, reward the correct final answer.
+- **[Alpaca](https://huggingface.co/datasets/yahma/alpaca-cleaned)** — an early instruction dataset. The clever bit was using GPT-4 to generate the training data cheaply. That "use a strong model to make data for a weaker one" trick is everywhere now.
+
+### Fine-tuning methods
+
+How you actually do the fine-tuning above without retraining the whole model:
+
+- **LoRA (Low-Rank Adaptation)** — instead of updating all the weights, freeze them and train a small low-rank matrix bolted alongside. Basically: stick a narrow matrix next to the model and only tune that. Far fewer parameters to update, so it's faster and cheaper, and you keep the base model's knowledge intact. ([Example on Llama 3](https://colab.research.google.com/drive/1efOx_rwZeF3i0YsirhM1xhYLtGNX6Fv3?usp=sharing#scrollTo=bDp0zNpwe6U_))
+- [Fine-Tune Your Own Llama 2 Model in a Colab Notebook](https://mlabonne.github.io/blog/posts/Fine_Tune_Your_Own_Llama_2_Model_in_a_Colab_Notebook.html) — a good hands-on walkthrough.
+
+### Deployment: quantization and serving
+
+Not training, but it's where the model you actually run comes from, so it lands here.
+
+- **Quantization** — compress the weights from 16 bits per parameter down to ~4 bits or less (`Q4_0`, `IQ2_XXS`, and friends). [How the methods work](https://www.reddit.com/r/LocalLLaMA/comments/1ba55rj/overview_of_gguf_quantization_methods/), and a [scorecard comparing them](https://huggingface.co/datasets/christopherthompson81/quant_exploration). It's _lossy_ compression, so you have to eval the damage — a common check is comparing the difference in answers via embeddings.
+- **GGUF (GPT-Generated Unified Format)** — the file format these models are stored in (GGUF is GGML's successor). It's what you download when you grab a quantized model to run locally.
+- [Introduction to Weight Quantization](https://mlabonne.github.io/blog/posts/Introduction_to_Weight_Quantization.html) — the explainer I keep going back to.
+
+## How does post-training differ from RAG and the harness?
+
+There are three places to change how a model behaves, and picking the right one saves enormous effort. Post-training changes the **weights**; RAG and the harness change things at **runtime**. Runtime is cheaper, faster to iterate, and updatable — so the order I actually reach for is harness → RAG → fine-tune, and I rarely get to the third.
+
+| Layer                       | What it changes                           | Reach for it when                             | Iterate in |
+| --------------------------- | ----------------------------------------- | --------------------------------------------- | ---------- |
+| **Harness / MCP** (runtime) | what the model can _do_ and how it _acts_ | it needs tools, or a different way of working | seconds    |
+| **RAG** (runtime)           | what the model _knows_                    | it needs your facts or fresh data             | seconds    |
+| **Post-training** (weights) | the model's _default_ behavior            | the change must hold for everyone, every call | days       |
+
+- **New facts** — your docs, today's data, private knowledge → **RAG**. Retrieve the relevant text at query time and put it in context. You can't reliably fine-tune facts in; that's pre-training's job, and fine-tuning on a handful of examples teaches _style_, not _knowledge_ — then cheerfully hallucinates the gaps.
+- **New actions, or a different way of working** — call an API, read a file, search the web, plan before acting, always check its work → **the harness**: the system prompt, the tools you expose (increasingly through [MCP](https://modelcontextprotocol.io), a standard way to hand a model tools), the agent loop, memory, retries. The weights don't change; the scaffolding gets bigger. Building this well is most of what [/chop](/chop) and the [agent cockpit](/ai-cockpit) are about.
+- **A new default everywhere** — behavior that has to hold for everyone without re-explaining it every call, or that prompting just can't make reliable → **post-training** (the [methods above](#post-training)).
+
+Rule of thumb: facts → RAG, actions → harness, baked-in defaults → post-train. When in doubt, push the change as far toward runtime as it'll go.
+
+## See how it works
+
+For the concepts — how a neural network actually learns, then how a transformer turns that into language — nothing beats 3Blue1Brown's [neural networks series](https://www.3blue1brown.com/topics/neural-networks). Start with gradient descent and backprop (that _is_ training), then the [transformers and GPT chapters](https://www.youtube.com/watch?v=wjZofJX0v4M).
+
+For the mechanics, Brendan Bycroft's [LLM visualization](https://bbycroft.net/llm) walks a single token through every layer of a GPT model in 3D — embeddings, attention, the lot.
+
+I want to embed a small next-token-prediction demo right here (type a prefix, watch the probability distribution over the next token), built as a standalone [explainer](/explainers) and iframed in. Coming soon.
+
+## What this post is not about
+
+To keep the map focused, a few neighbors that live elsewhere:
+
+- **Image / diffusion models** — a different training story altogether (denoising, not next-token). See [/ai-image](/ai-image) for generating images of yourself, and [/ai-art](/ai-art) for the art side.
+- **The actual math** — I'm staying at the mental-model level on purpose. For the deep version, start with the [seminal papers](/ai-paper). For the intuition behind language models, see [/gpt](/gpt).
+- **Distributed-training infrastructure** — the 8,000-GPU engineering problem. Real, hard, and out of scope for me.
+
+For the basics ("what even is an LLM"), [/ai-faq](/ai-faq) is the canonical reference; for putting models to work, see [/chop](/chop); for checking they actually work, [/ai-testing](/ai-testing).
+
+## Appendix: engineering, science, and alchemy
+
+Two of the three roles have clean definitions. **Science** figures out a true fact about a model that already exists; **engineering** makes a system hit a target. The same question word tells you which — _"why is this true?"_ is science, _"how do I hit this number?"_ is engineering.
+
+Concrete pairs, same topic on each line:
+
+| Topic          | Science question                                      | Engineering question                                          |
+| -------------- | ----------------------------------------------------- | ------------------------------------------------------------- |
+| Scaling        | Why does loss drop predictably with compute?          | How do I train this 70B model on 8k GPUs without it crashing? |
+| Inference      | What is the model actually computing in these layers? | How do I serve it at 50ms/token without going broke?          |
+| Generalization | Why don't overparameterized nets just memorize?       | How do I stop _this_ model overfitting on _my_ data?          |
+| Alignment      | Does the model have goals? Can it deceive?            | How do I make it refuse harmful requests in prod?             |
+| Capabilities   | Why do new abilities appear suddenly at scale?        | How do I get reliable tool-calling out of what I have?        |
+| Data           | What did the model actually learn from this corpus?   | How do I dedup, filter, and decontaminate 10T tokens?         |
+
+Science output is a _fact_ ("loss scales as a power law"). Engineering output is a _working thing_ ("a serving stack that hits the SLA").
+
+The one insight worth keeping: in AI the usual order is reversed. Normally science comes first — thermodynamics, then engines. In deep learning we built the thing first and are still reverse-engineering why it works, so a lot of AI "science" is closer to biology (dissect an organism you didn't design) than physics. That's why the line feels blurry: the systems are running ahead of the explanations.
+
+Which brings in the third role. A lot of training is still **alchemy** — you curate the data, pick the recipe, run it, and see what comes out, and when it works the explanation usually arrives later, if at all. It can feel like macrodata refinement in _Severance_: sort the numbers that _feel_ wrong into the bin, without being told why they're wrong or what the bin is for. The difference is ours ships a product at the end.
+
+{% include youtube.html src="Gnffe374Upw" %}
+
+## Appendix: AI inference
+
+Training is how the model gets made; inference is what you pay for every time you _use_ it. The whole game is one question: **how do I serve tokens as cheaply as possible at a given level of intelligence?** You can always spend more compute and memory to go faster — the price just rises with it. The knobs that move that trade-off:
+
+- **Prefill vs decode** — two very different phases. _Prefill_ reads the whole prompt in parallel and is compute-bound; it sets your time-to-first-token. _Decode_ then generates one token at a time, sequentially, bound by memory bandwidth — it has to stream the entire model plus the growing KV cache for every single token. Long outputs are decode-bound, which is why they feel slow.
+- **Quantization** — fewer bits per weight means less data to move per token, so decode gets faster and cheaper, at some quality cost. Same lever as in [deployment](#deployment-quantization-and-serving), pointed at speed instead of disk.
+- **The model matters** — a Mixture-of-Experts (MoE) model only activates a slice of its parameters per token, so you get big-model quality at small-model inference cost. Speculative decoding (a small draft model proposes tokens, the big model verifies a batch of them at once) is another way around the sequential bottleneck.
+
+This one is big enough to deserve its own post — the full version lives at [/ai-inference](/ai-inference).

--- a/back-links.json
+++ b/back-links.json
@@ -177,6 +177,7 @@
         "/iina": "/vlc",
         "/imposter": "/insecure",
         "/in-real-life": "/irl",
+        "/inference": "/ai-inference",
         "/insecurity": "/insecure",
         "/interactive-explanations": "/explainers",
         "/intern-llm": "/genai-talk",
@@ -287,6 +288,7 @@
         "/search-inside-yourself": "/siy",
         "/second-brain": "/ai-second-brain",
         "/self-vs-ego": "/self-ego",
+        "/serving-llms": "/ai-inference",
         "/shadows": "/psychic-shadows",
         "/side-quest": "/side-quests",
         "/simple-and-sinister": "/kettlebell",
@@ -294,9 +296,11 @@
         "/some": "/sleight-of-mouth",
         "/stages": "/chapters",
         "/stewardship": "/delegate",
+        "/sticky": "/made-to-stick",
         "/strong": "/physical-health",
         "/sublime-state": "/sublime",
         "/sublime-states": "/sublime",
+        "/succes": "/made-to-stick",
         "/talk-to-tony": "/tesla",
         "/td/advertising": "/advertising",
         "/td/design": "/design",
@@ -401,7 +405,6 @@
             "incoming_links": [
                 "/chapters",
                 "/retire",
-                "/timeoff-2026-07",
                 "/y24",
                 "/y25",
                 "/y26"
@@ -742,6 +745,7 @@
             "file_path": "_site/affirmations.html",
             "incoming_links": [
                 "/act",
+                "/ai-journal",
                 "/be-proactive",
                 "/four-healths",
                 "/gap-year-igor",
@@ -839,7 +843,8 @@
             "file_path": "_site/ai-art.html",
             "incoming_links": [
                 "/ai",
-                "/ai-journal"
+                "/ai-journal",
+                "/ai-training"
             ],
             "last_modified": "2025-12-06T18:03:02-08:00",
             "markdown_path": "_d/ai-art.md",
@@ -892,6 +897,7 @@
                 "/ai-native-manager",
                 "/ai-operator",
                 "/ai-second-brain",
+                "/ai-training",
                 "/hill-climbing",
                 "/how-igor-chops",
                 "/igors-claws",
@@ -938,7 +944,9 @@
             "incoming_links": [
                 "/agency",
                 "/ai",
+                "/ai-inference",
                 "/ai-security",
+                "/ai-training",
                 "/chow",
                 "/gpt"
             ],
@@ -1020,7 +1028,8 @@
             "file_path": "_site/ai-image.html",
             "incoming_links": [
                 "/ai",
-                "/ai-art"
+                "/ai-art",
+                "/ai-training"
             ],
             "last_modified": "2025-12-06T18:03:02-08:00",
             "markdown_path": "_d/ai-imagegen.md",
@@ -1029,9 +1038,28 @@
             "title": "AI Image Generation",
             "url": "/ai-image"
         },
+        "/ai-inference": {
+            "description": "Training is how a model gets made; inference is what you pay for every time you use it. I don’t build serving stacks — I pick a model, pick a provider, and pay per token — but it helps to carry a rough map of where that price comes from. The whole game is one question: how do I serve tokens as cheaply as possible at a given level of intelligence? You can always spend more compute and memory to go faster — the price just rises with it.\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/ai-inference.html",
+            "incoming_links": [
+                "/ai-training"
+            ],
+            "last_modified": "2026-06-06T17:19:53.788162+00:00",
+            "markdown_path": "_d/ai-inference.md",
+            "outgoing_links": [
+                "/ai-faq",
+                "/ai-training",
+                "/chop",
+                "/how-igor-chops"
+            ],
+            "redirect_url": "",
+            "title": "AI Inference",
+            "url": "/ai-inference"
+        },
         "/ai-journal": {
             "description": "A journal of random explorations in AI. Keeping track of them so I don’t get lost\n\n",
-            "doc_size": 165000,
+            "doc_size": 169000,
             "file_path": "_site/ai-journal.html",
             "incoming_links": [
                 "/ai",
@@ -1049,10 +1077,11 @@
                 "/walking-with-god",
                 "/y25"
             ],
-            "last_modified": "2026-05-11T09:26:06-07:00",
+            "last_modified": "2026-05-31T15:16:53-07:00",
             "markdown_path": "_d/ai-journal.md",
             "outgoing_links": [
                 "/7-habits",
+                "/affirmations",
                 "/ai-art",
                 "/ai-journal",
                 "/ai-second-brain",
@@ -1062,6 +1091,7 @@
                 "/claw",
                 "/end-in-mind",
                 "/eulogy",
+                "/gas-city",
                 "/genai-talk",
                 "/gpt",
                 "/hill-climbing",
@@ -1073,6 +1103,7 @@
                 "/mortality-software",
                 "/parkinson",
                 "/pet-projects",
+                "/produce-consume",
                 "/tesla"
             ],
             "redirect_url": "",
@@ -1166,7 +1197,8 @@
             "file_path": "_site/ai-paper.html",
             "incoming_links": [
                 "/ai",
-                "/ai-faq"
+                "/ai-faq",
+                "/ai-training"
             ],
             "last_modified": "2025-11-25T22:40:07+00:00",
             "markdown_path": "_d/ai-paper.md",
@@ -1251,6 +1283,7 @@
             "file_path": "_site/ai-testing.html",
             "incoming_links": [
                 "/ai",
+                "/ai-training",
                 "/chop",
                 "/genai-talk",
                 "/hill-climbing",
@@ -1268,13 +1301,26 @@
             "url": "/ai-testing"
         },
         "/ai-training": {
-            "description": "Generally, I don’t deal with training or deeper tech, but might as well keep some notes on it.\n\n",
-            "doc_size": 16000,
+            "description": "I don’t train models for a living — I build on top of them. But to use LLMs well, it helps to carry a rough map of how one gets made: what pre-training buys you, what post-training changes, and where fine-tuning, RAG, and quantization actually fit. These are my working notes on that map, kept deliberately shallow — enough to make good decisions as a consumer of models, not to go train one.\n\n",
+            "doc_size": 30000,
             "file_path": "_site/ai-training.html",
-            "incoming_links": [],
-            "last_modified": "2026-01-02T01:31:44+00:00",
+            "incoming_links": [
+                "/ai-inference"
+            ],
+            "last_modified": "2026-06-06T17:20:06.059130+00:00",
             "markdown_path": "_d/ai-training.md",
-            "outgoing_links": [],
+            "outgoing_links": [
+                "/ai-art",
+                "/ai-cockpit",
+                "/ai-faq",
+                "/ai-image",
+                "/ai-inference",
+                "/ai-paper",
+                "/ai-testing",
+                "/chop",
+                "/explainers",
+                "/gpt"
+            ],
             "redirect_url": "",
             "title": "Training LLMs",
             "url": "/ai-training"
@@ -1891,10 +1937,10 @@
         },
         "/changelog": {
             "description": "A weekly summary of what changed on this blog and across my GitHub projects. Useful for returning readers who want to catch up on new content and updates.\n\n",
-            "doc_size": 158000,
+            "doc_size": 173000,
             "file_path": "_site/changelog.html",
             "incoming_links": [],
-            "last_modified": "2026-05-12T19:52:11-07:00",
+            "last_modified": "2026-05-31T11:20:16-07:00",
             "markdown_path": "_d/changelog.md",
             "outgoing_links": [
                 "/7h-concepts",
@@ -1905,12 +1951,14 @@
                 "/ai-journal",
                 "/ai-native-manager",
                 "/ai-operator",
+                "/ai-optimism",
                 "/ai-relationships",
                 "/ai-second-brain",
                 "/amelia",
                 "/be-proactive",
                 "/claw",
                 "/design",
+                "/emotional-lives",
                 "/end-in-mind",
                 "/eulogy",
                 "/first-things-first",
@@ -1924,6 +1972,7 @@
                 "/humans-are-underrated",
                 "/hyper-personal",
                 "/igors-claws",
+                "/image-selector",
                 "/irl",
                 "/keyboard",
                 "/larry",
@@ -1931,7 +1980,9 @@
                 "/lonely",
                 "/money",
                 "/mosh",
+                "/podcast",
                 "/product",
+                "/raccoon-history",
                 "/recent",
                 "/sharpen-the-saw",
                 "/shoulder-pain",
@@ -1939,6 +1990,7 @@
                 "/spiritual-health",
                 "/synergy",
                 "/taxes",
+                "/untangled",
                 "/vibing",
                 "/wally",
                 "/win-win",
@@ -1959,7 +2011,6 @@
                 "/gap-year-igor",
                 "/lonely",
                 "/retire",
-                "/timeoff-2026-07",
                 "/y25",
                 "/y26"
             ],
@@ -2006,8 +2057,10 @@
                 "/ai-developer",
                 "/ai-feed",
                 "/ai-hiring",
+                "/ai-inference",
                 "/ai-journal",
                 "/ai-native-manager",
+                "/ai-training",
                 "/chow",
                 "/explainers",
                 "/gtd",
@@ -2607,6 +2660,7 @@
                 "/coaching",
                 "/gap-year",
                 "/job-hunt-stress",
+                "/made-to-stick",
                 "/manager-book",
                 "/pride",
                 "/random-idea",
@@ -3108,6 +3162,7 @@
                 "/ai-feed",
                 "/ai-native-manager",
                 "/ai-operator",
+                "/ai-training",
                 "/chop",
                 "/chow",
                 "/hill-climbing",
@@ -3346,11 +3401,10 @@
                 "/stock-concentration",
                 "/timeoff",
                 "/timeoff-2025-08",
-                "/timeoff-2026-07",
                 "/y25",
                 "/y26"
             ],
-            "last_modified": "2026-04-18T16:18:08.016875+00:00",
+            "last_modified": "2026-05-31T11:32:27-07:00",
             "markdown_path": "_d/igor-gap-year.md",
             "outgoing_links": [
                 "/7-habits",
@@ -3388,7 +3442,9 @@
             "description": "If you’ve read Standing Up Gas City, or seen “Gas City” mentioned in /wally or /igors-claws, and you want to know what the thing actually is before you stand up your own — this is that post. Three concepts carry the whole design: beads (the unit of work), molecules (the choreography), and the propulsion principle (what keeps the engine running). Each one is plain enough on its own; the leverage is in how they compose.\n\n",
             "doc_size": 25000,
             "file_path": "_site/gas-city.html",
-            "incoming_links": [],
+            "incoming_links": [
+                "/ai-journal"
+            ],
             "last_modified": "2026-05-04T12:23:28.406847+00:00",
             "markdown_path": "_d/gas-city.md",
             "outgoing_links": [
@@ -3491,6 +3547,7 @@
                 "/ai-art",
                 "/ai-faq",
                 "/ai-journal",
+                "/ai-training",
                 "/ml",
                 "/nlp"
             ],
@@ -3728,6 +3785,7 @@
                 "/ai",
                 "/ai-cockpit",
                 "/ai-feed",
+                "/ai-inference",
                 "/ai-journal",
                 "/chop",
                 "/hill-climbing",
@@ -4270,6 +4328,24 @@
             "title": "Loneliness",
             "url": "/lonely"
         },
+        "/made-to-stick": {
+            "description": "Why does a made-up story about a man waking in an ice-filled bathtub with one kidney stolen travel the globe for fifteen years, while the strategy memo you sweated over dies the moment it leaves the room? Chip and Dan Heath spent a decade on that question and found six traits shared by ideas that stick: Simple, Unexpected, Concrete, Credible, Emotional, Stories — which spell SUCCESs. The villain fighting you the whole way is the Curse of Knowledge: once you know something, you can’t remember what it was like not to know it, so you bury the lead, talk in abstractions, and quote numbers nobody feels. This is a nurture book. Sticky ideas are made, not born, and the six traits are a checklist anyone can run.\n\n",
+            "doc_size": 51000,
+            "file_path": "_site/made-to-stick.html",
+            "incoming_links": [],
+            "last_modified": "2026-05-31T15:01:43-07:00",
+            "markdown_path": "_d/made-to-stick.md",
+            "outgoing_links": [
+                "/decisive",
+                "/moments",
+                "/sell",
+                "/switch",
+                "/writing"
+            ],
+            "redirect_url": "",
+            "title": "Made to Stick",
+            "url": "/made-to-stick"
+        },
         "/magic": {
             "description": "Being a dealer of smiles and wonder is a priority in my life, and magic is my instrument. This post details my history and some highlights\n\n",
             "doc_size": 26000,
@@ -4591,6 +4667,7 @@
                 "/balance",
                 "/chasing-daylight",
                 "/happy",
+                "/made-to-stick",
                 "/moments-at-work",
                 "/random-idea",
                 "/timeoff-2022-12",
@@ -5229,6 +5306,7 @@
             "file_path": "_site/produce-consume.html",
             "incoming_links": [
                 "/ai-feed",
+                "/ai-journal",
                 "/gap-year-igor",
                 "/slow"
             ],
@@ -5667,7 +5745,9 @@
             "description": "Selling matters - it’s pitching, convincing, negotiating, hiring. Selling has a bad rap, because the seller often puts their needs ahead of the buyer - a win/lose paradigm. You should make selling win/win or no deal by needing to answer yes to these questions. 1/ If the buyer agrees, will their life improve? 2/ When the deal is done, will the world be a better place than when you began?\n\n",
             "doc_size": 21000,
             "file_path": "_site/sell.html",
-            "incoming_links": [],
+            "incoming_links": [
+                "/made-to-stick"
+            ],
             "last_modified": "2025-12-07T02:33:55+00:00",
             "markdown_path": "_d/2017-2-5-To-Sell-Is-Human.md",
             "outgoing_links": [
@@ -6149,6 +6229,7 @@
             "incoming_links": [
                 "/enable",
                 "/first-things-first",
+                "/made-to-stick",
                 "/negotiate",
                 "/productive",
                 "/random-idea",
@@ -6721,7 +6802,7 @@
         },
         "/timeoff-2020-03": {
             "description": "In March 2020, I took a 2 month sabbatical between leaving Amazon and joining Facebook. Given it was a substantial amount of time, I came up with some big plans, and wrote them down. It was a great plan, BUT my time off correlated perfectly to the Corona Virus and as a result I wasted lots of my mental energy thinking about the Corona Virus, and adjusting to being in pseudo-quarantine. Took me a while, but I finally realized I should ignore corona virus, or at least minimize my time thinking about it.\n\n",
-            "doc_size": 30000,
+            "doc_size": 31000,
             "file_path": "_site/timeoff-2020-03.html",
             "incoming_links": [
                 "/timeoff"
@@ -6994,19 +7075,15 @@
             "url": "/timeoff-2025-08"
         },
         "/timeoff-2026-07": {
-            "description": "22 days, 5 countries, 4 Dvorkins, one whirlwind tour. From Reykjavík to Amsterdam by way of Stockholm, Oslo, and the Norwegian fjords. This is the first time we’ve attempted a trip of this scope as a family — the kids are 16 and 14, both still home, and the window for “all four of us on the road together” closes faster than I’d like.\n\n",
+            "description": "22 days, 5 countries, 4 Dvorkins, one whirlwind tour. From Reykjavík to Amsterdam by way of Stockholm, Oslo, and the Norwegian fjords. This is the first time we’ve attempted a trip of this scope as a family — the kids are 16 and 12, both still home, and the window for “all four of us on the road together” closes faster than I’d like.\n\n",
             "doc_size": 20000,
             "file_path": "_site/timeoff-2026-07.html",
             "incoming_links": [
                 "/y26"
             ],
-            "last_modified": "2026-05-25T19:31:05-07:00",
+            "last_modified": "2026-06-03T16:04:27-07:00",
             "markdown_path": "_d/time-off-2026-07.md",
             "outgoing_links": [
-                "/42",
-                "/ammon-quotes",
-                "/chapters",
-                "/gap-year-igor",
                 "/meta",
                 "/timeoff",
                 "/y26"
@@ -7333,7 +7410,7 @@
         },
         "/weeks": {
             "description": "\n\n",
-            "doc_size": 4346000,
+            "doc_size": 4348000,
             "file_path": "_site/weeks.html",
             "incoming_links": [
                 "/balance"
@@ -7488,6 +7565,7 @@
                 "/chow",
                 "/enable",
                 "/four-healths",
+                "/made-to-stick",
                 "/manager-book",
                 "/manager-book-appendix",
                 "/operating-manual",


### PR DESCRIPTION
## What & why

`/ai-training` was a thin, orphaned notes page. This reworks it into a proper map of how an LLM gets made and how you change one — and splits the serving side into a new `/ai-inference` post.

### `/ai-training` (rework)
- Reframed around **three roles in training: engineering, science, and alchemy** (top section + full appendix with the science/engineering question table and the *Severance* macrodata-refinement "still alchemy" bit + clip).
- Added the **"how a model gets made"** spine: pre-training → post-training → deployment, with the *knowledge vs behavior* intuition.
- New **"How does post-training differ from RAG and the harness?"** decision model (H2 + comparison table): weights vs runtime, reach-for order = harness → RAG → fine-tune.
- Re-filed the existing notes (RLHF/RLAIF/DPO/SFT/Alpaca/LoRA/quant/GGUF) under the right sections; added **RLVR / reasoning models**.
- "See how it works" → 3Blue1Brown (concepts) + Bycroft (mechanics); placeholder for an embedded next-token demo.
- Disclaimer alert (public info / own opinions / not employer's views); `ai-slop` 50%.

### `/ai-inference` (new post)
Serving tokens as cheaply as possible at a given level of intelligence: the cost/latency/throughput triangle, **prefill vs decode** (+ KV cache), quantization for speed, **MoE / speculative decoding / smaller models**, batching (continuous batching + PagedAttention), serving stacks, and "bandwidth not FLOPs." `ai-slop` 70%.

Cross-linked both ways; backlinks rebuilt.

## Screenshots

**/ai-training**
![ai-training](https://gist.githubusercontent.com/idvorkin-ai-tools/bb822b1818d00f6963743c4bc616e2fb/raw/ai-training.jpg)

**/ai-inference**
![ai-inference](https://gist.githubusercontent.com/idvorkin-ai-tools/bb822b1818d00f6963743c4bc616e2fb/raw/ai-inference.jpg)

## Notes / open items
- **Interactive demo**: "See how it works" links Bycroft's LLM viz with a "coming soon" note — the embedded next-token explainer is a planned follow-up, not in this PR.
- **ai-slop %**: 50% on `/ai-training` (co-written), 70% on `/ai-inference` (AI-drafted from my framing) — adjust if you disagree.
- **Pre-existing, not in this PR**: the anchor-checker flags two broken TOC anchors in `_d/ai-optimism.md` (`#sergios-school`, `#stuff-i-know-nothing-…`). That file is unchanged here; worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
