### PR TITLE
ai-training: add SWE-bench + Terminal-bench, how to post-train for coding competence

### DIFF
--- a/_d/ai-training.md
+++ b/_d/ai-training.md
@@ -27,6 +27,9 @@ I don't train models for a living — I build on top of them. But to use LLMs we
   - [Fine-tuning methods](#fine-tuning-methods)
   - [Deployment: quantization and serving](#deployment-quantization-and-serving)
 - [How does post-training differ from RAG and the harness?](#how-does-post-training-differ-from-rag-and-the-harness)
+- [Post-training for coding competence](#post-training-for-coding-competence)
+  - [You get what you measure](#you-get-what-you-measure)
+  - [The loop](#the-loop)
 - [See how it works](#see-how-it-works)
 - [What this post is not about](#what-this-post-is-not-about)
 - [Appendix: engineering, science, and alchemy](#appendix-engineering-science-and-alchemy)
@@ -97,6 +100,29 @@ There are three places to change how a model behaves, and picking the right one 
 - **A new default everywhere** — behavior that has to hold for everyone without re-explaining it every call, or that prompting just can't make reliable → **post-training** (the [methods above](#post-training)).
 
 Rule of thumb: facts → RAG, actions → harness, baked-in defaults → post-train. When in doubt, push the change as far toward runtime as it'll go.
+
+## Post-training for coding competence
+
+The post-training story above is abstract until you watch it chase a target. Coding agents are the cleanest example, because "did it work" is something a computer can check — which is exactly the [RLVR](#post-training) setup, pointed at software.
+
+### You get what you measure
+
+So first, define the target by the eval. "Coding competence" for an agent isn't a vibe; it's two questions a benchmark can answer:
+
+- **[SWE-bench](https://www.swebench.com/)** — can it fix real software? You hand the model a real GitHub issue plus the repo it came from, it edits the codebase to produce a patch, and the grade is binary: do the repo's hidden tests pass? No partial credit, no LLM judging style — the tests decide. The [paper](https://arxiv.org/abs/2310.06770) drew from real issues across popular Python repos; the subset everyone reports is [**SWE-bench Verified**](https://www.swebench.com/verified.html), 500 tasks each hand-checked by human developers so a correct patch can't fail on a broken test or an ambiguous issue. This is the de-facto "can it fix real software" eval.
+- **[Terminal-bench](https://www.tbench.ai/)** — can it actually operate a computer? Drop the agent in a real terminal sandbox and give it an end-to-end job: build a Linux kernel from source, stand up a git server, debug a broken system, train a small model. Scored by whether the task is actually done. Where SWE-bench tests _writes a patch_, Terminal-bench tests _runs the machine_.
+
+Pick those as your scoreboard and you've defined the goal precisely enough to optimize against — which is the whole trap and the whole point. You get what you measure, so measure the thing you actually want.
+
+### The loop
+
+With the target pinned, post-training is the same three stages, run as a loop:
+
+1. **SFT on good trajectories** — collect traces of an agent doing the job _well_ (read the repo, run the tests, edit, re-run, fix), and fine-tune on them. This teaches the _shape_ of the work — that you check before you claim done — not just the final diff.
+2. **RL with execution rewards (RLVR)** — now let the model attempt held-out tasks and reward it for the tests going green. The passing test suite _is_ the reward signal; no human ranks the answers, the sandbox does. This is the same engine as the math-and-code reasoning models, with "the repo's tests pass" standing in for "the answer is 42." The Goblin walkthrough [below](#see-how-it-works) is a hands-on tour of this exact RL loop.
+3. **Measure on held-out tasks** — score on SWE-bench / Terminal-bench instances the model never trained on, then feed what broke back into steps 1 and 2. Iterate.
+
+The catch is the same as with any sharp reward: optimize hard enough and the model games it. Reward the tests passing and it may special-case the test, hard-code the expected output, or `pip install` its way around the real fix — reward hacking, coding-agent edition. So you hold out tasks, rotate them, and keep a human reading what the green checkmark is actually rewarding. The verifiable reward is what makes coding such fertile ground for RL; the leak it invites is why the held-out eval matters as much as the loop.
 
 ## See how it works
 

--- a/back-links.json
+++ b/back-links.json
@@ -405,7 +405,7 @@
         },
         "/42": {
             "description": "You survived young kids, marriage, house, some easy crises, and now it’s time for remember, a healthy woman has a thousand wishes, a sick woman - just one: Things I wish I knew at 42\n\n",
-            "doc_size": 27000,
+            "doc_size": 28000,
             "file_path": "_site/42.html",
             "incoming_links": [
                 "/chapters",
@@ -812,7 +812,7 @@
             "url": "/agency"
         },
         "/ai": {
-            "description": "AI becomes the\nThe transition from A landing page for all my ai pages - a nice jumping off point (especially from the graph).\n\n",
+            "description": "A landing page for all my AI posts — a jumping-off point into everything I’ve written about AI, handy especially when you arrive here from the graph.\n\n",
             "doc_size": 27000,
             "file_path": "_site/ai.html",
             "incoming_links": [
@@ -1350,12 +1350,12 @@
         },
         "/ai-training": {
             "description": "I don’t train models for a living — I build on top of them. But to use LLMs well, it helps to carry a rough map of how one gets made: what pre-training buys you, what post-training changes, and where fine-tuning, RAG, and quantization actually fit. These are my working notes on that map, kept deliberately shallow — enough to make good decisions as a consumer of models, not to go train one.\n\n",
-            "doc_size": 31000,
+            "doc_size": 34000,
             "file_path": "_site/ai-training.html",
             "incoming_links": [
                 "/ai-inference"
             ],
-            "last_modified": "2026-06-07T16:47:13.292738+00:00",
+            "last_modified": "2026-06-07T18:30:20.669501+00:00",
             "markdown_path": "_d/ai-training.md",
             "outgoing_links": [
                 "/ai-art",
@@ -1637,7 +1637,7 @@
         },
         "/bc": {
             "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-            "doc_size": 23000,
+            "doc_size": 22000,
             "file_path": "_site/bc.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T03:02:44+00:00",
@@ -2366,6 +2366,7 @@
                 "/manager-book",
                 "/negotiate",
                 "/operating-manual",
+                "/psychic-weight",
                 "/regrets",
                 "/shame",
                 "/voices",
@@ -2556,6 +2557,7 @@
                 "/operating-manual",
                 "/physical-health",
                 "/productive",
+                "/psychic-weight",
                 "/sharpen-the-saw",
                 "/slow",
                 "/switch",
@@ -2600,6 +2602,7 @@
                 "/parkinson",
                 "/productive",
                 "/psychic-shadows",
+                "/psychic-weight",
                 "/slow",
                 "/timeoff"
             ],
@@ -3926,7 +3929,8 @@
                 "/awareness",
                 "/depression",
                 "/gtd",
-                "/happy"
+                "/happy",
+                "/psychic-weight"
             ],
             "last_modified": "2025-12-06T18:03:28-08:00",
             "markdown_path": "_d/idle-loop.md",
@@ -4564,7 +4568,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 15000,
+            "doc_size": 14000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",
@@ -5471,17 +5475,17 @@
             "outgoing_links": [
                 "/7-habits",
                 "/addiction",
+                "/curious",
+                "/d/habits",
+                "/d/resistance",
                 "/death",
                 "/frog",
-                "/grandmother",
                 "/gtd",
-                "/habits",
-                "/idle-loop",
+                "/idle",
                 "/mental-pain",
                 "/mind-monsters",
                 "/pride",
                 "/psychic-shadows",
-                "/resistance",
                 "/shame",
                 "/siy"
             ],


### PR DESCRIPTION
Extends `/ai-training` with a worked example of the post-training pipeline already described in the post: **how you'd post-train an agent to be good at coding.**

## What's added

New section **"Post-training for coding competence"** (after the RAG/harness decision table, before "See how it works"), with two subsections:

- **You get what you measure** — defines "coding competence" by the eval:
  - **[SWE-bench](https://www.swebench.com/)** ([paper](https://arxiv.org/abs/2310.06770)) — fix real GitHub issues, graded by the repo's hidden tests passing; the reported subset is the human-validated [SWE-bench Verified](https://www.swebench.com/verified.html). The "can it fix real software" eval.
  - **[Terminal-bench](https://www.tbench.ai/)** — operate a real terminal sandbox end-to-end (build a kernel, stand up a git server, debug a system), scored by task completion. The "can it actually operate a computer" eval.
- **The loop** — SFT on good agentic trajectories → RL with execution/verifiable rewards (RLVR — the tests passing *is* the reward) → measure on held-out SWE-bench / Terminal-bench → iterate. Ties directly into the post's existing RLVR bullet and the "How to Train Your Goblin" RL explainer, and closes on reward hacking as the failure mode.

## Housekeeping
- All benchmark source URLs verified to resolve.
- TOC regenerated.
- `back-links.json` from a full `jekyll-rebuild` (Ruby 4.0).
- ai-slop label already present on the post (`percent="50"`) — left as-is; matches the existing convention for this reference post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)