### PR TITLE
content(42): add Decline section anchored on "no one looks 50"

### DIFF
--- a/_d/42.md
+++ b/_d/42.md
@@ -16,6 +16,7 @@ You survived young kids, marriage, house, some easy crises, and now it's time fo
 - [The 40s in Context](#the-40s-in-context)
 - [Good news](#good-news)
 - [Bad news](#bad-news)
+- [Decline - the self-fulfilling prophecy](#decline---the-self-fulfilling-prophecy)
 - [Pondering Some Time Off](#pondering-some-time-off)
   - [The Gap Year Alternative: Why Wait Until 65?](#the-gap-year-alternative-why-wait-until-65)
   - [Some lies about retirement](#some-lies-about-retirement)
@@ -24,10 +25,10 @@ You survived young kids, marriage, house, some easy crises, and now it's time fo
 - [Health - Goodbye my friend](#health---goodbye-my-friend)
   - [Colonoscopy: The Camera Nobody Wants to Be In Front Of](#colonoscopy-the-camera-nobody-wants-to-be-in-front-of)
   - [Vision: Welcome to the Arm's Length Club](#vision-welcome-to-the-arms-length-club)
+  - [Hearing: Can you turn that up?](#hearing-can-you-turn-that-up)
   - [Other Health Stuff](#other-health-stuff)
 - [Themes](#themes)
   - [Optimizing vs Satisfying](#optimizing-vs-satisfying)
-- [Decline - the self-fulfilling prophecy](#decline---the-self-fulfilling-prophecy)
 - [Some ideas from Ammon](#some-ideas-from-ammon)
 - [more ideas](#more-ideas)
 
@@ -55,6 +56,22 @@ For a broader perspective on how the 40s fit into life's chapters:
 
 - Your per-domain peak is done.
 - Your health is starting to decline, and without active investment will fall sharply
+
+# Decline - the self-fulfilling prophecy
+
+> No one looks 50. They either look 40 because they're fighting for their life, or 60 because they gave up.
+
+I notice this at reunions. Same graduating class, same number on the birth certificate, two different people standing across the room. One is lean and curious and still picking things up. The other settled into the chair a decade ago - body, wardrobe, and opinions all frozen around the year they decided they were done.
+
+The gap isn't mostly genetics. It's a prophecy you write for yourself in your 40s and then spend the next decade making come true. "I'm getting old" skips the walk, and skipping the walk makes you older. "I'm not done yet" takes the stairs, and taking the stairs keeps you not-done. Each small choice is a vote for the version of 60 you're going to become.
+
+Decline is real - that's the bad news. But the _rate_ of decline is negotiable, and the story you tell yourself sets the dial. The work you do now is both the starting line and the slope. Your 40s are where you pick which 60 you get.
+
+What I'm trying to hold onto:
+
+- **Move toward the fight.** When something gets harder, that's the argument for doing it, not the excuse to quit it.
+- **Don't pre-retire your body.** It's easy to quietly cancel the things that keep you young - running, lifting, playing - and call it maturity. It isn't.
+- **Audit the "I'm too old" reflex.** Sometimes it's wisdom. Often it's the prophecy talking. Catch it and ask which one it is.
 
 # Pondering Some Time Off
 
@@ -167,8 +184,6 @@ While we're on the topic of age-related changes, your ears also need attention. 
 
 ### Optimizing vs Satisfying
 
-# Decline - the self-fulfilling prophecy
-
 # Some ideas from Ammon
 
 - Money isn't everything. Try to get enough money, then turn your focus to other pursuits. While you're getting enough money, don't forget everything else.
@@ -179,5 +194,4 @@ While we're on the topic of age-related changes, your ears also need attention. 
 - Prepare for the day when your employer casts you aside in favor of someone younger who has eagerly drank the kool aid and will work cheap.
 - Don't think about the past unless it's a happy memory. Don't re-examine negative outcomes through the parallax view of the present.
 - This is your peak earnings, and peak productivity. You've got maximum experience and minimal mental decline.
-- As you get older, you will decline, the work you do in your 40s will be the starting point for your decline, and simultaneously impact your rate of decline.
 - If you always wanted a motorcycle or boat or tattoo or Corvette or whatever, now is the time to buy such things if you're able. Don't be upset if you can't afford such things as you've made it

--- a/back-links.json
+++ b/back-links.json
@@ -387,7 +387,7 @@
                 "/y25",
                 "/y26"
             ],
-            "last_modified": "2026-01-03T17:27:23+00:00",
+            "last_modified": "2026-06-07T17:47:24.420898+00:00",
             "markdown_path": "_d/42.md",
             "outgoing_links": [
                 "/chapters",


### PR DESCRIPTION
## What

Promotes **Decline - the self-fulfilling prophecy** in `/42` ("What I wish I knew at 42") from a buried empty stub (#9, after Themes) up to **#4, right after Bad news**, and anchors it on a new epigraph:

> No one looks 50. They either look 40 because they're fighting for their life, or 60 because they gave up.

This line is the punchy, memorable version of the talk's whole decline thesis, so it now opens the section instead of being stranded near the bottom.

## Changes

- New **Decline** section: epigraph + reunion observation + the "prophecy, not genetics" framing + a short "what I'm trying to hold onto" list.
- Folded the redundant rate-of-decline bullet from *more ideas* into the new section (it was the dry restatement of the same point).
- Removed the old empty Decline stub from its #9 slot.
- Regenerated the TOC (`:Mtoc update`) so Decline now sits at #4.

## Screenshot

![Decline section](https://gist.githubusercontent.com/idvorkin-ai-tools/9fa757839559358b63a0ec924db3b3c2/raw/decline-section.jpg)

## Notes

Voice follows `how igor ticks` (Personal Philosophy): first-person, concrete, no AI tells. `prek` passes (internal links, anchors, backlinks). Three section stubs remain for a later pass: **Balance**, **Themes** intro, **Optimizing vs Satisfying**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
