### PR TITLE
fix: Ruby 4 build crashes without the shim — correct /gas-city-rig + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,15 @@ Why it matters: the inbound "Mentioned in:" section on every linked post reads f
 
 #### Ruby version requirement (local backlinks rebuild)
 
-`build_back_links.py build` reads from `_site/` (built HTML), so a fresh Jekyll build must succeed first. **The local build works on Ruby 4.x** (verified 2026-06): liquid-4.0.3 guards its only `tainted?` call — `obj.respond_to?(:tainted?) && obj.tainted?` (`variable.rb:124`) — so on Ruby 3.2+/4.x the removed method short-circuits, no crash. Just run `bundle exec jekyll build`. A **stale or missing `_site/`** is what makes the backlinks rebuild error out or emit stale entries — not the Ruby version.
+`build_back_links.py build` reads from `_site/` (built HTML), so a fresh Jekyll build must succeed first. **A bare `bundle exec jekyll build` CRASHES on Ruby 4.x** — verified 2026-06. liquid is exact-pinned to `4.0.3` by the `github-pages` gem, and `liquid-4.0.3/lib/liquid/variable.rb:124` is `return unless obj.tainted?` with **no** `respond_to?` guard (read the gem source — an earlier version of this note claimed the line was guarded; it is not). Ruby 4 removed `tainted?`, so the build dies with `undefined method 'tainted?'` rendering `_layouts/post.html`.
 
-CI builds on Ruby 3.2 (matching `.ruby-version` = 3.2.8). As of 2026-06 no Ruby workaround is needed locally — `bundle exec jekyll build` works on 4.x. Only if a future liquid drops that `respond_to?` guard would you pin an older Ruby (`brew install ruby@3.2`).
+The working fix is the `_ruby_compat.rb` shim, which patches the removed methods back. **Every `just` build recipe already exports `RUBYOPT="-r$(pwd)/_ruby_compat.rb"`**, so `just`-based builds (`just jekyll-serve`, `just back-links`, …) work on Ruby 4 — which is exactly why the crash is easy to miss: it only surfaces when you bypass `just`. To build by hand on Ruby 4, load the shim yourself:
+
+```bash
+RUBYOPT="-r$(pwd)/_ruby_compat.rb" bundle exec jekyll build
+```
+
+You **cannot** `bundle update` to a patched liquid: `github-pages` exact-pins `liquid (= 4.0.3)` and `jekyll (= 3.9.0)` to mirror GitHub Pages' native build (which is how this site deploys — there is no custom site-build workflow). The only ways off the shim are pinning an older local Ruby that still has `tainted?` (`brew install ruby@3.1`), or migrating off `github-pages` to plain `jekyll 4` / `liquid 5` — a deploy-stack change, not a quick bump. A **stale or missing `_site/`** is a separate failure mode — it makes the backlinks rebuild emit stale entries even when the build itself succeeds.
 
 When superseding a PR you opened on `idvorkin/*`, **close it yourself** — `gh pr close <N> --repo idvorkin/<repo> --comment "Superseded by #M — …"` works for the `idvorkin-ai-tools` actor on PRs it authored. Don't leave orphan PRs for Igor to clean up.
 

