### PR TITLE
Default raccoon-ai-native og:image on AI posts (ai_default_image property)

### DIFF
--- a/_d/ai-art.md
+++ b/_d/ai-art.md
@@ -2,6 +2,7 @@
 layout: post
 title: "AI and art"
 permalink: /ai-art
+ai_default_image: true
 ---
 
 Creativity is a critical aspect of art, and that's something which I think AI can be really good at. Some very random ideas

--- a/_d/ai-bestie.md
+++ b/_d/ai-bestie.md
@@ -5,6 +5,7 @@ permalink: /ai-bestie
 redirect_from:
   - /bestiegpt
   - /aGPT
+ai_default_image: true
 ---
 
 My best friend and I communicate over chat lots (33,60,101 messages/day P50, P75, P95). I have years of chat history, and so this seemed like a super fun way to get deeper into ML. This is created and shared with his permission.

--- a/_d/ai-business-model.md
+++ b/_d/ai-business-model.md
@@ -5,6 +5,7 @@ permalink: /ai-bm
 redirect_from:
 tags:
   - ai
+ai_default_image: true
 ---
 
 Business Models drive the world, and they'll drive the world of AI too.

--- a/_d/ai-coder.md
+++ b/_d/ai-coder.md
@@ -5,6 +5,7 @@ permalink: /chop
 mermaid: true
 redirect_from:
   - /ai-coder
+ai_default_image: true
 ---
 
 Welcome to The CHOP Shop! CHOP - or Chat-Oriented Programming - is revolutionizing how we write code. Think of those old-school auto shops: AI started as the shop hand, fetching tools and cleaning parts. Then it became an apprentice mechanic, helping diagnose problems and suggesting fixes. Now? It's a master mechanic, capable of rebuilding entire engines from your high-level specs. Our AIs are getting smarter by the day, and we'll explore how to make the most of this evolution.

--- a/_d/ai-developer.md
+++ b/_d/ai-developer.md
@@ -2,6 +2,7 @@
 layout: post
 title: AI Developer
 permalink: /ai-developer
+ai_default_image: true
 ---
 
 ML Engineer is a hot new job. It's the boys and girls who train and deploy models. I heard the word AI developer the other day, and I'll refer to it as AI application engineers. People who use AI to solve use cases. NOTE: This is not what most developers do today. What most developers do today is ask how can AI do the things I would have done (e.g. write the function).

--- a/_d/ai-faq.md
+++ b/_d/ai-faq.md
@@ -8,6 +8,7 @@ redirect_from:
   - /ai-questions
 tags:
   - ai
+ai_default_image: true
 ---
 
 Questions I keep getting asked about AI, and my current (probably wrong) answers. The ones that don't resolve cleanly.

--- a/_d/ai-feed.md
+++ b/_d/ai-feed.md
@@ -8,6 +8,7 @@ redirect_from:
 tags:
   - ai
   - productivity
+ai_default_image: true
 ---
 
 Pretty common: I get a bag of links — a newsletter, a Twitter thread, a friend's Slack message. I open them all in tabs, skim, close most, and forget. Maybe one in ten sticks. The rest vanish into the consumption void.

--- a/_d/ai-hiring.md
+++ b/_d/ai-hiring.md
@@ -10,6 +10,7 @@ tags:
   - ai
   - job-hunt
   - exploration
+ai_default_image: true
 ---
 
 Like everything else in the new AI world, hiring is gonna change. I don't know where we'll land, but I'm collecting thoughts as this plays out. The industry is all over the map - some companies now require AI use in interviews, others ban it entirely, most are somewhere in between trying to figure it out. How do we assess working with AI? What new behaviors/skills should we be testing for? I don't have answers, just observations.

--- a/_d/ai-imagegen.md
+++ b/_d/ai-imagegen.md
@@ -4,6 +4,7 @@ title: AI Image Generation
 permalink: /ai-image
 redirect-from:
   - /ai-imagegen
+ai_default_image: true
 ---
 
 Everyone talks about GPT, but you can also generate images. Lately, I've been playing with Flux, which is an image generator. You can generate images of me using the idvorkin with this lora on replicate.

--- a/_d/ai-inference.md
+++ b/_d/ai-inference.md
@@ -8,6 +8,7 @@ redirect_from:
 tags:
   - ai
   - machine-learning
+ai_default_image: true
 ---
 
 [Training](/ai-training) is how a model gets made; inference is what you pay for every time you _use_ it. I don't build serving stacks — I pick a model, pick a provider, and pay per token — but it helps to carry a rough map of where that price comes from. The whole game is one question: **how do I serve tokens as cheaply as possible at a given level of intelligence?** You can always spend more compute and memory to go faster — the price just rises with it.

--- a/_d/ai-journal.md
+++ b/_d/ai-journal.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Igor's AI Journal"
 permalink: /ai-journal
+ai_default_image: true
 ---
 
 A journal of random explorations in AI. Keeping track of them so I don't get lost

--- a/_d/ai-native-vocab.md
+++ b/_d/ai-native-vocab.md
@@ -8,7 +8,7 @@ tags:
 redirect_from:
   - /ai-vocab
   - /ai-native-words
-imagefeature: /images/raccoon-nerd.webp
+ai_default_image: true
 ---
 
 AI is spawning a whole new vocabulary — some of it genuinely useful, some of it pure hype. This is my running glossary of the terms worth knowing, with my take on what each one actually means and why it matters. It's the companion glossary to [The AI Native Engineering Manager](/ai-native-manager).

