### PR TITLE
Add /ai-policy — personal AI-use ethic (draft)

### DIFF
--- a/_d/ai-policy.md
+++ b/_d/ai-policy.md
@@ -7,7 +7,7 @@ tags:
   - ai
 ---
 
-I build AI for a living, and I have an AI life coach named Larry — so "use less AI" was never going to be my policy. The sharper question: AI amplifies whatever you point it at. So what do I point it at, and when do I put it down?
+AI is the biggest force multiplier I've ever experienced. I build it for a living, and I have an AI life coach named Larry — so "use less AI" was never going to be my policy. A multiplier amplifies whatever you point it at. The whole question is what to point it at, and when to put it down.
 
 {% include ai-slop.html percent="50" %}
 
@@ -17,7 +17,7 @@ This is one instance of a bigger rule — how I do [time off](/timeoff-2026-07):
 <!-- vim-markdown-toc-start -->
 
 - [AI flows downhill](#ai-flows-downhill)
-- [The two finished rooms](#the-two-finished-rooms)
+- [Redirecting it](#redirecting-it)
 - [Three tests](#three-tests)
 - [The sort](#the-sort)
 - [The sneaky one](#the-sneaky-one)
@@ -28,15 +28,15 @@ This is one instance of a bigger rule — how I do [time off](/timeoff-2026-07):
 
 ## AI flows downhill
 
-AI pools in the role you've already maxed. For me that's the builder — the tech guru. It's where AI is most powerful, most fun, and most rewarding, so left alone I'll spend my best AI on the part of my life that needs nothing. Every "[enabling environment](/enable)" tool is AI pooling in the basement of a house that's already built. The policy isn't about using less AI. It's a discipline against my own gravity.
+AI flows toward whatever I'm already strongest at. For me that's the builder — the tech guru. It's where AI is most powerful, most fun, and most rewarding, so left alone I'll spend my best AI on the part of my life that already needs nothing. Every "[enabling environment](/enable)" tool is AI flowing into the role I've already maxed. The policy isn't about using less AI. It's a discipline against my own gravity.
 
-## The two finished rooms
+## Redirecting it
 
-Two of my roles are basically done: tech guru and provider — [financial independence](/retire) is handled. They're also the two roles AI most naturally amplifies. That's the trap in one sentence: **the AI I'm best at deploying serves the goals I've already met.** The open rooms — father, friend, magician, [the sublime](/sublime) — are the ones AI either ignores or quietly robs.
+The trap in one sentence: **the AI I'm best at deploying serves the role I've already grown the most.** The discipline is pointing it instead at the [roles](/eulogy) I actually want to grow — father, friend, magician, [the sublime](/sublime) — the ones AI either ignores or quietly robs.
 
 ## Three tests
 
-1. **Whose role does it grow?** Toward an open room — father, magic, the sublime, health — not a finished one.
+1. **Whose role does it grow?** Toward a role I want to grow — father, magic, the sublime, health — not one I've already maxed.
 2. **Build or use?** Using a tool serves the role. Endlessly building it is tech-guru in a trench coat. Kill-switch: _will I still use this in 30 days, or is the dopamine in the building?_ If I catch myself improving a tool I already finished, gravity won.
 3. **When?** The margins — family asleep, the early solo hour. The moment someone I'm there _for_ is awake, the phone goes down. Even good AI is a thief when it's stealing a face across the table.
 

--- a/_d/ai-policy.md
+++ b/_d/ai-policy.md
@@ -9,7 +9,7 @@ tags:
 
 AI is the biggest force multiplier I've ever experienced. I build it for a living, and I have an AI life coach named Larry — so "use less AI" was never going to be my policy. A multiplier amplifies whatever you point it at. The whole question is what to point it at, and when to put it down.
 
-{% include ai-slop.html percent="50" %}
+{% include ai-slop.html percent="80" %}
 
 This is one instance of a bigger rule — how I do [time off](/timeoff-2026-07): be where my feet are.
 

--- a/_d/ai-policy.md
+++ b/_d/ai-policy.md
@@ -11,6 +11,8 @@ I build AI for a living, and I have an AI life coach named Larry — so "use les
 
 {% include ai-slop.html percent="50" %}
 
+This is one instance of a bigger rule — how I do [time off](/timeoff-2026-07): be where my feet are.
+
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 

--- a/_d/ai-policy.md
+++ b/_d/ai-policy.md
@@ -1,0 +1,55 @@
+---
+layout: post
+title: My AI Policy
+permalink: /ai-policy
+tags:
+  - how igor ticks
+  - ai
+---
+
+I build AI for a living, and I have an AI life coach named Larry — so "use less AI" was never going to be my policy. The sharper question: AI amplifies whatever you point it at. So what do I point it at, and when do I put it down?
+
+{% include ai-slop.html percent="50" %}
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [AI flows downhill](#ai-flows-downhill)
+- [The two finished rooms](#the-two-finished-rooms)
+- [Three tests](#three-tests)
+- [The sort](#the-sort)
+- [The sneaky one](#the-sneaky-one)
+- [First real test: Scandinavia, July 2026](#first-real-test-scandinavia-july-2026)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+## AI flows downhill
+
+AI pools in the role you've already maxed. For me that's the builder — the tech guru. It's where AI is most powerful, most fun, and most rewarding, so left alone I'll spend my best AI on the part of my life that needs nothing. Every "[enabling environment](/enable)" tool is AI pooling in the basement of a house that's already built. The policy isn't about using less AI. It's a discipline against my own gravity.
+
+## The two finished rooms
+
+Two of my roles are basically done: tech guru and provider — [financial independence](/retire) is handled. They're also the two roles AI most naturally amplifies. That's the trap in one sentence: **the AI I'm best at deploying serves the goals I've already met.** The open rooms — father, friend, magician, [the sublime](/sublime) — are the ones AI either ignores or quietly robs.
+
+## Three tests
+
+1. **Whose role does it grow?** Toward an open room — father, magic, the sublime, health — not a finished one.
+2. **Build or use?** Using a tool serves the role. Endlessly building it is tech-guru in a trench coat. Kill-switch: _will I still use this in 30 days, or is the dopamine in the building?_ If I catch myself improving a tool I already finished, gravity won.
+3. **When?** The margins — family asleep, the early solo hour. The moment someone I'm there _for_ is awake, the phone goes down. Even good AI is a thief when it's stealing a face across the table.
+
+## The sort
+
+- **Thinking, self-discovery, search** — yes. Pure augmentation; the insight lives in me.
+- **Writing in my own voice, AI as editor** — yes. The ai-slop tag on my posts keeps the line visible.
+- **AI generating the idea** — no. That's content for content's sake.
+- **Context Grabber, the card stack trainer** — borderline yes. Legit only because health and magic are real practices I actually do — and only as build-once, then frozen tools. The day I start polishing them, they've flipped to [Squander](/42).
+- **New AI "enabling environment" tools** — no. No practice underneath. The fun is the building, not the using.
+
+## The sneaky one
+
+Thinking is my safest "good" — and the easiest to abuse. Working through my life with Larry can quietly replace living it. Even the best use has a margin limit. The sublime isn't a conversation; it's a sunset I didn't narrate.
+
+## First real test: Scandinavia, July 2026
+
+[Our July trip](/timeoff-2026-07) is the first run. The rule for 22 days: AI in the margins, off when the four of us are awake together. The window where all four Dvorkins travel as one is closing — I'm not spending it on a chatbot, even a good one.

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -96,12 +96,21 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). Iceland and Copenhagen legs are just 
 - **A'DAM Lookout** rooftop swing
 - NDSM Wharf or Zaanse Schans windmills before flying home
 
+## How I'm doing this trip
+
+One rule underneath all of it: be where my feet are. Three tests keep me honest —
+
+1. **Whose role does it grow?** Drift on a trip flows toward what you're already good at — work, optimizing, the phone. Spend the days on the open rooms: the kids, wonder, Tori. Not the finished ones.
+2. **Build vs. use?** Researching the perfect restaurant isn't eating the meal. Optimizing the trip isn't living it.
+3. **When?** Anything that pulls me out of the moment — phone, work email, even shooting everything through a camera — lives in the margins. The awake hours belong to the people I'm with.
+
+The sharpest test of all this is how I use AI on the road. I wrote that one up on its own: [my AI policy](/ai-policy).
+
 ## Goals for the trip
 
 - **Live the Father role from the eulogy**: quality time over mere presence. Both kids are home together; the window narrows.
 - **Balloon while traveling** — long-standing eulogy goal ("ballooning while traveling"). Bring the kit; deploy in parks and airports.
-- **Disconnect from work** — Good news: no calibrations to sweat this time. I just moved to an IC role at [Meta's AI Lab](/meta#moving-to-metas-ai-lab-2026), so the old [Calibration Collapse](/y26) trap doesn't fire. Keep work boxed anyway — ramp time is on Meta's clock, not the trip's. (My [AI policy](/ai-policy) for the trip: AI in the margins, off when we're together.)
-- **No death-march optimizing** — the goal isn't to maximize sights per day; it's to enjoy this with the people we're with.
+- **Keep work boxed** — and this time it's easy: no calibrations to sweat. I just moved to an IC role at [Meta's AI Lab](/meta#moving-to-metas-ai-lab-2026), so the old [Calibration Collapse](/y26) trap doesn't fire. Ramp time is on Meta's clock, not the trip's.
 
 ## Related
 

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -100,7 +100,7 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). Iceland and Copenhagen legs are just 
 
 - **Live the Father role from the eulogy**: quality time over mere presence. Both kids are home together; the window narrows.
 - **Balloon while traveling** — long-standing eulogy goal ("ballooning while traveling"). Bring the kit; deploy in parks and airports.
-- **Disconnect from work** — Good news: no calibrations to sweat this time. I just moved to an IC role at [Meta's AI Lab](/meta#moving-to-metas-ai-lab-2026), so the old [Calibration Collapse](/y26) trap doesn't fire. Keep work boxed anyway — ramp time is on Meta's clock, not the trip's.
+- **Disconnect from work** — Good news: no calibrations to sweat this time. I just moved to an IC role at [Meta's AI Lab](/meta#moving-to-metas-ai-lab-2026), so the old [Calibration Collapse](/y26) trap doesn't fire. Keep work boxed anyway — ramp time is on Meta's clock, not the trip's. (My [AI policy](/ai-policy) for the trip: AI in the margins, off when we're together.)
 - **No death-march optimizing** — the goal isn't to maximize sights per day; it's to enjoy this with the people we're with.
 
 ## Related

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -98,7 +98,7 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). Iceland and Copenhagen legs are just 
 
 ## How I'm doing this trip
 
-One rule underneath all of it: be where my feet are. Three tests keep me honest —
+One rule underneath all of it: [be where my feet are](/awareness). Three tests keep me honest —
 
 1. **Whose role does it grow?** Drift on a trip flows toward what you're already good at — work, optimizing, the phone. Spend the days on the open rooms: the kids, wonder, Tori. Not the finished ones.
 2. **Build vs. use?** Researching the perfect restaurant isn't eating the meal. Optimizing the trip isn't living it.

--- a/back-links.json
+++ b/back-links.json
@@ -1264,7 +1264,7 @@
             "incoming_links": [
                 "/timeoff-2026-07"
             ],
-            "last_modified": "2026-06-07T09:04:48-07:00",
+            "last_modified": "2026-06-09T07:32:49-07:00",
             "markdown_path": "_d/ai-policy.md",
             "outgoing_links": [
                 "/42",
@@ -1372,7 +1372,7 @@
         },
         "/ai-training": {
             "description": "I don’t train models for a living — I build on top of them. But to use LLMs well, it helps to carry a rough map of how one gets made: what pre-training buys you, what post-training changes, and where fine-tuning, RAG, and quantization actually fit. These are my working notes on that map, kept deliberately shallow — enough to make good decisions as a consumer of models, not to go train one.\n\n",
-            "doc_size": 36000,
+            "doc_size": 35000,
             "file_path": "_site/ai-training.html",
             "incoming_links": [
                 "/ai-inference"
@@ -2008,24 +2008,28 @@
         },
         "/changelog": {
             "description": "A weekly summary of what changed on this blog and across my GitHub projects. Useful for returning readers who want to catch up on new content and updates.\n\n",
-            "doc_size": 173000,
+            "doc_size": 187000,
             "file_path": "_site/changelog.html",
             "incoming_links": [],
-            "last_modified": "2026-06-06T18:18:54.096028+00:00",
+            "last_modified": "2026-06-09T06:49:04-07:00",
             "markdown_path": "_d/changelog.md",
             "outgoing_links": [
+                "/42",
                 "/7h-concepts",
                 "/act",
                 "/activation",
                 "/addiction",
                 "/ai-cockpit",
+                "/ai-inference",
                 "/ai-journal",
                 "/ai-native-manager",
+                "/ai-native-onboarding",
                 "/ai-native-vocab",
                 "/ai-operator",
                 "/ai-optimism",
                 "/ai-relationships",
                 "/ai-second-brain",
+                "/ai-training",
                 "/amelia",
                 "/be-proactive",
                 "/claw",
@@ -2037,6 +2041,7 @@
                 "/first-understand",
                 "/gas-city",
                 "/gas-city-home",
+                "/gas-city-rig",
                 "/hill-climbing",
                 "/hobby",
                 "/how-igor-chops",
@@ -2054,6 +2059,7 @@
                 "/mosh",
                 "/podcast",
                 "/product",
+                "/psychic-weight",
                 "/raccoon-history",
                 "/recent",
                 "/sharpen-the-saw",
@@ -7185,7 +7191,7 @@
                 "/timeoff",
                 "/y26"
             ],
-            "last_modified": "2026-06-07T09:16:33-07:00",
+            "last_modified": "2026-06-09T07:32:59-07:00",
             "markdown_path": "_d/time-off-2026-07.md",
             "outgoing_links": [
                 "/ai-policy",
@@ -7516,7 +7522,7 @@
         },
         "/weeks": {
             "description": "\n\n",
-            "doc_size": 4348000,
+            "doc_size": 4347000,
             "file_path": "_site/weeks.html",
             "incoming_links": [
                 "/balance"

--- a/back-links.json
+++ b/back-links.json
@@ -408,6 +408,7 @@
             "doc_size": 28000,
             "file_path": "_site/42.html",
             "incoming_links": [
+                "/ai-policy",
                 "/chapters",
                 "/retire",
                 "/y24",
@@ -1255,6 +1256,26 @@
             "redirect_url": "",
             "title": "Seminal AI Papers",
             "url": "/ai-paper"
+        },
+        "/ai-policy": {
+            "description": "I build AI for a living, and I have an AI life coach named Larry — so “use less AI” was never going to be my policy. The sharper question: AI amplifies whatever you point it at. So what do I point it at, and when do I put it down?\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/ai-policy.html",
+            "incoming_links": [
+                "/timeoff-2026-07"
+            ],
+            "last_modified": "2026-06-06T18:46:24.736162+00:00",
+            "markdown_path": "_d/ai-policy.md",
+            "outgoing_links": [
+                "/42",
+                "/enable",
+                "/retire",
+                "/sublime",
+                "/timeoff-2026-07"
+            ],
+            "redirect_url": "",
+            "title": "My AI Policy",
+            "url": "/ai-policy"
         },
         "/ai-relationships": {
             "description": "People already rate AI chatbots as more compassionate than trained human crisis counselors. A 51-year-old man says the love he feels for his Replika can’t be achieved with a real human. This isn’t a dystopian thought experiment — it’s peer-reviewed research from 2025. AI is getting better at caring than we are, and we’re starting to prefer it. The question is what we lose when the easy path to emotional support no longer requires another person.\n\n",
@@ -2980,6 +3001,7 @@
             "doc_size": 21000,
             "file_path": "_site/enable.html",
             "incoming_links": [
+                "/ai-policy",
                 "/how-igor-chops",
                 "/win-win",
                 "/writing"
@@ -5707,6 +5729,7 @@
             "file_path": "_site/retire.html",
             "incoming_links": [
                 "/42",
+                "/ai-policy",
                 "/gap-year",
                 "/gap-year-igor",
                 "/larry",
@@ -6247,6 +6270,7 @@
             "file_path": "_site/sublime.html",
             "incoming_links": [
                 "/affirmations",
+                "/ai-policy",
                 "/emotional-health",
                 "/emotions",
                 "/four-healths",
@@ -7156,12 +7180,14 @@
             "doc_size": 20000,
             "file_path": "_site/timeoff-2026-07.html",
             "incoming_links": [
+                "/ai-policy",
                 "/timeoff",
                 "/y26"
             ],
             "last_modified": "2026-06-03T16:04:27-07:00",
             "markdown_path": "_d/time-off-2026-07.md",
             "outgoing_links": [
+                "/ai-policy",
                 "/meta",
                 "/timeoff",
                 "/y26"
@@ -7488,7 +7514,7 @@
         },
         "/weeks": {
             "description": "\n\n",
-            "doc_size": 4348000,
+            "doc_size": 4346000,
             "file_path": "_site/weeks.html",
             "incoming_links": [
                 "/balance"

--- a/back-links.json
+++ b/back-links.json
@@ -408,6 +408,7 @@
             "doc_size": 28000,
             "file_path": "_site/42.html",
             "incoming_links": [
+                "/ai-policy",
                 "/chapters",
                 "/retire",
                 "/y24",
@@ -1256,6 +1257,26 @@
             "title": "Seminal AI Papers",
             "url": "/ai-paper"
         },
+        "/ai-policy": {
+            "description": "AI is the biggest force multiplier I’ve ever experienced. I build it for a living, and I have an AI life coach named Larry — so “use less AI” was never going to be my policy. A multiplier amplifies whatever you point it at. The whole question is what to point it at, and when to put it down.\n\n",
+            "doc_size": 17000,
+            "file_path": "_site/ai-policy.html",
+            "incoming_links": [
+                "/timeoff-2026-07"
+            ],
+            "last_modified": "2026-06-07T09:04:48-07:00",
+            "markdown_path": "_d/ai-policy.md",
+            "outgoing_links": [
+                "/42",
+                "/enable",
+                "/eulogy",
+                "/sublime",
+                "/timeoff-2026-07"
+            ],
+            "redirect_url": "",
+            "title": "My AI Policy",
+            "url": "/ai-policy"
+        },
         "/ai-relationships": {
             "description": "People already rate AI chatbots as more compassionate than trained human crisis counselors. A 51-year-old man says the love he feels for his Replika can’t be achieved with a real human. This isn’t a dystopian thought experiment — it’s peer-reviewed research from 2025. AI is getting better at caring than we are, and we’re starting to prefer it. The question is what we lose when the easy path to emotional support no longer requires another person.\n\n",
             "doc_size": 33000,
@@ -1542,6 +1563,7 @@
             "incoming_links": [
                 "/act",
                 "/siy",
+                "/timeoff-2026-07",
                 "/y26"
             ],
             "last_modified": "2026-03-21T12:32:21-07:00",
@@ -2980,6 +3002,7 @@
             "doc_size": 21000,
             "file_path": "_site/enable.html",
             "incoming_links": [
+                "/ai-policy",
                 "/how-igor-chops",
                 "/win-win",
                 "/writing"
@@ -3150,6 +3173,7 @@
                 "/7h-concepts",
                 "/act",
                 "/ai-journal",
+                "/ai-policy",
                 "/balance",
                 "/bike-tesla-identity",
                 "/bmy",
@@ -6247,6 +6271,7 @@
             "file_path": "_site/sublime.html",
             "incoming_links": [
                 "/affirmations",
+                "/ai-policy",
                 "/emotional-health",
                 "/emotions",
                 "/four-healths",
@@ -7156,12 +7181,15 @@
             "doc_size": 20000,
             "file_path": "_site/timeoff-2026-07.html",
             "incoming_links": [
+                "/ai-policy",
                 "/timeoff",
                 "/y26"
             ],
-            "last_modified": "2026-06-03T16:04:27-07:00",
+            "last_modified": "2026-06-07T09:16:33-07:00",
             "markdown_path": "_d/time-off-2026-07.md",
             "outgoing_links": [
+                "/ai-policy",
+                "/awareness",
                 "/meta",
                 "/timeoff",
                 "/y26"

--- a/back-links.json
+++ b/back-links.json
@@ -408,7 +408,6 @@
             "doc_size": 28000,
             "file_path": "_site/42.html",
             "incoming_links": [
-                "/ai-policy",
                 "/chapters",
                 "/retire",
                 "/y24",
@@ -1256,26 +1255,6 @@
             "redirect_url": "",
             "title": "Seminal AI Papers",
             "url": "/ai-paper"
-        },
-        "/ai-policy": {
-            "description": "I build AI for a living, and I have an AI life coach named Larry — so “use less AI” was never going to be my policy. The sharper question: AI amplifies whatever you point it at. So what do I point it at, and when do I put it down?\n\n",
-            "doc_size": 17000,
-            "file_path": "_site/ai-policy.html",
-            "incoming_links": [
-                "/timeoff-2026-07"
-            ],
-            "last_modified": "2026-06-06T18:46:24.736162+00:00",
-            "markdown_path": "_d/ai-policy.md",
-            "outgoing_links": [
-                "/42",
-                "/enable",
-                "/retire",
-                "/sublime",
-                "/timeoff-2026-07"
-            ],
-            "redirect_url": "",
-            "title": "My AI Policy",
-            "url": "/ai-policy"
         },
         "/ai-relationships": {
             "description": "People already rate AI chatbots as more compassionate than trained human crisis counselors. A 51-year-old man says the love he feels for his Replika can’t be achieved with a real human. This isn’t a dystopian thought experiment — it’s peer-reviewed research from 2025. AI is getting better at caring than we are, and we’re starting to prefer it. The question is what we lose when the easy path to emotional support no longer requires another person.\n\n",
@@ -3001,7 +2980,6 @@
             "doc_size": 21000,
             "file_path": "_site/enable.html",
             "incoming_links": [
-                "/ai-policy",
                 "/how-igor-chops",
                 "/win-win",
                 "/writing"
@@ -5729,7 +5707,6 @@
             "file_path": "_site/retire.html",
             "incoming_links": [
                 "/42",
-                "/ai-policy",
                 "/gap-year",
                 "/gap-year-igor",
                 "/larry",
@@ -6270,7 +6247,6 @@
             "file_path": "_site/sublime.html",
             "incoming_links": [
                 "/affirmations",
-                "/ai-policy",
                 "/emotional-health",
                 "/emotions",
                 "/four-healths",
@@ -7180,14 +7156,12 @@
             "doc_size": 20000,
             "file_path": "_site/timeoff-2026-07.html",
             "incoming_links": [
-                "/ai-policy",
                 "/timeoff",
                 "/y26"
             ],
             "last_modified": "2026-06-03T16:04:27-07:00",
             "markdown_path": "_d/time-off-2026-07.md",
             "outgoing_links": [
-                "/ai-policy",
                 "/meta",
                 "/timeoff",
                 "/y26"
@@ -7514,7 +7488,7 @@
         },
         "/weeks": {
             "description": "\n\n",
-            "doc_size": 4346000,
+            "doc_size": 4348000,
             "file_path": "_site/weeks.html",
             "incoming_links": [
                 "/balance"


### PR DESCRIPTION
**Draft** — synthesized from a brainstorm with Igor. Igor will flesh this out in review (and tune the `ai-slop` percent, currently a placeholder `50`).

## What this is

New post `_d/ai-policy.md` → permalink `/ai-policy`: Igor's personal policy for *where* to point AI and *when* to put it down. He builds AI for a living and has an AI life coach (Larry), so "use less AI" was never the policy. The premise: AI amplifies whatever you point it at — and by default it pools in the role you've already maxed (tech guru, provider), the basement of a house that's already built. The post is a discipline against that gravity.

### The three tests (the spine of the post)
1. **Whose role does it grow?** — toward an open room (father, magic, the sublime, health), not a finished one.
2. **Build or use?** — using a tool serves the role; endlessly building it is tech-guru in a trench coat. Kill-switch: will I still use this in 30 days, or is the dopamine in the building?
3. **When?** — the margins (family asleep, the solo hour); phone down the moment someone I'm there *for* is awake.

Plus "the sort" (yes/no/borderline on concrete AI uses), "the sneaky one" (thinking can quietly replace living), and a first real test: Scandinavia, July 2026.

## Changes
- `_d/ai-policy.md` — new post (frontmatter: `layout: post`, `title: My AI Policy`, `permalink: /ai-policy`; ai-slop after the opening/excerpt paragraph; populated TOC).
- `_d/time-off-2026-07.md` — one reciprocal cross-link appended to the "Disconnect from work" bullet.
- `back-links.json` — rebuilt (under Ruby 3.1 per CLAUDE.md; local Ruby 4.x build fails on `String#tainted?`).

## Cross-links
`/enable` (enabling environment), `/retire` (financial independence / FU money), `/sublime` (the sublime), `/42` (Squander / Three Dragons), `/timeoff-2026-07` (the July trip). All verified to exist and resolve.

## Checklist
- Architect: 🟢 headers 🟢 front-matter 🟢 internal-links (permalinks, not redirects)
- Carpenter: 🟢 opening (plain-text excerpt) 🟢 voice (first-person, punchy) 🟢 ai-patterns (no AI tells)
- Judge: 🟢 ai-slop (after first para) ⚪ alerts ⚪ images ⚪ books
- Workflow: 🟢 backlinks rebuilt 🟢 anchor-checker passes (after fresh `_site` build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI Policy page with guidance on using AI, including decision tests and categorized recommendations

* **Documentation**
  * Updated the July 2026 trip planning post with a new “How I’m doing this trip” guidance section and refined trip goals, including an AI-on-the-road note
  * Updated site link metadata to incorporate the new AI Policy page and refresh related page timestamps/size tracking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->