### PR TITLE
Add Year of Wonder glossary entry

### DIFF
--- a/_d/ai-native-vocab.md
+++ b/_d/ai-native-vocab.md
@@ -31,6 +31,7 @@ AI is spawning a whole new vocabulary — some of it genuinely useful, some of i
 - [Infinite Loop](#infinite-loop)
 - [Human In, On, and Out of the Loop](#human-in-on-and-out-of-the-loop)
 - [In Distribution](#in-distribution)
+- [Year of Wonder](#year-of-wonder)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
@@ -144,3 +145,11 @@ A term borrowed from machine learning: data the model has seen during training i
 Yegge identifies this as one of his [six levers for software survival](https://steve-yegge.medium.com/software-survival-3-0-97a2a6255f7b) — he calls it the "Awareness" lever. Tools like Git and Postgres have essentially zero awareness cost because every model has been trained on mountains of content about them. Your team's internal CLI tool? Completely out of distribution. You're paying the awareness tax every time an agent encounters it.
 
 My take: this matters because it changes how you think about tooling decisions. When your team picks a well-known tool over a technically superior but obscure one, that's not just "going with the safe choice" — it's a rational calculation about agent effectiveness. Your CLAUDE.md files, your onboarding docs, your custom slash commands — these are all attempts to push out-of-distribution knowledge into the agent's working context. The better you are at this, the more effective your AI-augmented team becomes. And when you're evaluating whether to build custom tooling vs. using something standard, "will agents already know how to use it?" is now a legitimate engineering criterion.
+
+## Year of Wonder
+
+{% include local_image_float_right.html src="raccoon-year-of-chaos-wonder.webp" %}
+
+The optimist's read on the same AI moment that's exhausting everyone: this is the most creative period in the history of software. Things get built in a week that used to take a quarter, juniors punch above their weight class, and problems shelved years ago for lack of bandwidth are suddenly tractable. Its twin is the [Year of Chaos](/ai-native-manager#the-year-of-chaos-the-year-of-wonder) — the pessimist's read, which is just as accurate: roles are dissolving, skills are devaluing, and most of the weekly hype is garbage.
+
+My take: you don't get to pick the facts, you get to pick which ones you orient around. Both frames are true at once, so the choice isn't about being right — the chaos read is right, the same way [Deep Blue](#deep-blue) is a real feeling and not a delusion. The choice is about which read points somewhere good. Orient around the chaos and you play defense — tighten process, slow down, protect what exists. Orient around the wonder, while staying honest about the chaos, and you play offense — experiment more, raise the ambition, ask what's possible now that wasn't last year. The people who hold both and lean toward wonder are the ones others follow into the unknown.

--- a/back-links.json
+++ b/back-links.json
@@ -2129,7 +2129,7 @@
                 "/tesla",
                 "/y26"
             ],
-            "last_modified": "2026-03-01T12:10:54-08:00",
+            "last_modified": "2026-06-06T18:28:44.329796+00:00",
             "markdown_path": "_d/chow.md",
             "outgoing_links": [
                 "/ai-faq",
@@ -3190,7 +3190,7 @@
                 "/hill-climbing",
                 "/pet-projects"
             ],
-            "last_modified": "2026-04-16T23:12:34.253724+00:00",
+            "last_modified": "2026-06-06T18:28:44.329796+00:00",
             "markdown_path": "_d/explainers.md",
             "outgoing_links": [
                 "/ai-native-vocab",
@@ -3811,7 +3811,6 @@
                 "/ai-journal",
                 "/chop",
                 "/hill-climbing",
-                "/pet-projects",
                 "/wally",
                 "/y25",
                 "/y26"
@@ -5130,17 +5129,17 @@
                 "/side-quests",
                 "/y25"
             ],
-            "last_modified": "2026-04-16T23:12:34.253724+00:00",
+            "last_modified": "2026-06-06T18:28:44.329796+00:00",
             "markdown_path": "_d/pet-projects.md",
             "outgoing_links": [
                 "/ai-native-vocab",
                 "/bike-tesla-identity",
                 "/explainers",
-                "/how-igor-chops",
                 "/larry",
                 "/process-journal",
                 "/side-quests",
-                "/static/pet-projects.html"
+                "/static/pet-projects.html",
+                "/vibe"
             ],
             "redirect_url": "",
             "title": "Pet Projects",

--- a/back-links.json
+++ b/back-links.json
@@ -368,7 +368,7 @@
     "url_info": {
         "/22": {
             "description": "In 2019 I created a program for 15 fantastic interns! A program highlight was my talk titled “What I wish I knew at 22, and so might you”. The talk received a 94% overall rating from over 15 interns, 10 SDE-IIs, and 1 senior developer. Even though the talk focuses on how to live the good life, a big chunk of life is work, so there’s good coverage on how to optimize your career.\n\n",
-            "doc_size": 16000,
+            "doc_size": 17000,
             "file_path": "_site/22.html",
             "incoming_links": [
                 "/chapters",
@@ -691,6 +691,7 @@
                 "/productive",
                 "/psychic-shadows",
                 "/psychic-weight",
+                "/timeoff",
                 "/vibing",
                 "/walking-with-god"
             ],
@@ -1143,7 +1144,7 @@
         },
         "/ai-native-vocab": {
             "description": "AI is spawning a whole new vocabulary — some of it genuinely useful, some of it pure hype. This is my running glossary of the terms worth knowing, with my take on what each one actually means and why it matters. It’s the companion glossary to The AI Native Engineering Manager.\n\n",
-            "doc_size": 33000,
+            "doc_size": 34000,
             "file_path": "_site/ai-native-vocab.html",
             "incoming_links": [
                 "/ai-native-manager",
@@ -1964,8 +1965,7 @@
             "last_modified": "2026-06-06T18:18:54.096028+00:00",
             "markdown_path": "_d/changelog.md",
             "outgoing_links": [
-                "/7h-c0",
-                "/7h-c7",
+                "/7h-concepts",
                 "/act",
                 "/activation",
                 "/addiction",
@@ -2017,8 +2017,7 @@
                 "/vibing",
                 "/wally",
                 "/win-win",
-                "/work-gastown",
-                "/y2026"
+                "/y26"
             ],
             "redirect_url": "",
             "title": "Changelog",
@@ -2578,7 +2577,8 @@
                 "/productive",
                 "/psychic-shadows",
                 "/psychic-weight",
-                "/slow"
+                "/slow",
+                "/timeoff"
             ],
             "last_modified": "2024-10-05T21:35:59-07:00",
             "markdown_path": "_d/resistance.md",
@@ -2664,7 +2664,7 @@
         },
         "/debug": {
             "description": "Igor's Blog",
-            "doc_size": 23000,
+            "doc_size": 24000,
             "file_path": "_site/debug.html",
             "incoming_links": [],
             "last_modified": "2025-03-16T16:15:36+00:00",
@@ -3098,6 +3098,7 @@
                 "/overload",
                 "/parkinson",
                 "/partner-trouble",
+                "/timeoff",
                 "/timeoff-2022-07",
                 "/walking-with-god"
             ],
@@ -3811,6 +3812,7 @@
                 "/ai-journal",
                 "/chop",
                 "/hill-climbing",
+                "/pet-projects",
                 "/wally",
                 "/y25",
                 "/y26"
@@ -4145,6 +4147,7 @@
                 "/gap-year-igor",
                 "/physical-health",
                 "/shoulder-pain",
+                "/timeoff",
                 "/untangled",
                 "/y24"
             ],
@@ -4265,7 +4268,7 @@
         },
         "/learn-code": {
             "description": "Coding is way easier than people think. Here’s some pointers.\n\n",
-            "doc_size": 13000,
+            "doc_size": 14000,
             "file_path": "_site/learn-code.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T02:47:07+00:00",
@@ -4580,7 +4583,7 @@
         },
         "/mind-at-work": {
             "description": "I have a problem, an addiction, an addiction so detrimental to quality of life, it should be described as a disease. This disease is not being present. There are many symptoms of the disease, but today I’m going to talk about my most frequent symptoms, my body at home, but my mind at work.\n\n",
-            "doc_size": 19000,
+            "doc_size": 20000,
             "file_path": "_site/mind-at-work.html",
             "incoming_links": [
                 "/act",
@@ -5135,11 +5138,11 @@
                 "/ai-native-vocab",
                 "/bike-tesla-identity",
                 "/explainers",
+                "/how-igor-chops",
                 "/larry",
                 "/process-journal",
                 "/side-quests",
-                "/static/pet-projects.html",
-                "/vibe"
+                "/static/pet-projects.html"
             ],
             "redirect_url": "",
             "title": "Pet Projects",
@@ -6796,21 +6799,21 @@
             "last_modified": "2026-06-06T18:11:26.466427+00:00",
             "markdown_path": "_d/time_off.md",
             "outgoing_links": [
-                "/addictions",
+                "/addiction",
                 "/balloon",
+                "/d/resistance",
                 "/diet",
                 "/energy",
-                "/essential",
+                "/essentialism",
                 "/eulogy",
                 "/frog",
                 "/gap-year",
                 "/gap-year-igor",
                 "/happy",
-                "/kettlebells",
+                "/kettlebell",
                 "/magic",
                 "/mind-at-work",
                 "/parkinson",
-                "/resistance",
                 "/siy",
                 "/terzepatide",
                 "/timeoff-2020-03",
@@ -7357,7 +7360,7 @@
         },
         "/walking-with-god": {
             "description": "Someone important to me has been reading a daily devotional. Even though I’m not religious, I’m studying with them to be able to have conversations about the insights - whether in a secular or religious context. This is my attempt to bridge two worlds: honoring the spiritual wisdom they’re finding while translating it into language that works for my engineer brain.\n\n",
-            "doc_size": 81000,
+            "doc_size": 82000,
             "file_path": "_site/walking-with-god.html",
             "incoming_links": [
                 "/greek-orthodox",


### PR DESCRIPTION
Adds a **Year of Wonder** entry to `/ai-native-vocab` — the optimist's read on the AI moment (build in a week what took a quarter, juniors punching above their weight, shelved problems suddenly tractable), framed as the twin of the **Year of Chaos**.

- Definition + `My take:` in Igor's voice, role-neutral (no EM-specific framing).
- Cross-links its twin [Year of Chaos](/ai-native-manager#the-year-of-chaos-the-year-of-wonder) and contrasts with the same-page [Deep Blue](#deep-blue) entry.
- Includes the `raccoon-year-of-chaos-wonder.webp` float-right image.
- TOC regenerated; `back-links.json` rebuilt against a fresh Jekyll build.
- `anchor_checker.py --simple`: **All links valid!** (0 broken, 5882 links checked).