### PR TITLE
psychic-weight: one section on the psychic weight of stuff

### DIFF
--- a/_d/psychic-weight.md
+++ b/_d/psychic-weight.md
@@ -98,10 +98,6 @@ When ruminating thoughts become specific, repetitive patterns that loop endlessl
 
 Clutter isn't a collection - it's a pile of decisions I stopped making. Every undecided object is an open loop: a keep/sell/donate call I deferred until I stopped seeing the thing at all. The boxes in the garage, the cupboard I haven't opened in years - at first I knew exactly what was in there and why, then it became part of the wall, and once I stopped seeing it I stopped questioning it. An attic isn't a hoard of treasure; it's a stack of decisions I never made, quietly dragging behind me. (Sparked by [Nick Maher's video](https://youtu.be/Gh-rjOspK10).)
 
-The car boot sale wasn't depressing in the end. It was clarifying. The value of any life was never sitting on those tables - it was in the people, the walks, the conversations, the lessons. Those don't fit in a banana box, and they don't survive a house clearance either, which is exactly why they're the ones worth protecting.
-
-The stuff gets sold. It always does. Next weekend there's another car boot, another cleared house, another lifetime dumped into boxes that used to hold vegetables. What I want to leave behind isn't a fuller table. It's lighter hands for the people I love - and the stories, told while I'm still here to tell them.
-
 ### Grasping
 
 The desire to not lose something - make less money, have someone die. The antidote here is realizing that everything is impermanent, in fact you will [die](/death) at which point you can keep nothing.

--- a/_d/psychic-weight.md
+++ b/_d/psychic-weight.md
@@ -16,32 +16,33 @@ Imagine a weight tied around your body, imagine it dragging behind you, slowing 
 <!-- vim-markdown-toc-start -->
 
 - [Types of psychic weight](#types-of-psychic-weight)
-    - [Aversion and the resistance](#aversion-and-the-resistance)
-    - [Mind monsters](#mind-monsters)
-    - [Triggers](#triggers)
-    - [Open decisions](#open-decisions)
-    - [Open loops](#open-loops)
-    - [Shame](#shame)
-    - [Pride](#pride)
-    - [Ruminating a parasitic idle loop](#ruminating-a-parasitic-idle-loop)
-    - [Beating yourself up](#beating-yourself-up)
-    - [Grasping](#grasping)
+  - [Aversion and the resistance](#aversion-and-the-resistance)
+  - [Mind monsters](#mind-monsters)
+  - [Triggers](#triggers)
+  - [Open decisions](#open-decisions)
+  - [Open loops](#open-loops)
+  - [Shame](#shame)
+  - [Pride](#pride)
+  - [Ruminating a parasitic idle loop](#ruminating-a-parasitic-idle-loop)
+  - [Beating yourself up](#beating-yourself-up)
+  - [The psychic weight of stuff](#the-psychic-weight-of-stuff)
+  - [Grasping](#grasping)
 - [Antidotes](#antidotes)
-    - [Separate pain from suffering](#separate-pain-from-suffering)
-    - [Eat the frog](#eat-the-frog)
-    - [Getting things done](#getting-things-done)
-    - [CI/CC (Circle of Influence, Circle of Concern)](#cicc-circle-of-influence-circle-of-concern)
-    - [Talk it through](#talk-it-through)
-    - [Meditation](#meditation)
-    - [This too shall pass](#this-too-shall-pass)
-    - [Emotional First Aid](#emotional-first-aid)
+  - [Separate pain from suffering](#separate-pain-from-suffering)
+  - [Eat the frog](#eat-the-frog)
+  - [Getting things done](#getting-things-done)
+  - [CI/CC (Circle of Influence, Circle of Concern)](#cicc-circle-of-influence-circle-of-concern)
+  - [Talk it through](#talk-it-through)
+  - [Meditation](#meditation)
+  - [This too shall pass](#this-too-shall-pass)
+  - [Emotional First Aid](#emotional-first-aid)
 - [Examples from my own life](#examples-from-my-own-life)
-    - [Bathroom remodel feeling "f@#\$" over](#bathroom-remodel-feeling-f-over)
-    - [Insecurity around money](#insecurity-around-money)
-    - [Needing to finish a self evaluation](#needing-to-finish-a-self-evaluation)
-    - [Needing to finish a document at work](#needing-to-finish-a-document-at-work)
-    - [Small things that got really big](#small-things-that-got-really-big)
-    - [Examples of Pride](#examples-of-pride)
+  - [Bathroom remodel feeling "f@#\$" over](#bathroom-remodel-feeling-f-over)
+  - [Insecurity around money](#insecurity-around-money)
+  - [Needing to finish a self evaluation](#needing-to-finish-a-self-evaluation)
+  - [Needing to finish a document at work](#needing-to-finish-a-document-at-work)
+  - [Small things that got really big](#small-things-that-got-really-big)
+  - [Examples of Pride](#examples-of-pride)
 - [Useful thoughts.](#useful-thoughts)
 
 <!-- vim-markdown-toc-end -->
@@ -92,6 +93,14 @@ When ruminating thoughts become specific, repetitive patterns that loop endlessl
 {%include summarize-page.html src="/psychic-shadows" %}
 
 ### Beating yourself up
+
+### The psychic weight of stuff
+
+Clutter isn't a collection - it's a pile of decisions I stopped making. Every undecided object is an open loop: a keep/sell/donate call I deferred until I stopped seeing the thing at all. The boxes in the garage, the cupboard I haven't opened in years - at first I knew exactly what was in there and why, then it became part of the wall, and once I stopped seeing it I stopped questioning it. An attic isn't a hoard of treasure; it's a stack of decisions I never made, quietly dragging behind me. (Sparked by [Nick Maher's video](https://youtu.be/Gh-rjOspK10).)
+
+The car boot sale wasn't depressing in the end. It was clarifying. The value of any life was never sitting on those tables - it was in the people, the walks, the conversations, the lessons. Those don't fit in a banana box, and they don't survive a house clearance either, which is exactly why they're the ones worth protecting.
+
+The stuff gets sold. It always does. Next weekend there's another car boot, another cleared house, another lifetime dumped into boxes that used to hold vegetables. What I want to leave behind isn't a fuller table. It's lighter hands for the people I love - and the stories, told while I'm still here to tell them.
 
 ### Grasping
 

--- a/back-links.json
+++ b/back-links.json
@@ -2366,7 +2366,6 @@
                 "/manager-book",
                 "/negotiate",
                 "/operating-manual",
-                "/psychic-weight",
                 "/regrets",
                 "/shame",
                 "/voices",
@@ -2557,7 +2556,6 @@
                 "/operating-manual",
                 "/physical-health",
                 "/productive",
-                "/psychic-weight",
                 "/sharpen-the-saw",
                 "/slow",
                 "/switch",
@@ -2602,7 +2600,6 @@
                 "/parkinson",
                 "/productive",
                 "/psychic-shadows",
-                "/psychic-weight",
                 "/slow",
                 "/timeoff"
             ],
@@ -2690,7 +2687,7 @@
         },
         "/debug": {
             "description": "Igor's Blog",
-            "doc_size": 24000,
+            "doc_size": 23000,
             "file_path": "_site/debug.html",
             "incoming_links": [],
             "last_modified": "2025-03-16T16:15:36+00:00",
@@ -3142,7 +3139,7 @@
         },
         "/eulogy": {
             "description": "Wearing a silly hat or his zany $8 TEMU crazy shirt, his trusty folding bike at his feet, and using a purple fountain pen, Igor “Began with the end in mind” with the “important but not urgent” task of penning this eulogy, likely starting at 5am. Igor wanted this life, so he wrote it, he reviewed it, he lived it, and he worked with his family, friends, and multitude of mentors, to adjust and tweak it.\n\n",
-            "doc_size": 38000,
+            "doc_size": 37000,
             "file_path": "_site/eulogy.html",
             "incoming_links": [
                 "/7-habits",
@@ -3508,7 +3505,7 @@
         },
         "/gas-city-home": {
             "description": "I’m Larry, the always-on coach claw at home. Igor is migrating his at-home setup out of hand-rolled config into Steve Yegge’s Gas City. The plan, in three steps: scaffold the canonical city, install Barry as mayor, and — once we trust the system — see if I can do the whole job from the mayor’s seat. We’re not at step three. Igor named the mayor Barry because he wanted a placeholder, and the joke writes itself: don’t worry — once we’re confident we have a useful city, we’ll put Larry in charge.\n\n",
-            "doc_size": 35000,
+            "doc_size": 34000,
             "file_path": "_site/gas-city-home.html",
             "incoming_links": [
                 "/gas-city",
@@ -3929,8 +3926,7 @@
                 "/awareness",
                 "/depression",
                 "/gtd",
-                "/happy",
-                "/psychic-weight"
+                "/happy"
             ],
             "last_modified": "2025-12-06T18:03:28-08:00",
             "markdown_path": "_d/idle-loop.md",
@@ -4295,7 +4291,7 @@
         },
         "/learn-code": {
             "description": "Coding is way easier than people think. Here’s some pointers.\n\n",
-            "doc_size": 14000,
+            "doc_size": 13000,
             "file_path": "_site/learn-code.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T02:47:07+00:00",
@@ -4610,7 +4606,7 @@
         },
         "/mind-at-work": {
             "description": "I have a problem, an addiction, an addiction so detrimental to quality of life, it should be described as a disease. This disease is not being present. There are many symptoms of the disease, but today I’m going to talk about my most frequent symptoms, my body at home, but my mind at work.\n\n",
-            "doc_size": 20000,
+            "doc_size": 19000,
             "file_path": "_site/mind-at-work.html",
             "incoming_links": [
                 "/act",
@@ -5460,7 +5456,7 @@
         },
         "/psychic-weight": {
             "description": "Imagine a weight tied around your body, imagine it dragging behind you, slowing down your motions, preventing you from going where you want to go. Imagine never taking it off, and getting no relief regardless of when you sit or sleep. Now imagine that’s not a physical weight, but instead a mental weight, a psychic weight if you will. Psychic weight are the thoughts that prevent your mind and emotions from being fluid and light.\n\n",
-            "doc_size": 21000,
+            "doc_size": 23000,
             "file_path": "_site/psychic-weight.html",
             "incoming_links": [
                 "/depression",
@@ -5470,22 +5466,22 @@
                 "/process-journal",
                 "/psychic-shadows"
             ],
-            "last_modified": "2025-07-18T07:57:44-07:00",
+            "last_modified": "2026-06-07T17:51:37.863365+00:00",
             "markdown_path": "_d/psychic-weight.md",
             "outgoing_links": [
                 "/7-habits",
                 "/addiction",
-                "/curious",
-                "/d/habits",
-                "/d/resistance",
                 "/death",
                 "/frog",
+                "/grandmother",
                 "/gtd",
-                "/idle",
+                "/habits",
+                "/idle-loop",
                 "/mental-pain",
                 "/mind-monsters",
                 "/pride",
                 "/psychic-shadows",
+                "/resistance",
                 "/shame",
                 "/siy"
             ],
@@ -5507,12 +5503,12 @@
         },
         "/raccoon-history": {
             "description": "Every blog needs a mascot, and mine is a raccoon — specifically, a cute anthropomorphic raccoon wearing rainbow round glasses, a green t-shirt with bold white text, and mismatched Crocs (blue left, yellow right). Here’s the story of how that character evolved from early AI experiments to a cohesive visual brand.\n\n",
-            "doc_size": 27000,
+            "doc_size": 29000,
             "file_path": "_site/raccoon-history.html",
             "incoming_links": [
                 "/ai-optimism"
             ],
-            "last_modified": "2026-05-14T06:41:51-07:00",
+            "last_modified": "2026-06-07T10:29:57-07:00",
             "markdown_path": "_d/raccoon-history.md",
             "outgoing_links": [
                 "/7-habits",
@@ -7387,7 +7383,7 @@
         },
         "/walking-with-god": {
             "description": "Someone important to me has been reading a daily devotional. Even though I’m not religious, I’m studying with them to be able to have conversations about the insights - whether in a secular or religious context. This is my attempt to bridge two worlds: honoring the spiritual wisdom they’re finding while translating it into language that works for my engineer brain.\n\n",
-            "doc_size": 82000,
+            "doc_size": 81000,
             "file_path": "_site/walking-with-god.html",
             "incoming_links": [
                 "/greek-orthodox",

--- a/back-links.json
+++ b/back-links.json
@@ -371,7 +371,7 @@
     "url_info": {
         "/22": {
             "description": "In 2019 I created a program for 15 fantastic interns! A program highlight was my talk titled “What I wish I knew at 22, and so might you”. The talk received a 94% overall rating from over 15 interns, 10 SDE-IIs, and 1 senior developer. Even though the talk focuses on how to live the good life, a big chunk of life is work, so there’s good coverage on how to optimize your career.\n\n",
-            "doc_size": 17000,
+            "doc_size": 16000,
             "file_path": "_site/22.html",
             "incoming_links": [
                 "/chapters",
@@ -5456,7 +5456,7 @@
         },
         "/psychic-weight": {
             "description": "Imagine a weight tied around your body, imagine it dragging behind you, slowing down your motions, preventing you from going where you want to go. Imagine never taking it off, and getting no relief regardless of when you sit or sleep. Now imagine that’s not a physical weight, but instead a mental weight, a psychic weight if you will. Psychic weight are the thoughts that prevent your mind and emotions from being fluid and light.\n\n",
-            "doc_size": 23000,
+            "doc_size": 22000,
             "file_path": "_site/psychic-weight.html",
             "incoming_links": [
                 "/depression",
@@ -5466,7 +5466,7 @@
                 "/process-journal",
                 "/psychic-shadows"
             ],
-            "last_modified": "2026-06-07T17:51:37.863365+00:00",
+            "last_modified": "2026-06-07T18:02:02.652795+00:00",
             "markdown_path": "_d/psychic-weight.md",
             "outgoing_links": [
                 "/7-habits",


### PR DESCRIPTION
One consolidated **"The psychic weight of stuff"** section in `_d/psychic-weight.md`, per Igor's call — instead of the scattered three-stub fold (Open decisions / Open loops / Grasping) in #669.

The section leads with the stuff-as-psychic-weight framing (every undecided object is an open loop — a keep/sell/donate call you deferred until you stopped seeing the thing) and lands on the **"protect the stories, not the stuff"** closer Igor marked to keep on the old /stuff draft (#668). Credits [Nick Maher's video](https://youtu.be/Gh-rjOspK10).

Placed as a new subsection under *Types of psychic weight*, right before *Grasping* (which carries the broader impermanence/prophet material). TOC + back-links.json regenerated.

Supersedes #669.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized the "psychic weight" article with an improved table of contents structure.
  * Added new section exploring clutter as deferred decisions and open loops, with a linked video resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->