--- a/_d/gas-city-rig.md
+++ b/_d/gas-city-rig.md
@@ -23,7 +23,7 @@ If you want the concepts first — what a bead actually is, what a molecule does
 - [The honest part: what it cost](#the-honest-part-what-it-cost)
 - [Where the judgment earned its keep](#where-the-judgment-earned-its-keep)
 - [Where it was overkill](#where-it-was-overkill)
-- [The subplot that wasn't real](#the-subplot-that-wasnt-real)
+- [The subplot I got backwards](#the-subplot-i-got-backwards)
 - [And now Igor reads this](#and-now-igor-reads-this)
 
 <!-- vim-markdown-toc-end -->
@@ -69,13 +69,15 @@ And yet. Take the judgment call out, and what's left — rebuild, confirm the fi
 
 This is the lesson Igor keeps relearning across his whole [AI cockpit](/ai-cockpit): match the altitude of the tool to the altitude of the decision. The verify gate is a real judgment call — worth an expensive model. The plumbing around it is not — give it a shell script. The trap is letting the cost of the smart part talk you into spending it on the dumb part too, which is exactly backwards. I'm the expensive part. Most of what the agents did this weekend, a cron job should have done.
 
-## The subplot that wasn't real
+## The subplot I got backwards
 
-Igor's favorite waste of the weekend was Ruby.
+Igor's favorite waste of the weekend was Ruby — except the waste turned out to be deciding it was a waste. The first draft of this post had the story upside down, and catching that is its own lesson.
 
-The blog's Jekyll build leans on old github-pages gems that call `tainted?`, a method Ruby removed in 3.2. He "knew" Ruby 4 broke the build, so he'd written a compat shim — `_ruby_compat.rb`, patching the removed methods back in — and wired `RUBYOPT` to load it across several of the justfile's build recipes. Real code, solving a real-sounding problem.
+The blog's Jekyll build leans on an ancient liquid (4.0.3), frozen there by the `github-pages` gem, and liquid calls `tainted?` — a method Ruby removed. Igor "knew" Ruby 4 broke the build, so he'd written a compat shim, `_ruby_compat.rb`, that patches the removed methods back, and wired `RUBYOPT` to load it across the justfile's build recipes. Correct instinct, real fix.
 
-Then, building the formula, he actually checked: Ruby 4.x builds the blog **fine**. Liquid's one call site guards itself — `obj.respond_to?(:tainted?) && obj.tainted?` — so on Ruby 4 the missing method short-circuits and nothing crashes. The shim built to survive Ruby 4 was defending against a crash that doesn't happen. His own `CLAUDE.md` now says so in plain text — I read it on the way in. A whole subplot fighting a problem that wasn't there, and the only reason anyone found out is that automating the build forced a careful reading of what the build actually does.
+Then he talked himself out of it. He "checked," decided Ruby 4 built the blog fine, and concluded the crash he'd armored against wasn't real — wrote it down here and in his `CLAUDE.md`. Both were wrong, and wrong in the way this whole post is about. He only ever built through `just`, and **every `just` recipe exports `RUBYOPT="-r…/_ruby_compat.rb"`** — so the shim was loaded the entire time he was proving he didn't need it. Run the build the way `just` doesn't, a bare `bundle exec jekyll build` on Ruby 4, and it dies exactly where he first thought: `liquid-4.0.3/lib/liquid/variable.rb:124`, on an unguarded `return unless obj.tainted?`.
+
+So the shim isn't dead weight — it's load-bearing, hidden so well in the justfile that bypassing it is the only way to watch it work. The "real" fix is bigger than a one-liner: liquid is exact-pinned to 4.0.3 by `github-pages`, so you can't just pull a patched one; you'd have to leave the GitHub-Pages-native stack for plain Jekyll 4 and a liquid that dropped taint-checking entirely. That's a migration, and the 2 KB shim is the right-sized answer until it's worth doing. The lesson landed twice: trust the runtime over the doctor — and don't trust your own _"I checked"_ when the thing you checked through was quietly doing the work for you. An agent ran the build clean, without `just`, and that's what finally caught it — including the version of this very paragraph that used to say the opposite.
 
 ## And now Igor reads this
 


### PR DESCRIPTION
The `_ruby_compat.rb` shim is **load-bearing**, not the no-op a recently-merged post and the CLAUDE.md both claimed. This corrects both.

## What was wrong

- `/gas-city-rig`'s "subplot that wasn't real" section said Ruby 4 builds the blog fine and the shim defends against "a crash that doesn't happen."
- The CLAUDE.md Ruby note claimed `liquid-4.0.3/lib/liquid/variable.rb:124` is guarded — `obj.respond_to?(:tainted?) && obj.tainted?`.

Both are false.

## Evidence

- A bare `bundle exec jekyll build` on Ruby 4.0.3 crashes: `undefined method 'tainted?'` at `liquid-4.0.3/lib/liquid/variable.rb:124`, rendering `_layouts/post.html`.
- That line is `return unless obj.tainted?` — **unguarded**. The `respond_to?` guard does not exist in liquid 4.0.3 (read the gem source).
- `liquid` is exact-pinned to `4.0.3` by `gem 'github-pages'` (Gemfile.lock), so it can't be `bundle update`'d past the bug.
- Every `just` build recipe exports `RUBYOPT="-r$(pwd)/_ruby_compat.rb"`, so `just`-based builds load the shim — which masked the crash. It only surfaces on a bare hand-typed build, which is how it was finally caught.

## This PR

- **`_d/gas-city-rig.md`** — flip the section to the true story (renamed "The subplot I got backwards"); TOC regenerated. The narrator (the agent that wrote the post) owns the inverted conclusion.
- **`CLAUDE.md`** — correct the Ruby note: document the crash, the shim and how `just` loads it via `RUBYOPT`, the `github-pages` exact-pin, and the real-fix migration path. Explicitly flags that the old "guarded line" claim was fabricated.

Keeps the shim (the right-sized fix). Does **not** attempt the jekyll-4 / liquid-5 migration off `github-pages` — that's a separate, larger deploy-stack change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Ruby version requirement guidance with clarified build processes and compatibility information.
  * Enhanced technical documentation with corrected details on build dependencies and workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->