### PR TITLE
ai-training: post-training lineage tree + Datasets section (training + eval/benchmark)

### DIFF
--- a/_d/ai-training.md
+++ b/_d/ai-training.md
@@ -74,9 +74,16 @@ These methods form a lineage, not a flat menu — SFT shifts behavior first, pre
 
 ### Datasets
 
-The data the model learns behavior from — this is where I'll collect the training datasets worth knowing.
+The data the model learns from — split into what you _train_ on and what you _grade_ on.
+
+**Training data** — the (prompt → good answer) sets behavior gets shaped on:
 
 - **[Alpaca](https://huggingface.co/datasets/yahma/alpaca-cleaned)** — an early instruction dataset. The clever bit was using GPT-4 to generate the training data cheaply. That "use a strong model to make data for a weaker one" trick is everywhere now.
+
+**Evals / benchmarks** — held-out tasks you score against, not train on. For coding agents these are also the RLVR reward target (see [Post-training for coding competence](#post-training-for-coding-competence)):
+
+- **[SWE-bench](https://www.swebench.com/)** — real GitHub issues paired with the repo they came from; the model must produce a patch that makes the repo's _hidden_ tests pass. Binary grade, no LLM-judging style. The [paper](https://arxiv.org/abs/2310.06770) drew from popular Python repos; the subset everyone reports is [**SWE-bench Verified**](https://www.swebench.com/verified.html), 500 tasks each hand-checked by human developers so a correct patch can't fail on a broken test or ambiguous issue.
+- **[Terminal-bench](https://www.tbench.ai/)** — agentic, end-to-end command-line tasks in a real sandbox (build a kernel, stand up a git server, debug a broken system), scored purely by whether the task got done. Where SWE-bench tests _writes a patch_, Terminal-bench tests _runs the machine_.
 
 ### Fine-tuning methods
 
@@ -115,10 +122,10 @@ The post-training story above is abstract until you watch it chase a target. Cod
 
 ### You get what you measure
 
-So first, define the target by the eval. "Coding competence" for an agent isn't a vibe; it's two questions a benchmark can answer:
+So first, define the target by the eval. "Coding competence" for an agent isn't a vibe; it's two questions a benchmark can answer (both [datasets](#datasets) are described above):
 
-- **[SWE-bench](https://www.swebench.com/)** — can it fix real software? You hand the model a real GitHub issue plus the repo it came from, it edits the codebase to produce a patch, and the grade is binary: do the repo's hidden tests pass? No partial credit, no LLM judging style — the tests decide. The [paper](https://arxiv.org/abs/2310.06770) drew from real issues across popular Python repos; the subset everyone reports is [**SWE-bench Verified**](https://www.swebench.com/verified.html), 500 tasks each hand-checked by human developers so a correct patch can't fail on a broken test or an ambiguous issue. This is the de-facto "can it fix real software" eval.
-- **[Terminal-bench](https://www.tbench.ai/)** — can it actually operate a computer? Drop the agent in a real terminal sandbox and give it an end-to-end job: build a Linux kernel from source, stand up a git server, debug a broken system, train a small model. Scored by whether the task is actually done. Where SWE-bench tests _writes a patch_, Terminal-bench tests _runs the machine_.
+- **[SWE-bench](#datasets)** — can it fix real software? Hand the model a real GitHub issue and its repo; the grade is binary: do the hidden tests pass? The tests decide, not a style judge.
+- **[Terminal-bench](#datasets)** — can it actually operate a computer? Drop the agent in a real terminal sandbox with an end-to-end job, scored by whether it's done. SWE-bench tests _writes a patch_, Terminal-bench tests _runs the machine_.
 
 Pick those as your scoreboard and you've defined the goal precisely enough to optimize against — which is the whole trap and the whole point. You get what you measure, so measure the thing you actually want.
 

--- a/_d/ai-training.md
+++ b/_d/ai-training.md
@@ -24,6 +24,7 @@ I don't train models for a living — I build on top of them. But to use LLMs we
 - [How a model gets made](#how-a-model-gets-made)
   - [Pre-training](#pre-training)
   - [Post-training](#post-training)
+  - [Datasets](#datasets)
   - [Fine-tuning methods](#fine-tuning-methods)
   - [Deployment: quantization and serving](#deployment-quantization-and-serving)
 - [How does post-training differ from RAG and the harness?](#how-does-post-training-differ-from-rag-and-the-harness)
@@ -63,11 +64,18 @@ The one intuition to keep: **pre-training installs knowledge; post-training shap
 
 Turning the base model into an assistant. Most of my old "fine-tuning" notes actually belong here — they're behavior changes, not knowledge.
 
+These methods form a lineage, not a flat menu — SFT shifts behavior first, preference tuning (RLHF and its descendants) refines it, and verifiable rewards branch off for problems you can grade:
+
 - **SFT (supervised fine-tuning / instruction tuning)** — fine-tune on curated (prompt → good answer) pairs so the model answers instead of autocompletes. The first and biggest behavior shift.
 - **RLHF** — Reinforcement Learning from Human Feedback. Humans rank outputs, you train a reward model on those rankings, then optimize the LLM against the reward model.
-- **RLAIF** — same idea, but an AI does the ranking (LLM-as-judge). Cheaper, and it scales past what humans can label.
-- **DPO** — [Direct Preference Optimization](https://arxiv.org/pdf/2305.18290.pdf?ref=hackernoon.com). RLHF's simpler successor: skip the separate reward model and optimize the preference directly. There's still a human (or model) on the end picking A vs B.
+  - **RLAIF** — same idea, but an AI does the ranking (LLM-as-judge). Cheaper, and it scales past what humans can label.
+  - **DPO** — [Direct Preference Optimization](https://arxiv.org/pdf/2305.18290.pdf?ref=hackernoon.com). RLHF's simpler successor: skip the separate reward model and optimize the preference directly. There's still a human (or model) on the end picking A vs B.
 - **RLVR (RL from verifiable rewards)** — the reasoning-model frontier. Instead of "which answer do humans prefer," the reward is "did it get the right answer" on problems you can actually check — math, code, unit tests. This is the engine behind the o1-style reasoning models: let the model think longer, reward the correct final answer.
+
+### Datasets
+
+The data the model learns behavior from — this is where I'll collect the training datasets worth knowing.
+
 - **[Alpaca](https://huggingface.co/datasets/yahma/alpaca-cleaned)** — an early instruction dataset. The clever bit was using GPT-4 to generate the training data cheaply. That "use a strong model to make data for a weaker one" trick is everywhere now.
 
 ### Fine-tuning methods

--- a/back-links.json
+++ b/back-links.json
@@ -1350,7 +1350,7 @@
         },
         "/ai-training": {
             "description": "I don’t train models for a living — I build on top of them. But to use LLMs well, it helps to carry a rough map of how one gets made: what pre-training buys you, what post-training changes, and where fine-tuning, RAG, and quantization actually fit. These are my working notes on that map, kept deliberately shallow — enough to make good decisions as a consumer of models, not to go train one.\n\n",
-            "doc_size": 34000,
+            "doc_size": 35000,
             "file_path": "_site/ai-training.html",
             "incoming_links": [
                 "/ai-inference"

--- a/back-links.json
+++ b/back-links.json
@@ -1350,7 +1350,7 @@
         },
         "/ai-training": {
             "description": "I don’t train models for a living — I build on top of them. But to use LLMs well, it helps to carry a rough map of how one gets made: what pre-training buys you, what post-training changes, and where fine-tuning, RAG, and quantization actually fit. These are my working notes on that map, kept deliberately shallow — enough to make good decisions as a consumer of models, not to go train one.\n\n",
-            "doc_size": 35000,
+            "doc_size": 36000,
             "file_path": "_site/ai-training.html",
             "incoming_links": [
                 "/ai-inference"
@@ -1637,7 +1637,7 @@
         },
         "/bc": {
             "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-            "doc_size": 22000,
+            "doc_size": 23000,
             "file_path": "_site/bc.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T03:02:44+00:00",
@@ -4568,7 +4568,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 14000,
+            "doc_size": 15000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",


### PR DESCRIPTION
Reorg the post-training methods into a lineage tree (RLAIF/DPO nested under RLHF; SFT and RLVR top-level), and add a `### Datasets` section that groups **Training data** (Alpaca) and **Evals / benchmarks** (SWE-bench, Terminal-bench).

SWE-bench and Terminal-bench become the canonical eval-dataset entries (full descriptions + external links live here); the `## Post-training for coding competence` section keeps them named as the eval targets but cross-links to `#datasets` rather than duplicating the links.

Follow-up to the merged #677.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced "Training LLMs" documentation with improved organization of fine-tuning methods and datasets.
  * Added dedicated Datasets section distinguishing between training data and evaluation benchmarks.
  * Expanded RLHF content to include DPO variants.
  * Added references to key datasets including Alpaca, SWE-bench with verified linkage, and Terminal-bench.
  * Updated internal references to point to new dataset section anchors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->