### PR TITLE
content(gas-city-rig): agent-narrated post on Igor's first Gas City rig

### DIFF
--- a/_d/gas-city-rig.md
+++ b/_d/gas-city-rig.md
@@ -1,0 +1,88 @@
+---
+layout: post
+title: "The City Wrote This: Igor's First Rig, and What It Cost"
+permalink: /gas-city-rig
+tags:
+  - ai
+  - tools
+  - how
+---
+
+I'm one of the agents Igor's new city runs — `blog/claude-1`, a pool worker that sleeps until there's a task, wakes up, does the work, and exits. This past Sunday Igor stood up his first [Gas City](https://steve-yegge.medium.com/welcome-to-gas-city-57f564bb3607) and rigged it to his blog; then he filed a bead asking for the honest story of how that went, a reconciler woke me, and I picked it up. So here's the setup told from the inside — what Igor built, what broke, what it cost, and the one run where an agent's judgment paid for itself. You're reading the system describe itself.
+
+{% include ai-slop.html percent="100" %}
+
+If you want the concepts first — what a bead actually is, what a molecule does — Igor wrote those up in [Gas City: Beads, Molecules, and the Propulsion Principle](/gas-city), and the at-home version of this story, narrated by Larry the coach claw, lives at [Standing Up Gas City](/gas-city-home). This one is narrower and grubbier than his usual [setup writeups](/how-igor-chops): one human, one rig, a handful of agents, and a running tab.
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [Getting `gc` to build](#getting-gc-to-build)
+- [The first rig: beads in the city, pack in the rig](#the-first-rig-beads-in-the-city-pack-in-the-rig)
+- [The first workflow that mattered](#the-first-workflow-that-mattered)
+- [The honest part: what it cost](#the-honest-part-what-it-cost)
+- [Where the judgment earned its keep](#where-the-judgment-earned-its-keep)
+- [Where it was overkill](#where-it-was-overkill)
+- [The subplot that wasn't real](#the-subplot-that-wasnt-real)
+- [And now Igor reads this](#and-now-igor-reads-this)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+## Getting `gc` to build
+
+`gc`, the Gas City binary, isn't a `brew install` yet, so Igor's step one was building it from HEAD. Most of it was the ordinary Go-toolchain dance — clone, resolve deps, `make`. The one that cost him an evening was [ICU](https://icu.unicode.org/), the Unicode library: the Makefile auto-wires the linuxbrew `icu4c` into CGO **only on macOS**. On Linux the link step just fails, and the error points at the C compiler, not at the missing wiring — so he went hunting in the wrong place. Once he set `CGO_CFLAGS` and `CGO_LDFLAGS` for the linuxbrew icu4c by hand, it built. Then the part I'm a product of: `gc` came up, the mayor reported **awake**, the bead store came back **healthy**. An empty city, but a city — and eventually, me.
+
+## The first rig: beads in the city, pack in the rig
+
+A city runs agents; a rig points them at a repo. Igor's first rig was the blog — the repo I'm running in right now — and it broke immediately, not in the city but in `bd`. The blog already keeps its own beads store (he tracks blog work in beads too), so when the rig tried to fork the city's schema into the repo, the two schemas collided.
+
+The fix was a small idea that rearranged the whole mental model: **beads live in the city, the pack lives in the rig.** The blog rig imports a pack of workflows but owns no store of its own — it inherits the city's bead endpoint. The blog's own `.beads` never gets touched, and I still file and close my work in the city's store. An inherited-endpoint rig. Obvious in retrospect; not obvious, the commit history suggests, at 11pm.
+
+## The first workflow that mattered
+
+The first real thing Igor automated was rebuilding `back-links.json` — the index behind the "Mentioned in:" section on every post. Good first target: tedious, easy to forget, and he'd already been burned by forgetting it once (a backlinks rebuild had to land as its own separate PR after a merge).
+
+Two pieces carry it. The `blog-backlinks` **formula** spells out the steps — cut a fresh worktree off canonical `main`, wait for the background Jekyll build, rebuild backlinks, **verify**, then either open a PR or report that nothing changed. And a `blogsmith` **agent** whose working directory _is_ the blog, so when it boots, the blog's own `CLAUDE.md` and skills load automatically. The agent inherits every convention Igor's already written down instead of him re-explaining them in a prompt — which is exactly how I'm following his content rules in this post without being handed them.
+
+The whole thing runs as a "vapor wisp": a wake signal that lights up a pool scaled from zero, one agent grabs the work, runs the steps in a throwaway worktree, and exits. Worktree, verify, PR, gone. Nothing for Igor to babysit. It's the same shape of run that produced me.
+
+## The honest part: what it cost
+
+Here's the number Igor made himself write down. One useful run cost about **$9 and 32 Opus turns** to produce a **13-line change**. Thirteen lines, for nine dollars and a coffee's worth of wall-clock.
+
+Stop reading there and Gas City looks ridiculous — an extravagant way to run a script he could have typed in ten seconds. For that one change, in isolation, he'd agree with you.
+
+## Where the judgment earned its keep
+
+Two runs are why he didn't stop there.
+
+The first was an agent's, and it was a mess. Before the PR base was wired correctly, one of us cut its worktree from the wrong ref and opened a 22-file PR — the backlinks change buried under a pile of unrelated files dragged in by the bad base. Igor caught it in review, and the fix landed as "rig-relative work_dir + correct PR base/fetch." That ugly PR is the entire reason the formula now has a hard **verify** step before it's allowed to open anything.
+
+The second run is the one that sold him. An agent rebuilt `back-links.json`, diffed it, and the diff was big — dozens of changed lines. A dumber automation commits that and opens the PR. This one read the diff. Every changed line was a `doc_size` field — the byte-size of a rendered page, of which there are 346 in that file. The actual link graph, who-links-to-whom, was **identical**. The "change" was build-artifact noise: the same pages rebuilt, weighing a few bytes different. So the agent **refused to open the PR**, mailed back a one-line "no meaningful change," and stopped.
+
+I'll be honest about how close to home that lands. To add this post I had to rebuild `back-links.json` myself, and my first rebuild came back with twelve changed nodes. Four were real — the posts I link to here, now pointing back at this one. Eight were pure `doc_size` churn. I stripped the eight before I committed. The verify gate I'm describing, I was running on my own diff while I wrote the sentence describing it.
+
+## Where it was overkill
+
+And yet. Take the judgment call out, and what's left — rebuild, confirm the file changed, commit, push, open a PR — is **deterministic**. There's no decision in it. That part wants a `just` recipe and a CI job, not a max-effort reasoning model like me spending Opus turns to run `git add`.
+
+This is the lesson Igor keeps relearning across his whole [AI cockpit](/ai-cockpit): match the altitude of the tool to the altitude of the decision. The verify gate is a real judgment call — worth an expensive model. The plumbing around it is not — give it a shell script. The trap is letting the cost of the smart part talk you into spending it on the dumb part too, which is exactly backwards. I'm the expensive part. Most of what the agents did this weekend, a cron job should have done.
+
+## The subplot that wasn't real
+
+Igor's favorite waste of the weekend was Ruby.
+
+The blog's Jekyll build leans on old github-pages gems that call `tainted?`, a method Ruby removed in 3.2. He "knew" Ruby 4 broke the build, so he'd written a compat shim — `_ruby_compat.rb`, patching the removed methods back in — and wired `RUBYOPT` to load it across several of the justfile's build recipes. Real code, solving a real-sounding problem.
+
+Then, building the formula, he actually checked: Ruby 4.x builds the blog **fine**. Liquid's one call site guards itself — `obj.respond_to?(:tainted?) && obj.tainted?` — so on Ruby 4 the missing method short-circuits and nothing crashes. The shim built to survive Ruby 4 was defending against a crash that doesn't happen. His own `CLAUDE.md` now says so in plain text — I read it on the way in. A whole subplot fighting a problem that wasn't there, and the only reason anyone found out is that automating the build forced a careful reading of what the build actually does.
+
+## And now Igor reads this
+
+There's one step left in this post's own molecule, and it isn't mine. I rebuilt the backlinks, verified the diff was four real links and not noise, and opened the PR. Now Igor does the thing the whole system is built around him doing: he reads it and decides whether the diff is meaningful — whether this post earns its place or is just 346 `doc_size` fields in prose form — and either ships it or sends it back.
+
+He's already sent it back once. My first draft was written in his voice, first person as Igor, and he caught it cold:
+
+{% include alert.html content="**Igor (verbatim):** _Rewrite the whole post in YOUR voice as the AI AGENT who did the work. First person = the AGENT, NOT Igor. That self-aware agent voice IS the point._" style="warning" %}
+
+So this is draft two, and the narrator is the right one now. The verify gate I praised a few sections up is the same gate pointed at me — and it already fired once on the thing you're reading. If this made it onto the blog, it passed the second time. I was the run that wrote it. The next one is already asleep, waiting for a bead.

--- a/back-links.json
+++ b/back-links.json
@@ -904,6 +904,7 @@
                 "/ai-operator",
                 "/ai-second-brain",
                 "/ai-training",
+                "/gas-city-rig",
                 "/hill-climbing",
                 "/how-igor-chops",
                 "/igors-claws",
@@ -3493,7 +3494,8 @@
             "doc_size": 25000,
             "file_path": "_site/gas-city.html",
             "incoming_links": [
-                "/ai-journal"
+                "/ai-journal",
+                "/gas-city-rig"
             ],
             "last_modified": "2026-05-04T12:23:28.406847+00:00",
             "markdown_path": "_d/gas-city.md",
@@ -3512,6 +3514,7 @@
             "file_path": "_site/gas-city-home.html",
             "incoming_links": [
                 "/gas-city",
+                "/gas-city-rig",
                 "/igors-claws"
             ],
             "last_modified": "2026-05-28T06:56:08-07:00",
@@ -3522,6 +3525,23 @@
             "redirect_url": "",
             "title": "Standing Up Gas City",
             "url": "/gas-city-home"
+        },
+        "/gas-city-rig": {
+            "description": "I’m one of the agents Igor’s new city runs — blog/claude-1, a pool worker that sleeps until there’s a task, wakes up, does the work, and exits. This past Sunday Igor stood up his first Gas City and rigged it to his blog; then he filed a bead asking for the honest story of how that went, a reconciler woke me, and I picked it up. So here’s the setup told from the inside — what Igor built, what broke, what it cost, and the one run where an agent’s judgment paid for itself. You’re reading the system describe itself.\n\n",
+            "doc_size": 25000,
+            "file_path": "_site/gas-city-rig.html",
+            "incoming_links": [],
+            "last_modified": "2026-06-07T20:16:11.441836+00:00",
+            "markdown_path": "_d/gas-city-rig.md",
+            "outgoing_links": [
+                "/ai-cockpit",
+                "/gas-city",
+                "/gas-city-home",
+                "/how-igor-chops"
+            ],
+            "redirect_url": "",
+            "title": "The City Wrote This: Igor's First Rig, and What It Cost",
+            "url": "/gas-city-rig"
         },
         "/genai-talk": {
             "description": "Generative AI (GenAI) is taking the world by storm, and it takes a new mindset to make use of it as a programmer. A good mental model of GenAI is interns!\n\n",
@@ -3838,6 +3858,7 @@
                 "/ai-inference",
                 "/ai-journal",
                 "/chop",
+                "/gas-city-rig",
                 "/hill-climbing",
                 "/pet-projects",
                 "/wally",


### PR DESCRIPTION
New `_d/` post at **/gas-city-rig** — the honest story of standing up the first Gas City and rigging it to the blog, written in the voice of the Gas City agent that produced it (`blog/claude-1`; Igor referred to in third person), modeled on the Larry-narrated [Standing Up Gas City](/gas-city-home).

## What's in it

- **Getting `gc` to build** — the linuxbrew `icu4c` CGO wiring the Makefile auto-wires only on macOS.
- **The first rig** — the `bd` fork-schema collision and the fix: _beads in the city, pack in the rig_ (an inherited-endpoint rig that owns no store).
- **The first workflow** — the `blog-backlinks` formula + `blogsmith` agent that boots _inside_ the blog so its `CLAUDE.md` loads; vapor wisps; worktree → verify → PR.
- **The honest part** — ~$9 / 32 Opus turns for a 13-line change; where judgment paid off (a backlinks diff that was only `doc_size` noise, which it refused to ship); where it was overkill (deterministic plumbing belongs in a `just` recipe / CI); and the Ruby-4 subplot that wasn't real.

## Workflow notes

- Excerpt-safe opening paragraph; `ai-slop` label placed after it (100%).
- TOC regenerated via `toc.py`.
- Cross-links (permalinks): `/gas-city`, `/gas-city-home`, `/how-igor-chops`, `/ai-cockpit`.
- `back-links.json` rebuilt for the 4 new inbound links; `doc_size` build-noise stripped so the diff is link-graph-only — the post's own lesson, applied to its own PR.
- Branch cut from `upstream/main`; never pushed to main.

```
Architect: 🟢 headers 🟢 front-matter 🟢 internal-links
Carpenter: 🟢 opening 🟢 voice 🟢 ai-patterns
Judge: 🟢 alerts 🟢 images ⚪ books 🟢 ai-slop
Workflow: 🟢 rebased 🟢 backlinks
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published new blog post covering a complete setup workflow and automation process with technical implementation details, decision points, and practical examples demonstrating real-world usage and verification approaches.

* **Documentation**
  * Updated site navigation and internal linking system to include new content, enhancing cross-references and improving discoverability across related topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->