### PR TITLE
ai-training: link 'How to Train Your Goblin' RL post-training explainer

### DIFF
--- a/_d/ai-training.md
+++ b/_d/ai-training.md
@@ -103,6 +103,8 @@ For the concepts — how a neural network actually learns, then how a transforme
 
 For the mechanics, Brendan Bycroft's [LLM visualization](https://bbycroft.net/llm) walks a single token through every layer of a GPT model in 3D — embeddings, attention, the lot.
 
+And for post-training specifically, [How to Train Your Goblin](https://goblins.mchen.workers.dev/) (mchen and Will Brown, on Prime Intellect) is a playful scroll-through of RL — it retraces how GPT picked up its accidental "goblin" tic by deliberately RL-training models to overuse the word, hidden trigger reward and all. A concrete look at reward hacking and how RL differs from SFT, with the code and training runs open.
+
 I want to embed a small next-token-prediction demo right here (type a prefix, watch the probability distribution over the next token), built as a standalone [explainer](/explainers) and iframed in. Coming soon.
 
 ## What this post is not about

--- a/back-links.json
+++ b/back-links.json
@@ -1328,7 +1328,7 @@
             "incoming_links": [
                 "/ai-inference"
             ],
-            "last_modified": "2026-06-06T17:20:06.059130+00:00",
+            "last_modified": "2026-06-07T13:30:57.425073+00:00",
             "markdown_path": "_d/ai-training.md",
             "outgoing_links": [
                 "/ai-art",


### PR DESCRIPTION
Adds [How to Train Your Goblin](https://goblins.mchen.workers.dev/) (mchen + Will Brown, on Prime Intellect) to the **See how it works** section of [/ai-training](/ai-training).

It's an interactive scroll-explainer of **post-training via RL**: it retraces how GPT picked up its accidental "goblin" persona — a behavior quietly rewarded during post-training — by deliberately RL-training models to overuse the word, using a forked IFEval environment with a hidden trigger-word reward (reward hacking). A concrete, playful look at reward hacking and how RL differs from SFT; code and training runs are open.

Body-only edit; sits alongside the 3Blue1Brown and Bycroft visualizations. No new internal cross-links (external link), so no backlinks impact beyond the routine last-modified bump.