### PR TITLE
psychic-weight: fold in 'stuff'/decluttering (delayed decisions, grasping)

### DIFF
--- a/_d/psychic-weight.md
+++ b/_d/psychic-weight.md
@@ -16,32 +16,32 @@ Imagine a weight tied around your body, imagine it dragging behind you, slowing 
 <!-- vim-markdown-toc-start -->
 
 - [Types of psychic weight](#types-of-psychic-weight)
-    - [Aversion and the resistance](#aversion-and-the-resistance)
-    - [Mind monsters](#mind-monsters)
-    - [Triggers](#triggers)
-    - [Open decisions](#open-decisions)
-    - [Open loops](#open-loops)
-    - [Shame](#shame)
-    - [Pride](#pride)
-    - [Ruminating a parasitic idle loop](#ruminating-a-parasitic-idle-loop)
-    - [Beating yourself up](#beating-yourself-up)
-    - [Grasping](#grasping)
+  - [Aversion and the resistance](#aversion-and-the-resistance)
+  - [Mind monsters](#mind-monsters)
+  - [Triggers](#triggers)
+  - [Open decisions](#open-decisions)
+  - [Open loops](#open-loops)
+  - [Shame](#shame)
+  - [Pride](#pride)
+  - [Ruminating a parasitic idle loop](#ruminating-a-parasitic-idle-loop)
+  - [Beating yourself up](#beating-yourself-up)
+  - [Grasping](#grasping)
 - [Antidotes](#antidotes)
-    - [Separate pain from suffering](#separate-pain-from-suffering)
-    - [Eat the frog](#eat-the-frog)
-    - [Getting things done](#getting-things-done)
-    - [CI/CC (Circle of Influence, Circle of Concern)](#cicc-circle-of-influence-circle-of-concern)
-    - [Talk it through](#talk-it-through)
-    - [Meditation](#meditation)
-    - [This too shall pass](#this-too-shall-pass)
-    - [Emotional First Aid](#emotional-first-aid)
+  - [Separate pain from suffering](#separate-pain-from-suffering)
+  - [Eat the frog](#eat-the-frog)
+  - [Getting things done](#getting-things-done)
+  - [CI/CC (Circle of Influence, Circle of Concern)](#cicc-circle-of-influence-circle-of-concern)
+  - [Talk it through](#talk-it-through)
+  - [Meditation](#meditation)
+  - [This too shall pass](#this-too-shall-pass)
+  - [Emotional First Aid](#emotional-first-aid)
 - [Examples from my own life](#examples-from-my-own-life)
-    - [Bathroom remodel feeling "f@#\$" over](#bathroom-remodel-feeling-f-over)
-    - [Insecurity around money](#insecurity-around-money)
-    - [Needing to finish a self evaluation](#needing-to-finish-a-self-evaluation)
-    - [Needing to finish a document at work](#needing-to-finish-a-document-at-work)
-    - [Small things that got really big](#small-things-that-got-really-big)
-    - [Examples of Pride](#examples-of-pride)
+  - [Bathroom remodel feeling "f@#\$" over](#bathroom-remodel-feeling-f-over)
+  - [Insecurity around money](#insecurity-around-money)
+  - [Needing to finish a self evaluation](#needing-to-finish-a-self-evaluation)
+  - [Needing to finish a document at work](#needing-to-finish-a-document-at-work)
+  - [Small things that got really big](#small-things-that-got-really-big)
+  - [Examples of Pride](#examples-of-pride)
 - [Useful thoughts.](#useful-thoughts)
 
 <!-- vim-markdown-toc-end -->
@@ -73,7 +73,13 @@ Analogies:
 
 ### Open decisions
 
+Clutter isn't a collection - it's a pile of decisions I stopped making. The boxes in the garage, the cupboard I haven't opened in years: at first I knew exactly what was in there and why. Then it became background, part of the wall, and once I stopped _seeing_ it I stopped _questioning_ it. An attic isn't a hoard of treasure, it's a stack of keep/sell/donate calls I never made. Every undecided box is psychic weight I'm carrying even though I've stopped noticing it. (Sparked by [Nick Maher's video](https://youtu.be/Gh-rjOspK10).)
+
+The filter I run things through now: am I keeping this because it adds value to my life, or because I never made a decision about it? Use, love, or purpose stays. "I never decided" goes. That's freedom, not minimalism - I keep what earns its place and let the rest go.
+
 ### Open loops
+
+[Parkinson's Law](/parkinson) does the rest: stuff expands to fill whatever storage I give it, so a bigger garage just buys a bigger pile of unmade decisions. The undone small thing doesn't sit still either - it grows, and the loop keeps running in the background until I close it.
 
 ### Shame
 
@@ -96,6 +102,10 @@ When ruminating thoughts become specific, repetitive patterns that loop endlessl
 ### Grasping
 
 The desire to not lose something - make less money, have someone die. The antidote here is realizing that everything is impermanent, in fact you will [die](/death) at which point you can keep nothing.
+
+I grasp at objects because I think the memory lives in them - my dad's watch, the book I read at exactly the right moment. But the memory was never in the thing. It lives in me, and the object is just a trigger that points back at me. Once I'm gone the trigger fires for nobody and it's a watch again. Letting go of the object doesn't erase the person or the love - those were never stored in the ceramic.
+
+The collections are the same trap, one step removed. I see treasure; my kids will see work. Nobody wants the pile I spent decades building - they'll stand in a house full of stuff that meant everything to me and nothing to them, making a thousand keep/sell/bin calls while grieving. The greatest gift I can leave them isn't more stuff, it's fewer problems.
 
 From the prophet:
 

--- a/back-links.json
+++ b/back-links.json
@@ -691,6 +691,7 @@
                 "/productive",
                 "/psychic-shadows",
                 "/psychic-weight",
+                "/timeoff",
                 "/vibing",
                 "/walking-with-god"
             ],
@@ -1323,12 +1324,12 @@
         },
         "/ai-training": {
             "description": "I don’t train models for a living — I build on top of them. But to use LLMs well, it helps to carry a rough map of how one gets made: what pre-training buys you, what post-training changes, and where fine-tuning, RAG, and quantization actually fit. These are my working notes on that map, kept deliberately shallow — enough to make good decisions as a consumer of models, not to go train one.\n\n",
-            "doc_size": 30000,
+            "doc_size": 31000,
             "file_path": "_site/ai-training.html",
             "incoming_links": [
                 "/ai-inference"
             ],
-            "last_modified": "2026-06-07T13:30:57.425073+00:00",
+            "last_modified": "2026-06-07T08:39:57-07:00",
             "markdown_path": "_d/ai-training.md",
             "outgoing_links": [
                 "/ai-art",
@@ -1964,8 +1965,7 @@
             "last_modified": "2026-06-06T18:18:54.096028+00:00",
             "markdown_path": "_d/changelog.md",
             "outgoing_links": [
-                "/7h-c0",
-                "/7h-c7",
+                "/7h-concepts",
                 "/act",
                 "/activation",
                 "/addiction",
@@ -2017,8 +2017,7 @@
                 "/vibing",
                 "/wally",
                 "/win-win",
-                "/work-gastown",
-                "/y2026"
+                "/y26"
             ],
             "redirect_url": "",
             "title": "Changelog",
@@ -2129,7 +2128,7 @@
                 "/tesla",
                 "/y26"
             ],
-            "last_modified": "2026-03-01T12:10:54-08:00",
+            "last_modified": "2026-06-06T11:23:00-07:00",
             "markdown_path": "_d/chow.md",
             "outgoing_links": [
                 "/ai-faq",
@@ -2341,7 +2340,6 @@
                 "/manager-book",
                 "/negotiate",
                 "/operating-manual",
-                "/psychic-weight",
                 "/regrets",
                 "/shame",
                 "/voices",
@@ -2532,7 +2530,6 @@
                 "/operating-manual",
                 "/physical-health",
                 "/productive",
-                "/psychic-weight",
                 "/sharpen-the-saw",
                 "/slow",
                 "/switch",
@@ -2577,8 +2574,8 @@
                 "/parkinson",
                 "/productive",
                 "/psychic-shadows",
-                "/psychic-weight",
-                "/slow"
+                "/slow",
+                "/timeoff"
             ],
             "last_modified": "2024-10-05T21:35:59-07:00",
             "markdown_path": "_d/resistance.md",
@@ -3098,6 +3095,7 @@
                 "/overload",
                 "/parkinson",
                 "/partner-trouble",
+                "/timeoff",
                 "/timeoff-2022-07",
                 "/walking-with-god"
             ],
@@ -3190,7 +3188,7 @@
                 "/hill-climbing",
                 "/pet-projects"
             ],
-            "last_modified": "2026-04-16T23:12:34.253724+00:00",
+            "last_modified": "2026-06-06T11:23:00-07:00",
             "markdown_path": "_d/explainers.md",
             "outgoing_links": [
                 "/ai-native-vocab",
@@ -3901,8 +3899,7 @@
                 "/awareness",
                 "/depression",
                 "/gtd",
-                "/happy",
-                "/psychic-weight"
+                "/happy"
             ],
             "last_modified": "2025-12-06T18:03:28-08:00",
             "markdown_path": "_d/idle-loop.md",
@@ -4146,6 +4143,7 @@
                 "/gap-year-igor",
                 "/physical-health",
                 "/shoulder-pain",
+                "/timeoff",
                 "/untangled",
                 "/y24"
             ],
@@ -5077,6 +5075,7 @@
                 "/manager-book-appendix",
                 "/money",
                 "/operating-manual",
+                "/psychic-weight",
                 "/timeoff"
             ],
             "last_modified": "2025-03-11T06:05:27-07:00",
@@ -5130,7 +5129,7 @@
                 "/side-quests",
                 "/y25"
             ],
-            "last_modified": "2026-04-16T23:12:34.253724+00:00",
+            "last_modified": "2026-06-06T11:23:00-07:00",
             "markdown_path": "_d/pet-projects.md",
             "outgoing_links": [
                 "/ai-native-vocab",
@@ -5431,7 +5430,7 @@
         },
         "/psychic-weight": {
             "description": "Imagine a weight tied around your body, imagine it dragging behind you, slowing down your motions, preventing you from going where you want to go. Imagine never taking it off, and getting no relief regardless of when you sit or sleep. Now imagine that’s not a physical weight, but instead a mental weight, a psychic weight if you will. Psychic weight are the thoughts that prevent your mind and emotions from being fluid and light.\n\n",
-            "doc_size": 21000,
+            "doc_size": 23000,
             "file_path": "_site/psychic-weight.html",
             "incoming_links": [
                 "/depression",
@@ -5441,22 +5440,23 @@
                 "/process-journal",
                 "/psychic-shadows"
             ],
-            "last_modified": "2025-07-18T07:57:44-07:00",
+            "last_modified": "2026-06-07T15:50:07.959790+00:00",
             "markdown_path": "_d/psychic-weight.md",
             "outgoing_links": [
                 "/7-habits",
                 "/addiction",
-                "/curious",
-                "/d/habits",
-                "/d/resistance",
                 "/death",
                 "/frog",
+                "/grandmother",
                 "/gtd",
-                "/idle",
+                "/habits",
+                "/idle-loop",
                 "/mental-pain",
                 "/mind-monsters",
+                "/parkinson",
                 "/pride",
                 "/psychic-shadows",
+                "/resistance",
                 "/shame",
                 "/siy"
             ],
@@ -6797,21 +6797,21 @@
             "last_modified": "2026-06-06T18:11:26.466427+00:00",
             "markdown_path": "_d/time_off.md",
             "outgoing_links": [
-                "/addictions",
+                "/addiction",
                 "/balloon",
+                "/d/resistance",
                 "/diet",
                 "/energy",
-                "/essential",
+                "/essentialism",
                 "/eulogy",
                 "/frog",
                 "/gap-year",
                 "/gap-year-igor",
                 "/happy",
-                "/kettlebells",
+                "/kettlebell",
                 "/magic",
                 "/mind-at-work",
                 "/parkinson",
-                "/resistance",
                 "/siy",
                 "/terzepatide",
                 "/timeoff-2020-03",


### PR DESCRIPTION
Distilled from the standalone /stuff draft per Igor's call to fold the best ideas into the existing /psychic-weight post rather than ship a separate post. Supersedes #668.

What landed (in existing stub sections, not a fat new section):
- **Open decisions** — clutter is a pile of decisions you stopped making; an attic isn't treasure, it's keep/sell/donate calls you never made. Adds the "does it earn its place / freedom not minimalism" filter.
- **Open loops** — Parkinson's Law: stuff expands to fill whatever storage you give it.
- **Grasping** — the memory was never in the object (it lives in you; the thing is just a trigger); nobody wants your collections (kids see work, not value); the gift to your kids is fewer problems, not more stuff.

Light single-line credit to [Nick Maher's video](https://youtu.be/Gh-rjOspK10) where the imported ideas land. No ai-slop label — the additions are short, distilled, first-person prose folded into Igor's existing post. TOC regenerated; back-links.json rebuilt (new /parkinson outlink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)