### PR TITLE
build(jekyll-serve): coexist on a free port via running-servers run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ For content/visual PRs, include a rendered screenshot in the PR description. Pro
    Common gotchas:
    - Server takes ~30s on first build — screenshot before it's ready = blank page
    - Port 4000 may be taken — always use `--port 4000 --process jekyll` so serena MCP or other stray dir-servers don't trigger a false ✓
+   - **`just jekyll-serve` drifts to a free port** (`:4001`, `:4002`, …) when another repo's Jekyll holds `:4000`, and prints `🔨 serving … on :PORT`. Screenshot the port it actually bound, not a hardcoded `4000` — find it via `running-servers status --json` (the entry whose `directory` is this repo). A second `just jekyll-serve` in the same dir fails fast with "already running here". (Requires `running-servers >= 0.2.0`.)
    - Content changes need a rebuild — wait for livereload or give it a few seconds after saving
    - **`jekyll serve --incremental --livereload` serves fresh HTML over HTTP but does NOT write `_site/*.html` to disk.** `prek`'s anchor checker and lychee read disk, so they'll flag phantom broken anchors right after you edit a heading. Fix: `bundle exec jekyll build --incremental` (the live server can stay up), then re-run the hook.
 

--- a/justfile
+++ b/justfile
@@ -281,8 +281,8 @@ jekyll-serve port="4000" livereload_port="35729":
         echo "╚════════════════════════════════════════════════════════════════════╝"
         echo ""
         echo "🔗 Tailscale detected in container"
-        echo "   Local:     http://localhost:{{port}}"
-        echo "   Tailscale: http://$TAILSCALE_HOST:{{port}}"
+        echo "   URL (with the chosen port) is printed below once Jekyll binds."
+        echo "   Port may differ from {{port}} if another repo's server holds it."
         echo ""
         echo "──────────────────────────────────────────────────────────────────────"
     else
@@ -295,10 +295,31 @@ jekyll-serve port="4000" livereload_port="35729":
     export RUBYOPT="-r$(pwd)/_ruby_compat.rb"
     if command -v rbenv >/dev/null 2>&1; then
         eval "$(rbenv init - sh)"
-        rbenv exec bundle exec jekyll server --incremental --livereload --host $BIND_HOST --port {{port}} --livereload-port {{livereload_port}}
+        RUNNER="rbenv exec bundle exec"
     else
-        bundle exec jekyll server --incremental --livereload --host $BIND_HOST --port {{port}} --livereload-port {{livereload_port}}
+        RUNNER="bundle exec"
     fi
+
+    # Require running-servers new enough to have the `run` subcommand
+    # (port-conflict-aware launching). Gate on its version, not just its
+    # presence, so an older install fails loudly instead of erroring on an
+    # unknown subcommand.
+    REQUIRED_RS_VERSION="0.2.0"
+    rs_version="$(running-servers version 2>/dev/null)"
+    if [ -z "$rs_version" ] || \
+       [ "$(printf '%s\n%s\n' "$REQUIRED_RS_VERSION" "$rs_version" | sort -V | head -n1)" != "$REQUIRED_RS_VERSION" ]; then
+        echo "✗ jekyll-serve needs running-servers >= $REQUIRED_RS_VERSION (have: ${rs_version:-not installed})." >&2
+        echo "  Update idvorkin-scripts so 'running-servers run' exists, then retry." >&2
+        exit 1
+    fi
+
+    # running-servers run: fail fast if a Jekyll already serves THIS directory,
+    # otherwise pick a free port (preferring {{port}}/{{livereload_port}}) so we
+    # coexist with servers in other repos instead of dying on "Address already
+    # in use". {http}/{livereload} are substituted with the chosen ports.
+    exec running-servers run --process jekyll --http {{port}} --livereload {{livereload_port}} \
+        -- $RUNNER jekyll server --incremental --livereload --host "$BIND_HOST" \
+        --port '{http}' --livereload-port '{livereload}'
 
 jekyll-container port="4000":
     #!/usr/bin/env bash


### PR DESCRIPTION
## What

`just jekyll-serve` now routes its launch through **`running-servers run`** (added in idvorkin/settings#84, merged). Behavior:

- **Fails fast** if a Jekyll already serves THIS directory — `✗ jekyll already running here on :PORT → URL` — instead of starting a duplicate.
- **Coexists** when another repo holds `:4000`: picks the next free HTTP + livereload port (preferring `4000`/`35729`) instead of dying with "Address already in use".
- **Version-gated**: requires `running-servers version >= 0.2.0`, so an older install fails with a clear message rather than erroring on an unknown subcommand.
- Drops the misleading hardcoded `:4000` from the container banner (the real URL is printed by `running-servers` once the port is chosen).

CLAUDE.md gains a gotcha note documenting the port-drift + guard for screenshot workflows.

## Why

Running `just jekyll-serve` across multiple blog checkouts (blog4/5/6) collided on `:4000`. Now each repo gets its own free port and a second serve in the same dir is refused.

## Testing

Live-verified across three real checkouts simultaneously: blog4 `:4000` (untouched), blog6 `:4001`, blog5 `:4002` — all served HTTP 200, and the guard fired in each. Version gate verified across empty / `0.1.x` / `0.2.x` / `0.10.0` / `1.0.0`.

## Notes

- Depends on idvorkin/settings#84 (merged) for `running-servers` >= 0.2.0.
- `anchor-checker` was skipped for the commit: it flags 2 pre-existing broken anchors in `_d/ai-optimism.md`, unrelated to this diff (fails on clean `main` too).