### PR TITLE
Drop Ruby 3.1: bump backlinks CI to 3.2, remove obsolete ruby@3.1 fallback

### DIFF
--- a/.github/workflows/update-backlinks.yml
+++ b/.github/workflows/update-backlinks.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.2'
           bundler-cache: true
 
       - run: bundle exec jekyll build --config _config.yml,_config_ci.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,17 +51,7 @@ Why it matters: the inbound "Mentioned in:" section on every linked post reads f
 
 `build_back_links.py build` reads from `_site/` (built HTML), so a fresh Jekyll build must succeed first. **The local build works on Ruby 4.x** (verified 2026-06): liquid-4.0.3 guards its only `tainted?` call — `obj.respond_to?(:tainted?) && obj.tainted?` (`variable.rb:124`) — so on Ruby 3.2+/4.x the removed method short-circuits, no crash. Just run `bundle exec jekyll build`. A **stale or missing `_site/`** is what makes the backlinks rebuild error out or emit stale entries — not the Ruby version.
 
-**Fallback** (only if a future liquid drops that `respond_to?` guard and the build actually fails on Ruby 4.x):
-
-```bash
-brew install ruby@3.1
-export PATH=/home/linuxbrew/.linuxbrew/opt/ruby@3.1/bin:$PATH
-bundle install   # populates ~/.bundle-larry-blog or similar
-bundle exec jekyll build
-just update-backlinks
-```
-
-CI uses Ruby 3.1 and is unaffected. This rule lives here so future agents on Ruby 4.x dev VMs don't waste time chasing the wrong root cause.
+CI builds on Ruby 3.2 (matching `.ruby-version` = 3.2.8). As of 2026-06 no Ruby workaround is needed locally — `bundle exec jekyll build` works on 4.x. Only if a future liquid drops that `respond_to?` guard would you pin an older Ruby (`brew install ruby@3.2`).
 
 When superseding a PR you opened on `idvorkin/*`, **close it yourself** — `gh pr close <N> --repo idvorkin/<repo> --comment "Superseded by #M — …"` works for the `idvorkin-ai-tools` actor on PRs it authored. Don't leave orphan PRs for Igor to clean up.
 


### PR DESCRIPTION
Removes the last 'Ruby 3.1' references now that the build works on 3.2+/4.x (liquid-4.0.3 guards its `tainted?` call — see #678).

- **`.github/workflows/update-backlinks.yml`**: `ruby-version: '3.1'` → `'3.2'` (aligns CI with `.ruby-version` = 3.2.8; was the only real 3.1 pin).
- **`CLAUDE.md`**: drop the obsolete `brew install ruby@3.1` fallback block; note CI is on 3.2 and no local workaround is needed.

Low-risk: the Jekyll build succeeds on 3.2+ (the `respond_to?(:tainted?)` guard short-circuits the removed method). **Watch the next `update-backlinks` run go green** to confirm CI on 3.2. (`.ruby-version` stays 3.2.8; going fully to Ruby 4.x in CI is a separate, bigger step.)

The lychee 'Failed URLs: CLAUDE.md' check is a non-blocking false positive (parses `variable.rb:124` as a link).