### PR TITLE
Add /stuff — what to keep, what to let go (draft)

### DIFF
--- a/_d/stuff.md
+++ b/_d/stuff.md
@@ -1,0 +1,82 @@
+---
+layout: post
+title: "Stuff"
+comments: true
+tags:
+  - how igor ticks
+permalink: /stuff
+
+author: "Igor Dvorkin"
+---
+
+There's a folding table at a car boot sale somewhere with a dead person's whole life laid out on it, four for a pound. Strangers paw through the teapots and the watches and the model cars, and not one of them knows whose hands these used to be in. The objects outlived the owner. The stories didn't. That's the part that gets me — the stuff survives, the meaning evaporates, and nobody at the table is the wiser.
+
+{% include ai-slop.html percent="35" %}
+
+Sparked by [Nick Maher's video "I'm Begging You To DITCH Your Stuff"](https://youtu.be/Gh-rjOspK10), which I watched on a Saturday morning and couldn't shake. This is me thinking it through, not summarizing his pitch.
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [The memory was never in the thing](#the-memory-was-never-in-the-thing)
+- [Nobody wants your collections](#nobody-wants-your-collections)
+- [Clutter is delayed decisions, not a collection](#clutter-is-delayed-decisions-not-a-collection)
+- [The house-clearance test](#the-house-clearance-test)
+- [What if I die tomorrow?](#what-if-i-die-tomorrow)
+- [This is freedom, not minimalism](#this-is-freedom-not-minimalism)
+- [Protect the stories, not the stuff](#protect-the-stories-not-the-stuff)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+## The memory was never in the thing
+
+Here's the flip that reorganized how I look at my own house: the memory doesn't live in the object. It lives in you. And you leave.
+
+I want to keep things because they're "containers for the story" — my dad's watch, the photo on the shelf, the book I read at exactly the right moment. But the watch can't tell the story. I tell the story. The object is just a trigger that points back at me. Once I'm gone, the trigger fires for nobody, and it's a teapot again.
+
+This isn't sad, it's clarifying. Letting go of an object doesn't erase the person or the experience or the love — those were never stored in the ceramic. Maher's line lands hard: if you genuinely need a trigger, get a tattoo. Carry it on your body where the story actually lives.
+
+## Nobody wants your collections
+
+This is the brutal one. I have things I see as treasure that my kids will see as work.
+
+You spend decades building a collection and never once ask who you're building it for. Then you die, the family calls a dealer, the dealer offers a hundred bucks, and the family takes it — not out of cruelty but because what else are they supposed to do? They're standing in a house full of stuff that meant everything to you and nothing to them, and they have to make a thousand decisions while grieving.
+
+So the question I keep asking now: _who am I keeping this for?_ If the honest answer is "nobody, I just never decided," that's not a collection. That's the next thing.
+
+## Clutter is delayed decisions, not a collection
+
+The boxes in the garage, the cupboard in the spare room, the shelf you stopped seeing years ago. At first you know exactly what's in there and why. Then it becomes background. The boxes become part of the wall. The garage becomes a storage unit you happen to own.
+
+That's the trap — when you stop _seeing_ it, you stop _questioning_ it. You stop asking "do I still use this, do I still need this, do I even remember why I bought it." A lot of what surrounds us isn't loved. It's just stuff we never got around to dealing with. One is a collection. The other is a delayed decision that quietly multiplies. This is the same machinery I wrote about in [psychic weight](/psychic-weight) — every undecided box is an open loop running in the background, and it taxes you even when you've stopped noticing it. [Parkinson's Law](/parkinson) does the rest: stuff expands to fill whatever storage you give it, so a bigger garage just buys you a bigger pile of unmade decisions.
+
+## The house-clearance test
+
+One day somebody else has to deal with everything I own, and they won't see it the way I do. House clearance is dead simple: every object sorts into one of three piles — sellable, recyclable, disposable. Whoever does it isn't being cruel. They're being practical, because every single thing eventually meets the same question: _does anybody actually want this?_
+
+So I've started running my own stuff through one filter:
+
+> Am I keeping this because it adds value to my life, or because I never made a decision about it?
+
+That's it. Use, love, or purpose stays. "I never decided" goes. Maher bought a 20-quid French flour pot at the same car boot sale that depressed him — and that's not a contradiction. He'll actually use it for his sourdough. It earns its place. The point was never _own less_. The point is _decide on purpose_.
+
+## What if I die tomorrow?
+
+I know — morbid. But it's the most useful question in the whole exercise, and it's the heart of my [mortality software](/mortality-software).
+
+If I died tonight, would someone spend weeks clearing my house — sorting boxes, opening cupboards, making thousands of tiny keep/sell/donate/bin calls while gutted that I'm gone? Or have I already done most of that work myself?
+
+The greatest gift I can leave my kids isn't more stuff. It's fewer problems. Fewer boxes, fewer files, fewer weekends lost to my attic. That's not morbid — that's kind. It's the same move as writing my own [eulogy](/eulogy) or sitting with [On Being Mortal](/death): you point straight at the end, and instead of flinching you let it sharpen what you do today. Decluttering reframed as an act of love is the whole trick. Do the hard sorting now so the people I love don't have to do it through tears.
+
+## This is freedom, not minimalism
+
+The reframe that makes it stick: this isn't sacrifice, and it isn't about empty white rooms. It's freedom.
+
+Less stuff is less maintenance, less cleaning, less organizing, less mental load. A garage I can park in. A spare room that's a gym instead of a landfill. Cupboards that open without things falling on my head. It sounds small. It doesn't feel small — it feels like breathing room. Keep what earns its place; let the rest go. Be intentional, not empty.
+
+## Protect the stories, not the stuff
+
+The car boot sale wasn't depressing in the end. It was clarifying. The value of any life was never sitting on those tables — it was in the people, the walks, the conversations, the lessons. Those don't fit in a banana box, and they don't survive a house clearance either, which is exactly why they're the ones worth protecting.
+
+The stuff gets sold. It always does. Next weekend there's another car boot, another cleared house, another lifetime dumped into boxes that used to hold vegetables. What I want to leave behind isn't a fuller table. It's lighter hands for the people I love — and the stories, told while I'm still here to tell them.

--- a/back-links.json
+++ b/back-links.json
@@ -691,6 +691,7 @@
                 "/productive",
                 "/psychic-shadows",
                 "/psychic-weight",
+                "/timeoff",
                 "/vibing",
                 "/walking-with-god"
             ],
@@ -1143,7 +1144,7 @@
         },
         "/ai-native-vocab": {
             "description": "AI is spawning a whole new vocabulary — some of it genuinely useful, some of it pure hype. This is my running glossary of the terms worth knowing, with my take on what each one actually means and why it matters. It’s the companion glossary to The AI Native Engineering Manager.\n\n",
-            "doc_size": 33000,
+            "doc_size": 32000,
             "file_path": "_site/ai-native-vocab.html",
             "incoming_links": [
                 "/ai-native-manager",
@@ -1610,7 +1611,7 @@
         },
         "/bc": {
             "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-            "doc_size": 23000,
+            "doc_size": 22000,
             "file_path": "_site/bc.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T03:02:44+00:00",
@@ -1964,8 +1965,7 @@
             "last_modified": "2026-06-06T18:18:54.096028+00:00",
             "markdown_path": "_d/changelog.md",
             "outgoing_links": [
-                "/7h-c0",
-                "/7h-c7",
+                "/7h-concepts",
                 "/act",
                 "/activation",
                 "/addiction",
@@ -2017,8 +2017,7 @@
                 "/vibing",
                 "/wally",
                 "/win-win",
-                "/work-gastown",
-                "/y2026"
+                "/y26"
             ],
             "redirect_url": "",
             "title": "Changelog",
@@ -2129,7 +2128,7 @@
                 "/tesla",
                 "/y26"
             ],
-            "last_modified": "2026-03-01T12:10:54-08:00",
+            "last_modified": "2026-06-06T11:23:00-07:00",
             "markdown_path": "_d/chow.md",
             "outgoing_links": [
                 "/ai-faq",
@@ -2578,7 +2577,8 @@
                 "/productive",
                 "/psychic-shadows",
                 "/psychic-weight",
-                "/slow"
+                "/slow",
+                "/timeoff"
             ],
             "last_modified": "2024-10-05T21:35:59-07:00",
             "markdown_path": "_d/resistance.md",
@@ -2626,7 +2626,7 @@
         },
         "/day-in-the-life": {
             "description": "A running journal of days that actually worked - the ones where health habits stuck, family time hit different, or I remembered what it feels like to be fully alive. Not every day needs to be Instagram-worthy, but some days deserve a bookmark. This is that bookmark collection.\n\n",
-            "doc_size": 19000,
+            "doc_size": 18000,
             "file_path": "_site/day-in-the-life.html",
             "incoming_links": [],
             "last_modified": "2025-10-04T18:43:51-07:00",
@@ -2651,7 +2651,8 @@
                 "/gap-year-igor",
                 "/last-year",
                 "/mortality-software",
-                "/psychic-weight"
+                "/psychic-weight",
+                "/stuff"
             ],
             "last_modified": "2025-08-22T11:54:12-07:00",
             "markdown_path": "_d/on-being-mortal.md",
@@ -3098,6 +3099,7 @@
                 "/overload",
                 "/parkinson",
                 "/partner-trouble",
+                "/timeoff",
                 "/timeoff-2022-07",
                 "/walking-with-god"
             ],
@@ -3141,6 +3143,7 @@
                 "/retire",
                 "/sharpen-the-saw",
                 "/spiritual-health",
+                "/stuff",
                 "/timeoff",
                 "/todo_enjoy",
                 "/walking-with-god",
@@ -3190,7 +3193,7 @@
                 "/hill-climbing",
                 "/pet-projects"
             ],
-            "last_modified": "2026-04-16T23:12:34.253724+00:00",
+            "last_modified": "2026-06-06T11:23:00-07:00",
             "markdown_path": "_d/explainers.md",
             "outgoing_links": [
                 "/ai-native-vocab",
@@ -3584,7 +3587,7 @@
         },
         "/grammerly": {
             "description": "\n\n",
-            "doc_size": 13000,
+            "doc_size": 12000,
             "file_path": "_site/grammerly.html",
             "incoming_links": [],
             "last_modified": "2025-08-24T09:03:19-07:00",
@@ -4146,6 +4149,7 @@
                 "/gap-year-igor",
                 "/physical-health",
                 "/shoulder-pain",
+                "/timeoff",
                 "/untangled",
                 "/y24"
             ],
@@ -4539,7 +4543,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 15000,
+            "doc_size": 14000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",
@@ -4812,6 +4816,7 @@
                 "/how-igor-chops",
                 "/igors-claws",
                 "/larry",
+                "/stuff",
                 "/walking-with-god",
                 "/y26"
             ],
@@ -5077,6 +5082,7 @@
                 "/manager-book-appendix",
                 "/money",
                 "/operating-manual",
+                "/stuff",
                 "/timeoff"
             ],
             "last_modified": "2025-03-11T06:05:27-07:00",
@@ -5130,7 +5136,7 @@
                 "/side-quests",
                 "/y25"
             ],
-            "last_modified": "2026-04-16T23:12:34.253724+00:00",
+            "last_modified": "2026-06-06T11:23:00-07:00",
             "markdown_path": "_d/pet-projects.md",
             "outgoing_links": [
                 "/ai-native-vocab",
@@ -5439,7 +5445,8 @@
                 "/gtd",
                 "/mind-at-work",
                 "/process-journal",
-                "/psychic-shadows"
+                "/psychic-shadows",
+                "/stuff"
             ],
             "last_modified": "2025-07-18T07:57:44-07:00",
             "markdown_path": "_d/psychic-weight.md",
@@ -6186,6 +6193,24 @@
             "title": "Humane Structure -  A Gentle Framework for Wild Minds",
             "url": "/structure"
         },
+        "/stuff": {
+            "description": "There’s a folding table at a car boot sale somewhere with a dead person’s whole life laid out on it, four for a pound. Strangers paw through the teapots and the watches and the model cars, and not one of them knows whose hands these used to be in. The objects outlived the owner. The stories didn’t. That’s the part that gets me — the stuff survives, the meaning evaporates, and nobody at the table is the wiser.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/stuff.html",
+            "incoming_links": [],
+            "last_modified": "2026-06-07T13:34:36.298820+00:00",
+            "markdown_path": "_d/stuff.md",
+            "outgoing_links": [
+                "/death",
+                "/eulogy",
+                "/mortality-software",
+                "/parkinson",
+                "/psychic-weight"
+            ],
+            "redirect_url": "",
+            "title": "Stuff",
+            "url": "/stuff"
+        },
         "/sublime": {
             "description": "Emotional health is pretty important. Western folks don’t have a lot of words to support this. Luckily, the Buddhists have the sublime states: Loving-kindness, Compassion, Altruistic Joy, and Equanimity. Give ‘em a try. Most of this post is based on “The Joy of Happiness”.\n\n",
             "doc_size": 19000,
@@ -6268,7 +6293,7 @@
         },
         "/synergize": {
             "description": "We’ve all got stuff we’re good at and stuff we’re bad at. Combine them right and the system is greater than the sum of the parts — sometimes a lot greater. Synergy is the payoff for everything that came before: independence, Win/Win, and seeking first to understand all converge here. These are my insights from 7 habits Chapter 6.\n\n",
-            "doc_size": 29000,
+            "doc_size": 28000,
             "file_path": "_site/synergize.html",
             "incoming_links": [
                 "/7-habits",
@@ -6351,7 +6376,7 @@
         },
         "/td/back_ref": {
             "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
-            "doc_size": 14000,
+            "doc_size": 13000,
             "file_path": "_site/td/back_ref.html",
             "incoming_links": [],
             "last_modified": "2022-04-16T15:22:43-07:00",
@@ -6797,21 +6822,21 @@
             "last_modified": "2026-06-06T18:11:26.466427+00:00",
             "markdown_path": "_d/time_off.md",
             "outgoing_links": [
-                "/addictions",
+                "/addiction",
                 "/balloon",
+                "/d/resistance",
                 "/diet",
                 "/energy",
-                "/essential",
+                "/essentialism",
                 "/eulogy",
                 "/frog",
                 "/gap-year",
                 "/gap-year-igor",
                 "/happy",
-                "/kettlebells",
+                "/kettlebell",
                 "/magic",
                 "/mind-at-work",
                 "/parkinson",
-                "/resistance",
                 "/siy",
                 "/terzepatide",
                 "/timeoff-2020-03",
@@ -7433,7 +7458,7 @@
         },
         "/weeks": {
             "description": "\n\n",
-            "doc_size": 4348000,
+            "doc_size": 4346000,
             "file_path": "_site/weeks.html",
             "incoming_links": [
                 "/balance"
@@ -7488,7 +7513,7 @@
         },
         "/win-win": {
             "description": "Win/Win is a constantly seeking mutual benefit in all interactions. Win/Win means that agreements or solutions are mutually beneficial, mutually satisfying. With a Win/Win solution, all parties feel good about the decision and feel committed to the action plan. Win/Win sees life as a cooperative, not a competitive arena. Most people tend to think in terms of dichotomies: strong or weak, hardball or softball, win or lose. But that kind of thinking is fundamentally flawed. It’s based on power and position rather than on principle. Win/Win is based on the paradigm that there is plenty for everybody, that one person’s success is not achieved at the expense or exclusion of the success of others.\n\n",
-            "doc_size": 48000,
+            "doc_size": 47000,
             "file_path": "_site/win-win.html",
             "incoming_links": [
                 "/7-habits",


### PR DESCRIPTION
**Draft.** New standalone post at permalink `/stuff` — a mortality-software essay on decluttering, sparked by [Nick Maher's video "I'm Begging You To DITCH Your Stuff"](https://youtu.be/Gh-rjOspK10). Igor confirmed standalone (not folded into `/psychic-weight`).

Written in Igor's voice as his own reflection building on the video, not a summary. Core arc: the memory lives in you not the object → nobody wants your collections → clutter is delayed decisions → the house-clearance test → "what if I die tomorrow" reframed as kindness → freedom not minimalism → protect the stories, not the stuff.

**Conventions:**
- `{% include ai-slop.html percent="35" %}` placed after the first paragraph (excerpt preserved).
- Attribution line + link to Maher's video right under the label.
- TOC regenerated via `toc.py`.

**Cross-links** (all verified to resolve, permalink form):
- `/death` (On Being Mortal)
- `/psychic-weight` (clutter as open loops / delayed decisions)
- `/eulogy`
- `/mortality-software`
- `/parkinson` (Parkinson's Law — stuff fills available storage)

**Backlinks:** rebuilt locally via `just update-backlinks` on the Ruby 3.1 path (system Ruby is 4.0.3, which can't build Jekyll); regenerated `back-links.json` committed in this PR. `prek` on `_d/stuff.md` passes clean (anchor-checker, lychee, prettier, typos).