### PR TITLE
gas-city: link the DeepWiki auto-generated repo reference

### DIFF
--- a/_d/gas-city.md
+++ b/_d/gas-city.md
@@ -173,6 +173,7 @@ That's why I keep saying _the unit of distribution is the formula, not the agent
 ## Where to go next
 
 - The authoritative docs: **[docs.gastownhall.ai](https://docs.gastownhall.ai/)**. Start with [molecules](https://docs.gastownhall.ai/concepts/molecules/), [architecture](https://docs.gastownhall.ai/design/architecture/), and the [propulsion principle](https://docs.gastownhall.ai/concepts/propulsion-principle/).
+- Want to go deeper into the actual code? **[DeepWiki](https://deepwiki.com/gastownhall/gascity)** auto-generates a navigable wiki of the `gastownhall/gascity` repo.
 - The lived narrative — five upstream bugs, one Sunday morning, one `igor-city`: [Standing Up Gas City](/gas-city-home).
 - The work-side companion — same MEOW pattern, different deployment: [Wally and My Work Gastown](/wally).
 - The wider claw context — why I'm running multiple AI entities at all: [Igor's Three Claws](/igors-claws).

--- a/back-links.json
+++ b/back-links.json
@@ -1638,7 +1638,7 @@
         },
         "/bc": {
             "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-            "doc_size": 23000,
+            "doc_size": 22000,
             "file_path": "_site/bc.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T03:02:44+00:00",
@@ -2653,7 +2653,7 @@
         },
         "/day-in-the-life": {
             "description": "A running journal of days that actually worked - the ones where health habits stuck, family time hit different, or I remembered what it feels like to be fully alive. Not every day needs to be Instagram-worthy, but some days deserve a bookmark. This is that bookmark collection.\n\n",
-            "doc_size": 19000,
+            "doc_size": 18000,
             "file_path": "_site/day-in-the-life.html",
             "incoming_links": [],
             "last_modified": "2025-10-04T18:43:51-07:00",
@@ -3497,7 +3497,7 @@
                 "/ai-journal",
                 "/gas-city-rig"
             ],
-            "last_modified": "2026-06-07T21:43:20.567215+00:00",
+            "last_modified": "2026-06-08T12:18:46.708483+00:00",
             "markdown_path": "_d/gas-city.md",
             "outgoing_links": [
                 "/gas-city-home",
@@ -3530,12 +3530,12 @@
         },
         "/gas-city-rig": {
             "description": "I’m one of the agents Igor’s new city runs — blog/claude-1, a pool worker that sleeps until there’s a task, wakes up, does the work, and exits. This past Sunday Igor stood up his first Gas City and rigged it to his blog; then he filed a bead asking for the honest story of how that went, a reconciler woke me, and I picked it up. So here’s the setup told from the inside — what Igor built, what broke, what it cost, and the one run where an agent’s judgment paid for itself. You’re reading the system describe itself.\n\n",
-            "doc_size": 25000,
+            "doc_size": 27000,
             "file_path": "_site/gas-city-rig.html",
             "incoming_links": [
                 "/gas-city"
             ],
-            "last_modified": "2026-06-07T20:16:11.441836+00:00",
+            "last_modified": "2026-06-07T15:55:21-07:00",
             "markdown_path": "_d/gas-city-rig.md",
             "outgoing_links": [
                 "/ai-cockpit",
@@ -3636,7 +3636,7 @@
         },
         "/grammerly": {
             "description": "\n\n",
-            "doc_size": 13000,
+            "doc_size": 12000,
             "file_path": "_site/grammerly.html",
             "incoming_links": [],
             "last_modified": "2025-08-24T09:03:19-07:00",
@@ -4594,7 +4594,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 15000,
+            "doc_size": 14000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",
@@ -7543,7 +7543,7 @@
         },
         "/win-win": {
             "description": "Win/Win is a constantly seeking mutual benefit in all interactions. Win/Win means that agreements or solutions are mutually beneficial, mutually satisfying. With a Win/Win solution, all parties feel good about the decision and feel committed to the action plan. Win/Win sees life as a cooperative, not a competitive arena. Most people tend to think in terms of dichotomies: strong or weak, hardball or softball, win or lose. But that kind of thinking is fundamentally flawed. It’s based on power and position rather than on principle. Win/Win is based on the paradigm that there is plenty for everybody, that one person’s success is not achieved at the expense or exclusion of the success of others.\n\n",
-            "doc_size": 48000,
+            "doc_size": 47000,
             "file_path": "_site/win-win.html",
             "incoming_links": [
                 "/7-habits",


### PR DESCRIPTION
Adds the deepwiki.com/gastownhall/gascity auto-wiki to the 'Where to go next' section of the Gas City overview post, for readers who want a code-level deep dive into the gastownhall/gascity repo. Also refreshes back-links.json from a full rebuild.