--- a/_d/ai-paper.md
+++ b/_d/ai-paper.md
@@ -4,6 +4,7 @@ title: "Seminal AI Papers"
 permalink: /ai-paper
 redirect_from:
   - ai-papers
+ai_default_image: true
 ---
 
 The original AI papers were all about training, super technical, and not that usable as a practitioner. Nowadays papers are less "mathy" and more applicable to practitioners. Here are some worth reading

--- a/_d/ai-security.md
+++ b/_d/ai-security.md
@@ -7,6 +7,7 @@ redirect_from:
 tags:
   - ai
   - llm
+ai_default_image: true
 ---
 
 Security is super interesting, AI is super interesting, the combination, is super-duper interesting!

--- a/_d/ai-testing.md
+++ b/_d/ai-testing.md
@@ -2,6 +2,7 @@
 layout: post
 title: Testing AI
 permalink: /ai-testing
+ai_default_image: true
 ---
 
 Testing math is easy, it's right or wrong. Testing spelling is easy too, but testing if a joke is funny - now that's tough. Let's talk about how to test AI.

--- a/_d/ai-training.md
+++ b/_d/ai-training.md
@@ -8,6 +8,7 @@ redirect_from:
 tags:
   - ai
   - machine-learning
+ai_default_image: true
 ---
 
 I don't train models for a living — I build on top of them. But to use LLMs well, it helps to carry a rough map of how one gets made: what pre-training buys you, what post-training changes, and where fine-tuning, RAG, and quantization actually fit. These are my working notes on that map, kept deliberately shallow — enough to make good decisions as a consumer of models, not to go train one.

--- a/_d/ai.md
+++ b/_d/ai.md
@@ -2,6 +2,7 @@
 layout: post
 title: All posts on AI
 permalink: /ai
+ai_default_image: true
 ---
 
 AI becomes the

--- a/_d/chow.md
+++ b/_d/chow.md
@@ -9,6 +9,7 @@ tags:
   - how
 redirect_from:
   - /chot
+ai_default_image: true
 ---
 
 I used to stare at blank pages. Now I have a different problem: AI will happily fill those pages for me, but my brain stays empty. CHOW - Chat-Oriented Writing - is my answer: using AI to think better, not just write faster. The written artifact is a side effect. The real product is clarity in your head. This post covers why writing equals thinking, the risk of outsourcing that thinking to AI, and the four thinking modes - Madman, Architect, Carpenter, Judge - that help you partner with AI instead of just delegating to it.

--- a/_d/genai-talk.md
+++ b/_d/genai-talk.md
@@ -9,6 +9,7 @@ redirect_from:
   - /intern-llm
   - /llm-talk
   - /ai-talk
+ai_default_image: true
 ---
 
 Generative AI (GenAI) is taking the world by storm, and it takes a new mindset to make use of it as a programmer. A good mental model of GenAI is interns!

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -62,6 +62,10 @@ else %}
 
     {% capture image_url%}https://github.com/idvorkin/blob/raw/master/ig66/{{page.week}}/montage.webp{%endcapture%}
 
+{% elsif page.ai_default_image %}
+
+    {% capture image_url%}https://github.com/idvorkin/blob/raw/master/blog/raccoon-ai-native.webp{%endcapture%}
+
 {% else %}
 
     {% assign image_url ="https://github.com/idvorkin/blob/raw/master/raccoon-imagination-executed-sustainably.webp" %}

--- a/back-links.json
+++ b/back-links.json
@@ -1323,12 +1323,12 @@
         },
         "/ai-training": {
             "description": "I don’t train models for a living — I build on top of them. But to use LLMs well, it helps to carry a rough map of how one gets made: what pre-training buys you, what post-training changes, and where fine-tuning, RAG, and quantization actually fit. These are my working notes on that map, kept deliberately shallow — enough to make good decisions as a consumer of models, not to go train one.\n\n",
-            "doc_size": 30000,
+            "doc_size": 31000,
             "file_path": "_site/ai-training.html",
             "incoming_links": [
                 "/ai-inference"
             ],
-            "last_modified": "2026-06-07T13:30:57.425073+00:00",
+            "last_modified": "2026-06-07T16:47:13.292738+00:00",
             "markdown_path": "_d/ai-training.md",
             "outgoing_links": [
                 "/ai-art",


### PR DESCRIPTION
Sets the **default social-card image** for AI-cluster posts that lack their own feature image to the new **raccoon-ai-native** (raccoon mascot + iridescent metal AI twin, "Year of Wonder").

**Mechanism (revised per review):**
- A frontmatter **property** `ai_default_image: true` (not a tag — keeps it out of the tag taxonomy) on 19 posts.
- `_includes/head.html` checks `page.ai_default_image` and sets `og:image` to the white `raccoon-ai-native.webp`, *before* the global default. Posts with their own `imagefeature` are unaffected; the site-wide default is unchanged.
- **No in-body image** — a decorative float adds no informational value.

**Scope:** 19 AI posts without a feature image (chop, ai-journal, ai-feed, ai-developer, ai-bestie, ai-image, ai-art, genai-talk, ai-faq, ai, ai-paper, ai-bm, ai-testing, ai-training, ai-security, ai-hiring, chow, ai-inference, ai-native-vocab). The `ai-native-vocab` placeholder (`raccoon-nerd.webp`) was removed in favor of this. Posts that already have a feature image were left alone.

**Asset:** white `raccoon-ai-native.webp` already merged (blob #26) — no remaining dependency.

Verified: clean build, `og:image` resolves correctly on tagged/untagged/own-image posts, `anchor_checker` all-green (0 broken).