### PR TITLE
raccoon-history: add The AI-Native Raccoon (June 2026)

### DIFF
--- a/_d/raccoon-history.md
+++ b/_d/raccoon-history.md
@@ -21,6 +21,7 @@ Every blog needs a mascot, and mine is a raccoon — specifically, a cute anthro
 - [The Brand System (v3 — 2026)](#the-brand-system-v3--2026)
 - [The March 2026 Audit](#the-march-2026-audit)
 - [The 7 Habits Marathon (May 2026)](#the-7-habits-marathon-may-2026)
+- [The AI-Native Raccoon (June 2026)](#the-ai-native-raccoon-june-2026)
 - [Character Design Reference](#character-design-reference)
 
 <!-- vim-markdown-toc-end -->
@@ -129,6 +130,23 @@ Final picks, one per habit:
 - **AI helps me think by showing me options.** When the work is a judgment call I'll live with, AI's job is to widen the option space, not narrow it. I often can't articulate my taste in the abstract — but I can tell you which raccoon I want when I see them side-by-side. Cheap model for the wide pass, human picks, expensive model only for the winners.
 
 **Final count after May 2026:** 23 raccoon images, all on-brand.
+
+## The AI-Native Raccoon (June 2026)
+
+June 2026 added a new _kind_ of raccoon. Not the mascot doing an activity — the mascot meeting a **metal twin of itself**: a chrome "AI" version, same silhouette, different material. The idea is "me and my AI" — a companion standing alongside, not a tool. It became the default social-card image for AI posts, wired in via a new `ai_default_image` frontmatter property that sets the `og:image` on any AI post lacking its own feature image.
+
+<div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; margin: 1em 0;">
+<div style="text-align: center;"><img src="https://github.com/idvorkin/blob/raw/master/blog/raccoon-ai-native.webp" style="width: 100%; border-radius: 8px;" /><br/><small><a href="/ai-native-manager">AI Native</a> — the mascot fist-bumping its metal AI twin</small></div>
+</div>
+
+Two things I learned dialing it in:
+
+- **Same shape, different material.** The twin only works if it's the _exact_ mascot silhouette cast in chrome, not a generic humanoid robot. Anchoring generation on the `raccoon-nerd.webp` reference locked the shape — and, as a side effect, pulled the reference's shirt text, a reminder that a reference image overrides prompt text for more than just style.
+- **Iridescent beats grey.** Flat mirror-chrome read "frozen." Iridescent anodized metal plus warm glowing eyes and thin energy-seams along the joints read "alive." The material does the emotional work.
+
+A transparent cut-out (`raccoon-ai-native-transparent.webp`) exists for floating inside posts, but the default treatment is `og:image` only — a decorative body float is empty calories.
+
+**Final count: 24 raccoon images.**
 
 ## Character Design Reference
 

--- a/back-links.json
+++ b/back-links.json
@@ -1323,12 +1323,12 @@
         },
         "/ai-training": {
             "description": "I don’t train models for a living — I build on top of them. But to use LLMs well, it helps to carry a rough map of how one gets made: what pre-training buys you, what post-training changes, and where fine-tuning, RAG, and quantization actually fit. These are my working notes on that map, kept deliberately shallow — enough to make good decisions as a consumer of models, not to go train one.\n\n",
-            "doc_size": 30000,
+            "doc_size": 31000,
             "file_path": "_site/ai-training.html",
             "incoming_links": [
                 "/ai-inference"
             ],
-            "last_modified": "2026-06-07T13:30:57.425073+00:00",
+            "last_modified": "2026-06-07T16:47:13.292738+00:00",
             "markdown_path": "_d/ai-training.md",
             "outgoing_links": [
                 "/ai-art",


### PR DESCRIPTION
Adds a **June 2026** section to [/raccoon-history](/raccoon-history) documenting the new **raccoon-ai-native** — the mascot meeting a **metal twin of itself** ('me and my AI'), now the default `og:image` for AI posts via the `ai_default_image` property (see #671).

Captures two reusable learnings from the iteration:
- **Same shape, different material** — the twin must be the exact mascot silhouette in chrome, not a generic robot; anchoring on `raccoon-nerd.webp` locked it (and pulled the ref's shirt text — refs override prompt text for more than style).
- **Iridescent beats grey** — flat chrome reads 'frozen'; anodized iridescent + glowing eyes + energy-seams read 'alive'.

Body-only: new section + TOC entry, image grid points at the merged blob asset, count 23 → 24. Only internal link is `/ai-native-manager` (already linked from the page) so no backlinks change.