### PR TITLE
Set default blog og:image to raccoon-ai-native

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -64,7 +64,7 @@ else %}
 
 {% else %}
 
-    {% assign image_url ="https://github.com/idvorkin/blob/raw/master/raccoon-imagination-executed-sustainably.webp" %}
+    {% assign image_url ="https://github.com/idvorkin/blob/raw/master/blog/raccoon-ai-native.webp" %}
 
 {% endif %}
 


### PR DESCRIPTION
Swaps the **default blog photo** — the `og:image` fallback in `_includes/head.html` used for any page without its own `imagefeature`/`imagefeatureblob`/`imagefeaturelocal` — from `raccoon-imagination-executed-sustainably.webp` to the new **`raccoon-ai-native.webp`** (the raccoon mascot fist-bumping its iridescent metal AI twin, "Year of Wonder" shirt). Hardcoded default, as requested, until better art lands.

One-line change.

⚠️ **Depends on [idvorkin/blob#26](https://github.com/idvorkin/blob/pull/26)** — the image asset must be merged to `blob` master first, or the URL 404s. Merge blob#26 before/with this.