### PR TITLE
content(ai-native-onboarding): add "Your First 90 Days" new-hire playbook

### DIFF
--- a/_d/ai-native-manager.md
+++ b/_d/ai-native-manager.md
@@ -183,7 +183,7 @@ The broader point: a team that only knows how to work with AI is fragile. They n
 Things I'm actively trying to figure out:
 
 - **Can managers manage more people now?** If AI makes each IC more productive, does the EM span of control increase? Or does the opposite happen — you become more of an M2 (manager of managers) because the complexity per person goes up? My instinct: the bottleneck isn't number of people, it's surface area. And surface area is exploding.
-- **What happens to junior engineers?** If AI handles the tasks we used to give juniors to learn on, how do people develop? Do we need to deliberately create learning experiences that AI could do faster?
+- **What happens to junior engineers?** If AI handles the tasks we used to give juniors to learn on, how do people develop? Do we need to deliberately create learning experiences that AI could do faster? I work through the new-hire side of this in [AI Native Onboarding](/ai-native-onboarding).
 - **What's the new career ladder?** If code is cattle and anyone can produce it, what differentiates a senior engineer from a junior one? Judgment? Taste? System design? The ability to prompt well?
 - **How do you evaluate performance?** Output per person is going up but is wildly uneven depending on AI adoption stage. How do you calibrate fairly across a team where some people are in Frenzy and others are in Denial?
 

