### PR TITLE
chore(back-links): rebuild back-links.json from current content

### DIFF
--- a/back-links.json
+++ b/back-links.json
@@ -371,7 +371,7 @@
     "url_info": {
         "/22": {
             "description": "In 2019 I created a program for 15 fantastic interns! A program highlight was my talk titled “What I wish I knew at 22, and so might you”. The talk received a 94% overall rating from over 15 interns, 10 SDE-IIs, and 1 senior developer. Even though the talk focuses on how to live the good life, a big chunk of life is work, so there’s good coverage on how to optimize your career.\n\n",
-            "doc_size": 16000,
+            "doc_size": 17000,
             "file_path": "_site/22.html",
             "incoming_links": [
                 "/chapters",
@@ -405,7 +405,7 @@
         },
         "/42": {
             "description": "You survived young kids, marriage, house, some easy crises, and now it’s time for remember, a healthy woman has a thousand wishes, a sick woman - just one: Things I wish I knew at 42\n\n",
-            "doc_size": 27000,
+            "doc_size": 28000,
             "file_path": "_site/42.html",
             "incoming_links": [
                 "/chapters",
@@ -812,7 +812,7 @@
             "url": "/agency"
         },
         "/ai": {
-            "description": "AI becomes the\nThe transition from A landing page for all my ai pages - a nice jumping off point (especially from the graph).\n\n",
+            "description": "A landing page for all my AI posts — a jumping-off point into everything I’ve written about AI, handy especially when you arrive here from the graph.\n\n",
             "doc_size": 27000,
             "file_path": "_site/ai.html",
             "incoming_links": [
@@ -2366,6 +2366,7 @@
                 "/manager-book",
                 "/negotiate",
                 "/operating-manual",
+                "/psychic-weight",
                 "/regrets",
                 "/shame",
                 "/voices",
@@ -2556,6 +2557,7 @@
                 "/operating-manual",
                 "/physical-health",
                 "/productive",
+                "/psychic-weight",
                 "/sharpen-the-saw",
                 "/slow",
                 "/switch",
@@ -2600,6 +2602,7 @@
                 "/parkinson",
                 "/productive",
                 "/psychic-shadows",
+                "/psychic-weight",
                 "/slow",
                 "/timeoff"
             ],
@@ -3926,7 +3929,8 @@
                 "/awareness",
                 "/depression",
                 "/gtd",
-                "/happy"
+                "/happy",
+                "/psychic-weight"
             ],
             "last_modified": "2025-12-06T18:03:28-08:00",
             "markdown_path": "_d/idle-loop.md",
@@ -5471,17 +5475,17 @@
             "outgoing_links": [
                 "/7-habits",
                 "/addiction",
+                "/curious",
+                "/d/habits",
+                "/d/resistance",
                 "/death",
                 "/frog",
-                "/grandmother",
                 "/gtd",
-                "/habits",
-                "/idle-loop",
+                "/idle",
                 "/mental-pain",
                 "/mind-monsters",
                 "/pride",
                 "/psychic-shadows",
-                "/resistance",
                 "/shame",
                 "/siy"
             ],
@@ -7383,7 +7387,7 @@
         },
         "/walking-with-god": {
             "description": "Someone important to me has been reading a daily devotional. Even though I’m not religious, I’m studying with them to be able to have conversations about the insights - whether in a secular or religious context. This is my attempt to bridge two worlds: honoring the spiritual wisdom they’re finding while translating it into language that works for my engineer brain.\n\n",
-            "doc_size": 81000,
+            "doc_size": 82000,
             "file_path": "_site/walking-with-god.html",
             "incoming_links": [
                 "/greek-orthodox",


### PR DESCRIPTION
## What

Rebuilds `back-links.json`, the inbound-link index that powers the **"Mentioned in:"** section on every post.

## Why

Seven content commits landed on `main` after the previous backlinks rebuild (`55cd1d11b`) without a subsequent refresh, so the index had drifted from the live content. This regenerates it.

Captured changes:
- **New `/psychic-weight` incoming links** across several posts (e.g. `/idle-loop`) — from the new psychic-weight cross-links
- **Corrected `/ai` landing-page description** — the garbled-intro fix is now reflected in the index
- **Updated `doc_size`** for posts that gained sections (`/22`, `/42`, `/walking-with-god`)
- Outgoing-link restructuring on one post to match current HTML

## Base-branch note

Built and based off **`main` (canonical / `upstream/main`)**, not the fork's stale `origin/main` (10 commits behind at build time). Backlinks must be computed from current content, and a clean backlinks-only diff requires basing off the branch the PR targets. The dispatch's `base_branch=origin/main` assumed the fork was synced; it wasn't, and syncing it would require pushing to a `main` (disallowed by policy).

## Verification

- Diff is **backlinks-only**: 1 file changed, 13 insertions(+), 9 deletions(-)
- JSON validated (346 pages, 367 redirects, 1406 links)
- All pre-commit gates passed: **Dasel JSON validator**, **Biome**, **Fast Tests**

## How it was built

```
bundle exec jekyll build            # Ruby 4.0.3 + _ruby_compat.rb shim
uv run ./build_back_links.py build  # reads _site/, writes back-links.json
```

No screenshot — this is a data-index change with no visual rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