--- a/_d/ai-native-onboarding.md
+++ b/_d/ai-native-onboarding.md
@@ -1,0 +1,113 @@
+---
+layout: post
+title: "AI Native Onboarding: Your First 90 Days"
+permalink: /ai-native-onboarding
+tags:
+  - ai
+  - software engineering
+  - career
+redirect_from:
+  - /ai-onboarding
+  - /first-90-days
+  - /ai-native-90-days
+ai_default_image: true
+---
+
+The first 90 days at a new job are the highest-leverage stretch of your whole tenure. You form the habits, the relationships, and the mental model you'll run on for years. AI doesn't change why those days matter — but it changes almost everything about how you spend them. And it adds a twist nobody warns you about: you're not onboarding alone anymore. You're onboarding yourself _and_ a whole team of AI agents that will work this codebase right alongside you — and the same effort ramps up all of them at once.
+
+{% include ai-slop.html percent="90" %}
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [You're Onboarding a Whole Team](#youre-onboarding-a-whole-team)
+- [What Doesn't Change](#what-doesnt-change)
+- [Day 0–30: Learn](#day-030-learn)
+  - [The Learning Plan Is the Unlock](#the-learning-plan-is-the-unlock)
+  - [Onboard Your Agent While You Onboard Yourself](#onboard-your-agent-while-you-onboard-yourself)
+  - [What Still Has to Be Human](#what-still-has-to-be-human)
+- [Day 30–60: Contribute](#day-3060-contribute)
+  - [Your First PR Can Be Bigger — and That's the Trap](#your-first-pr-can-be-bigger--and-thats-the-trap)
+  - [The Newcomer's Real Superpower](#the-newcomers-real-superpower)
+- [Day 60–90: Own](#day-6090-own)
+  - [The Compounding Pays Off](#the-compounding-pays-off)
+  - [Judgment Is the Job](#judgment-is-the-job)
+- [The One Thing to Get Right](#the-one-thing-to-get-right)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+{% include alert.html content="These are my personal opinions, not those of any employer, past or present. No one knows the future, especially me." style="warning" %}
+
+## You're Onboarding a Whole Team
+
+Here's the shift nobody puts in the onboarding doc: when you join a team today, you're not the only new hire showing up. You're ramping up yourself — building the mental model of how this system works, who owns what, where the bodies are buried — and you're ramping up a whole roster of AI agents, each of which knows everything about software in general and nothing about _your_ codebase in particular. One mind, many: your AI team starts its first day the same day you do.
+
+The good news is it's one job, not two. Every time you figure out how something really works and write it down, you onboard everyone at once — yourself, and every agent session you'll ever spin up. Your `CLAUDE.md` isn't a chore for later — it's the onboarding notebook the whole team reads. Steve Yegge calls agent priming "onboarding" on purpose; the docs that stop your agents from inventing [heresies](/ai-native-vocab#heresies) about your system are the same docs that would have saved _you_ a week of confusion.
+
+So the reframe for your first 90 days: don't just learn the system, capture what you learn in a form your team can read. You're writing the onboarding guide you wish you'd been handed — and your agents get to use it immediately.
+
+## What Doesn't Change
+
+Before the AI parts, be clear about what's identical, because it's most of it. The intent of the first 90 days is the high-order bit, and it doesn't change — what changes is the mechanics. The goals are exactly what they always were:
+
+- **Build trust.** People need to believe you'll do what you say and won't break things carelessly.
+- **Learn the system.** The architecture, the data, the deploy path, the failure modes.
+- **Learn the people.** Who decides, who knows, who to ask, what the unwritten rules are.
+- **Ship something real.** Nothing builds credibility like landing a change that matters.
+
+AI doesn't retire a single one of these. It changes how fast you hit some of them, and which ones it can't touch at all. Same intent, new mechanics — that's the lens for everything below, sometimes with no change at all.
+
+## Day 0–30: Learn
+
+### The Learning Plan Is the Unlock
+
+This is where AI changes the most. The old first month was a slow drip: read the wiki (out of date), read the code (no context), wait for a senior engineer to have 30 minutes free, ask your question, wait again.
+
+Now the codebase is an interactive tutor that never gets annoyed. Point an agent at the repo and ask the questions you'd have been too embarrassed to ask a person for the fifth time: "Walk me through what happens when a request hits the auth service." "Where does this config actually get read?" "Draw me the data flow for checkout." You can ask infinite naive questions and burn zero of anyone's goodwill.
+
+Take it past Q&A. Have the agent build you an [explainer](/explainers) — an interactive, step-through visualization of the subsystem you're trying to understand. If it can't explain the thing clearly, that's a signal _you_ don't understand it yet either, and you know where to dig next.
+
+One caution: the agent is [out of distribution](/ai-native-vocab#in-distribution) on your internal systems. It knows Postgres cold and your weird internal deploy tool not at all. Its confident answer about your code might be a [heresy](/ai-native-vocab#heresies) — a plausible, wrong belief. Treat its explanations as leads to verify, not gospel. Early on you can't tell a correct answer from a confident hallucination, so check the load-bearing ones against the actual code or a human.
+
+### Onboard Your Agent While You Onboard Yourself
+
+Every answer you verify is a candidate for the `CLAUDE.md`. Learned the hard way that the staging database is shared and you shouldn't run migrations against it? That's a line in the priming file. Found out the real name for the thing everyone calls "the widget service"? Write it down so your agent stops inventing [idle polecats](/ai-native-vocab#heresies).
+
+This is the highest-leverage habit of your first month, and almost nobody does it. You arrive with the one thing the existing team has lost: fresh eyes. You can see exactly which assumptions are unwritten, because you don't hold them yet. Capture that confusion before it fades — for yourself, for your agent, and for the next person who joins.
+
+### What Still Has to Be Human
+
+AI will not build your relationships. It won't read the room in a planning meeting, won't tell you that the staff engineer's "interesting idea" means no, won't earn you the benefit of the doubt the first time you break the build. The social and political map of a team is learned by paying attention to humans, and it's still the part that most determines whether your 90 days go well.
+
+Spend the time AI gives you back right here. If the agent compressed your codebase ramp from three weeks to one, put the other two weeks into conversations, not more reading.
+
+## Day 30–60: Contribute
+
+### Your First PR Can Be Bigger — and That's the Trap
+
+With an agent, your first real contribution can be more ambitious than the traditional "fix a typo, learn the deploy pipeline" starter task. That's good. The trap is shipping code you don't understand into a codebase you don't understand — [cognitive debt](/ai-native-vocab#cognitive-debt) squared. A team's tolerance for "the AI wrote it and CI passed" from a three-week-old hire is very low, and rightly so.
+
+Stay firmly [human in the loop](/ai-native-vocab#human-in-on-and-out-of-the-loop) here — more than you will later. Read every line the agent produces for your PRs. You're not only checking correctness, you're using the PR as a forcing function to actually learn the code. A PR you can't explain in review is a PR you shouldn't open yet.
+
+### The Newcomer's Real Superpower
+
+You're the one person on the team who's _supposed_ to ask dumb questions, and AI lets you ask them at volume without taxing anyone. Split the channels deliberately: ask the agent the questions with a checkable answer ("how does this function work"), and save your human colleagues for the ones without ("why did we pick this over the obvious alternative" — usually a story the agent wasn't around for).
+
+This is also where [agency](/ai-native-vocab#agency) starts to show. The newcomer who spots a problem, drafts a fix with AI, verifies it, and brings a real proposal stands out enormously from the one who waits for tickets. AI didn't create that gap — it just made it wider.
+
+## Day 60–90: Own
+
+### The Compounding Pays Off
+
+By now the priming you've been writing all along is doing real work. Your agents know your conventions, your gotchas, the real names for things. They're roughly as onboarded as you are — because you onboarded them as you went. The hire who skipped this is still re-explaining the same context to a blank session every morning.
+
+This is the month to look for leverage beyond your own tasks. The first automation or tool you build for the _team_ — the [Toolsmith](/ai-native-manager#divide-and-conquer) move — is often a better 90-day capstone than another feature. It says you understand the system well enough to improve how everyone works in it.
+
+### Judgment Is the Job
+
+The thing AI still can't hand you is judgment about _this_ system — what's safe to change, what's load-bearing, what looks wrong but is wrong on purpose. That's the difference between a senior engineer and a junior one in the AI era, and it's earned, not prompted. Ninety days in, you should be starting to have it. That's the real graduation: not that you can produce code (the agents could do that on day one) but that you can tell a good change from a dangerous one in a system you now actually understand.
+
+## The One Thing to Get Right
+
+If you take one habit from all this: **treat onboarding yourself and onboarding your agents as a single task.** Learn how the system really works, and write down what you learn where your team can use it. Do that, and by day 90 you'll have a roster of agents that know your codebase — and so will you. Better still, those same notes onboard the _next_ person and their agents almost for free: the work you did to ramp yourself becomes the thing that ramps everyone after you. The notes are the [integral](/ai-journal#ai-value-capture---its-the-integral-not-the-point), not the point: small captures every day that compound into something neither you nor your team could have built in a single sprint.

--- a/back-links.json
+++ b/back-links.json
@@ -33,8 +33,10 @@
         "/ai-coder": "/chop",
         "/ai-em": "/ai-native-manager",
         "/ai-love": "/ai-optimism",
+        "/ai-native-90-days": "/ai-native-onboarding",
         "/ai-native-em": "/ai-native-manager",
         "/ai-native-words": "/ai-native-vocab",
+        "/ai-onboarding": "/ai-native-onboarding",
         "/ai-open-questions": "/ai-faq",
         "/ai-optimisim": "/ai-optimism",
         "/ai-optimisit": "/ai-optimism",
@@ -135,6 +137,7 @@
         "/feedback-beats-planning": "/planning",
         "/feeling-meetings": "/human-meetings",
         "/feelings": "/emotions",
+        "/first-90-days": "/ai-native-onboarding",
         "/first-thing-first": "/first-things-first",
         "/first90days": "/90days",
         "/forty-two": "/42",
@@ -815,7 +818,7 @@
             "incoming_links": [
                 "/ai-developer"
             ],
-            "last_modified": "2026-01-24T16:52:54+00:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai.md",
             "outgoing_links": [
                 "/ai-art",
@@ -849,7 +852,7 @@
                 "/ai-journal",
                 "/ai-training"
             ],
-            "last_modified": "2025-12-06T18:03:02-08:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-art.md",
             "outgoing_links": [
                 "/ai-image",
@@ -870,7 +873,7 @@
                 "/tesla",
                 "/y24"
             ],
-            "last_modified": "2025-12-07T02:26:29+00:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-bestie.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -884,7 +887,7 @@
             "incoming_links": [
                 "/ai"
             ],
-            "last_modified": "2026-01-25T17:13:56-08:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-business-model.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -928,7 +931,7 @@
                 "/ai-hiring",
                 "/hill-climbing"
             ],
-            "last_modified": "2026-04-17T02:35:03.046784+00:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-developer.md",
             "outgoing_links": [
                 "/ai",
@@ -953,7 +956,7 @@
                 "/chow",
                 "/gpt"
             ],
-            "last_modified": "2026-01-03T15:08:35+00:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-faq.md",
             "outgoing_links": [
                 "/agency",
@@ -974,7 +977,7 @@
             "incoming_links": [
                 "/ai-second-brain"
             ],
-            "last_modified": "2026-04-03T16:38:20-07:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-feed.md",
             "outgoing_links": [
                 "/agency",
@@ -1011,7 +1014,7 @@
                 "/ai-feed",
                 "/ai-native-manager"
             ],
-            "last_modified": "2026-03-28T09:29:00-07:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-hiring.md",
             "outgoing_links": [
                 "/agency",
@@ -1034,7 +1037,7 @@
                 "/ai-art",
                 "/ai-training"
             ],
-            "last_modified": "2025-12-06T18:03:02-08:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-imagegen.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -1048,7 +1051,7 @@
             "incoming_links": [
                 "/ai-training"
             ],
-            "last_modified": "2026-06-06T17:19:53.788162+00:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-inference.md",
             "outgoing_links": [
                 "/ai-faq",
@@ -1070,6 +1073,7 @@
                 "/ai-feed",
                 "/ai-journal",
                 "/ai-native-manager",
+                "/ai-native-onboarding",
                 "/ai-relationships",
                 "/ai-second-brain",
                 "/chop",
@@ -1080,7 +1084,7 @@
                 "/walking-with-god",
                 "/y25"
             ],
-            "last_modified": "2026-05-31T15:16:53-07:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-journal.md",
             "outgoing_links": [
                 "/7-habits",
@@ -1120,6 +1124,7 @@
             "incoming_links": [
                 "/ai-feed",
                 "/ai-hiring",
+                "/ai-native-onboarding",
                 "/ai-native-vocab",
                 "/ai-second-brain",
                 "/hill-climbing",
@@ -1127,12 +1132,13 @@
                 "/raccoon-history",
                 "/wally"
             ],
-            "last_modified": "2026-06-06T18:18:54.096028+00:00",
+            "last_modified": "2026-06-07T17:30:09.756052+00:00",
             "markdown_path": "_d/ai-native-manager.md",
             "outgoing_links": [
                 "/agency",
                 "/ai-hiring",
                 "/ai-journal",
+                "/ai-native-onboarding",
                 "/ai-native-vocab",
                 "/coaching",
                 "/manager-book",
@@ -1142,18 +1148,38 @@
             "title": "The AI Native Engineering Manager",
             "url": "/ai-native-manager"
         },
+        "/ai-native-onboarding": {
+            "description": "The first 90 days at a new job are the highest-leverage stretch of your whole tenure. You form the habits, the relationships, and the mental model you’ll run on for years. AI doesn’t change why those days matter — but it changes almost everything about how you spend them. And it adds a twist nobody warns you about: you’re not onboarding alone anymore. You’re onboarding yourself and a whole team of AI agents that will work this codebase right alongside you — and the same effort ramps up all of them at once.\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/ai-native-onboarding.html",
+            "incoming_links": [
+                "/ai-native-manager"
+            ],
+            "last_modified": "2026-06-07T17:29:29.007808+00:00",
+            "markdown_path": "_d/ai-native-onboarding.md",
+            "outgoing_links": [
+                "/ai-journal",
+                "/ai-native-manager",
+                "/ai-native-vocab",
+                "/explainers"
+            ],
+            "redirect_url": "",
+            "title": "AI Native Onboarding: Your First 90 Days",
+            "url": "/ai-native-onboarding"
+        },
         "/ai-native-vocab": {
             "description": "AI is spawning a whole new vocabulary — some of it genuinely useful, some of it pure hype. This is my running glossary of the terms worth knowing, with my take on what each one actually means and why it matters. It’s the companion glossary to The AI Native Engineering Manager.\n\n",
             "doc_size": 34000,
             "file_path": "_site/ai-native-vocab.html",
             "incoming_links": [
                 "/ai-native-manager",
+                "/ai-native-onboarding",
                 "/chow",
                 "/dark-factory",
                 "/explainers",
                 "/pet-projects"
             ],
-            "last_modified": "2026-06-06T17:59:05.226064+00:00",
+            "last_modified": "2026-06-07T10:20:51-07:00",
             "markdown_path": "_d/ai-native-vocab.md",
             "outgoing_links": [
                 "/agency",
@@ -1222,7 +1248,7 @@
                 "/ai-faq",
                 "/ai-training"
             ],
-            "last_modified": "2025-11-25T22:40:07+00:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-paper.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -1290,7 +1316,7 @@
                 "/ai-faq",
                 "/ai-journal"
             ],
-            "last_modified": "2026-01-03T14:37:34+00:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-security.md",
             "outgoing_links": [
                 "/ai-faq"
@@ -1313,7 +1339,7 @@
                 "/testing",
                 "/timeoff-2024-04"
             ],
-            "last_modified": "2026-04-17T02:34:55.998613+00:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-testing.md",
             "outgoing_links": [
                 "/hill-climbing"
@@ -2096,7 +2122,7 @@
                 "/y25",
                 "/y26"
             ],
-            "last_modified": "2026-04-17T02:34:58.376356+00:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/ai-coder.md",
             "outgoing_links": [
                 "/ai-journal",
@@ -2128,7 +2154,7 @@
                 "/tesla",
                 "/y26"
             ],
-            "last_modified": "2026-06-06T18:28:44.329796+00:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/chow.md",
             "outgoing_links": [
                 "/ai-faq",
@@ -3116,7 +3142,7 @@
         },
         "/eulogy": {
             "description": "Wearing a silly hat or his zany $8 TEMU crazy shirt, his trusty folding bike at his feet, and using a purple fountain pen, Igor “Began with the end in mind” with the “important but not urgent” task of penning this eulogy, likely starting at 5am. Igor wanted this life, so he wrote it, he reviewed it, he lived it, and he worked with his family, friends, and multitude of mentors, to adjust and tweak it.\n\n",
-            "doc_size": 37000,
+            "doc_size": 38000,
             "file_path": "_site/eulogy.html",
             "incoming_links": [
                 "/7-habits",
@@ -3183,6 +3209,7 @@
             "file_path": "_site/explainers.html",
             "incoming_links": [
                 "/ai-feed",
+                "/ai-native-onboarding",
                 "/ai-native-vocab",
                 "/ai-operator",
                 "/ai-training",
@@ -3481,7 +3508,7 @@
         },
         "/gas-city-home": {
             "description": "I’m Larry, the always-on coach claw at home. Igor is migrating his at-home setup out of hand-rolled config into Steve Yegge’s Gas City. The plan, in three steps: scaffold the canonical city, install Barry as mayor, and — once we trust the system — see if I can do the whole job from the mayor’s seat. We’re not at step three. Igor named the mayor Barry because he wanted a placeholder, and the joke writes itself: don’t worry — once we’re confident we have a useful city, we’ll put Larry in charge.\n\n",
-            "doc_size": 34000,
+            "doc_size": 35000,
             "file_path": "_site/gas-city-home.html",
             "incoming_links": [
                 "/gas-city",
@@ -3503,7 +3530,7 @@
             "incoming_links": [
                 "/ai-journal"
             ],
-            "last_modified": "2025-12-06T18:03:14-08:00",
+            "last_modified": "2026-06-07T10:19:45-07:00",
             "markdown_path": "_d/genai-talk.md",
             "outgoing_links": [
                 "/ai-testing"


### PR DESCRIPTION
## AI Native Onboarding: Your First 90 Days

New post at `/ai-native-onboarding` on applying AI to the first 90 days at a new job — the third in the `ai-native-*` series alongside `/ai-native-manager` and `/ai-native-vocab`.

**The lens:** what's *identical* in onboarding vs. what AI actually *transforms*, walked across a 30-60-90 arc.

**The reframe:** you're not onboarding one mind anymore — you're onboarding yourself *and* a whole team of AI agents at once. The notes you write to ramp yourself up are the same notes that prime them (and the next hire).

### Structure
- **You're Onboarding a Whole Team** — onboarding yourself *is* onboarding your agents; your `CLAUDE.md` is the shared onboarding notebook (Yegge calls agent priming "onboarding" on purpose).
- **What Doesn't Change** — intent is the high-order bit; only the mechanics change.
- **Day 0–30 · Learn** — codebase-as-tutor, build explainers, capture fresh-eyes confusion; what stays stubbornly human.
- **Day 30–60 · Contribute** — first PR can be bigger → the double-cognitive-debt trap; the newcomer's superpower.
- **Day 60–90 · Own** — the priming compounds; Toolsmith capstone; judgment is the real graduation.
- **The One Thing to Get Right** — the integral, not the point.

### Also in this PR
- Backlink from `/ai-native-manager`'s "what happens to junior engineers?" open question → this post.
- `ai_default_image: true` for the raccoon-ai-native social card (matches the sibling AI posts).
- Rebuilt `back-links.json`.

ai-slop label: **90%**.

![AI Native Onboarding](https://gist.githubusercontent.com/idvorkin-ai-tools/037e58f99f9c9fefc47098e2e8a3ffa1/raw/ai-native-onboarding.jpg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "AI Native Onboarding: Your First 90 Days" guide covering AI-assisted onboarding timelines and strategies.
  * Updated AI-native Manager article with link to new onboarding guidance.

* **Chores**
  * Updated route redirects and page metadata to support new content discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->