### PR TITLE
gas-city: fold in architecture concepts (controller loop, runtime providers, city.toml)

### DIFF
--- a/_d/gas-city.md
+++ b/_d/gas-city.md
@@ -72,13 +72,17 @@ The principle is load-bearing for the **[polecat](https://docs.gastownhall.ai/co
 
 I learned this concretely [the morning I stood up `igor-city`](/gas-city-home). First-time polecats sat idle on wake — supervisor up, beads routed, polecats spawned, nothing happening. I had to manually `gc session nudge <id> "pick up your bead"` for each one. That's a propulsion-principle violation. Polecats existing in a state the design says cannot exist. The fix — a `polecat-step-0-self-claim` step in the agent prompt that runs `bd ready --json | jq …` immediately on wake — wasn't a feature; it was GUPP re-asserted. The bug was a class of state the system isn't supposed to have. Once you internalize the principle, the fix writes itself.
 
+GUPP is the rule each agent obeys. But something has to keep the agents themselves running — start the ones that should be up, restart the ones that died, notice when reality has drifted from the plan. That's a **controller**: a loop holding two pictures of the city side by side. The _desired_ state is computed from your config and your open beads — what _should_ be running. The _actual_ state is whatever the runtime is really doing. The controller's whole job is to keep comparing them and close the gap — spawn what's missing, reap what's orphaned. The docs call this **convergence**, the same idea Kubernetes built its reputation on: declare the end state, and a loop drives toward it in bounded steps instead of one fragile big-bang deploy. (A machine-wide **supervisor** sits above the controllers, tracking every city you run; each controller worries about exactly one.)
+
+That reframe is what finally made propulsion click for me. GUPP keeps each piston firing; the reconcile loop is the governor that keeps the _engine_ from stalling — and the two failure modes are different. My idle-polecat bug was a convergence gap as much as a GUPP one: the controller believed it had hit the desired state, but the actual state held a stalled worker the loop couldn't see. Propulsion isn't one mechanism. It's an agent-side rule and a system-side loop, and the city only moves when both are honest about what's running.
+
 ## Getting started — the mechanics in practice
 
 The three concepts above are the theory. Here's what they look like when you actually drive the thing. Three pieces: the city you stand up, the agents you configure, and the slinging that puts them to work.
 
 ### The city is just a directory
 
-`gc init` scaffolds one. The wizard asks for a provider and a template; the non-interactive form is `gc init --template minimal --default-provider claude ~/my-city`. What comes out is a plain directory — that's the whole model, a city is a directory on disk. You get a `city.toml` (deployment config), a `pack.toml` (the agent definitions), a `.gc/` runtime dir, and top-level folders for `agents/`, `formulas/`, and `orders/`.
+`gc init` scaffolds one. The wizard asks for a provider and a template; the non-interactive form is `gc init --template minimal --default-provider claude ~/my-city`. What comes out is a plain directory — that's the whole model, a city is a directory on disk. You get a `city.toml` (the declarative city — the desired state the controller reconciles toward), a `pack.toml` (the agent definitions), a `.gc/` runtime dir, and top-level folders for `agents/`, `formulas/`, and `orders/`.
 
 The `city.toml` is short. Mine, trimmed:
 
@@ -99,6 +103,8 @@ source = "/home/developer/gits/idvorkin.github.io/_gascity"
 ```
 
 A **rig** points the city at a repo. The blog rig imports a pack of agents and formulas (`_gascity/`) that lives _in the blog repo_, so the workflow definitions version alongside the content they operate on. The rig inherits the city's bead store, so the blog's own `.beads` is never touched — beads live in the city, the pack lives in the rig.
+
+That `provider` line is doing more than it looks. It names a **runtime provider** — the substrate the agents actually run on. Mine spawns local subprocesses; the same `city.toml` could target tmux sessions, or Kubernetes pods on a cluster, by changing that one block. The city definition — agents, rigs, formulas, the work itself — doesn't know or care where it runs. Provider is a swappable backend, not a rewrite. The work shape is portable; the substrate is a deployment detail.
 
 ### Agents: crew vs. pool
 

--- a/_d/gas-city.md
+++ b/_d/gas-city.md
@@ -13,7 +13,7 @@ The way to get more out of AI is to scale your productivity, and — just like h
 
 {% include ai-slop.html percent="80" %}
 
-This is the hands-on version. If you've read [Standing Up Gas City](/gas-city-home), or seen "Gas City" mentioned in [/wally](/wally) or [/igors-claws](/igors-claws), and you want to know what the thing actually _is_ — and how to start driving it — before you stand up your own, this is that post. Three concepts carry the whole design: **beads** (the unit of work), **molecules** (the choreography), and the **propulsion principle** (what keeps the engine running). Each is plain on its own; the leverage is in how they compose. The source of truth is [docs.gastownhall.ai](https://docs.gastownhall.ai/) — my job here is to translate, not duplicate, so when a section needs the precise definition I link out.
+This is the hands-on version. If you've read [Standing Up Gas City](/gas-city-home), or seen "Gas City" mentioned in [/wally](/wally) or [/igors-claws](/igors-claws), and you want to know what the thing actually _is_ — and how to start driving it — before you stand up your own, this is that post. Three concepts carry the whole design: **beads** (the unit of work), **molecules** (the choreography), and the **propulsion principle** (what keeps the engine running). Each is plain on its own; the leverage is in how they compose. The source of truth is [docs.gastownhall.ai](https://docs.gastownhall.ai/) — my job here is to translate, not duplicate, so when a section needs the precise definition I link out. (If you want a machine's-eye tour of the whole system, [DeepWiki](https://deepwiki.com/gastownhall/gascity) auto-generated a surprisingly good overview.)
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->

--- a/back-links.json
+++ b/back-links.json
@@ -1351,7 +1351,7 @@
         },
         "/ai-training": {
             "description": "I don’t train models for a living — I build on top of them. But to use LLMs well, it helps to carry a rough map of how one gets made: what pre-training buys you, what post-training changes, and where fine-tuning, RAG, and quantization actually fit. These are my working notes on that map, kept deliberately shallow — enough to make good decisions as a consumer of models, not to go train one.\n\n",
-            "doc_size": 36000,
+            "doc_size": 35000,
             "file_path": "_site/ai-training.html",
             "incoming_links": [
                 "/ai-inference"
@@ -1986,24 +1986,28 @@
         },
         "/changelog": {
             "description": "A weekly summary of what changed on this blog and across my GitHub projects. Useful for returning readers who want to catch up on new content and updates.\n\n",
-            "doc_size": 173000,
+            "doc_size": 187000,
             "file_path": "_site/changelog.html",
             "incoming_links": [],
-            "last_modified": "2026-06-06T18:18:54.096028+00:00",
+            "last_modified": "2026-06-09T06:49:04-07:00",
             "markdown_path": "_d/changelog.md",
             "outgoing_links": [
+                "/42",
                 "/7h-concepts",
                 "/act",
                 "/activation",
                 "/addiction",
                 "/ai-cockpit",
+                "/ai-inference",
                 "/ai-journal",
                 "/ai-native-manager",
+                "/ai-native-onboarding",
                 "/ai-native-vocab",
                 "/ai-operator",
                 "/ai-optimism",
                 "/ai-relationships",
                 "/ai-second-brain",
+                "/ai-training",
                 "/amelia",
                 "/be-proactive",
                 "/claw",
@@ -2015,6 +2019,7 @@
                 "/first-understand",
                 "/gas-city",
                 "/gas-city-home",
+                "/gas-city-rig",
                 "/hill-climbing",
                 "/hobby",
                 "/how-igor-chops",
@@ -2032,6 +2037,7 @@
                 "/mosh",
                 "/podcast",
                 "/product",
+                "/psychic-weight",
                 "/raccoon-history",
                 "/recent",
                 "/sharpen-the-saw",
@@ -3491,13 +3497,13 @@
         },
         "/gas-city": {
             "description": "The way to get more out of AI is to scale your productivity, and — just like humans — agents scale two ways. Scale up (vertical): make one agent more capable by giving it better tools and pre-created skills. That’s the whole world of how I chop — a tuned CLAUDE.md, a library of skills, custom CLIs the agent already knows how to drive. Scale out (horizontal): run many agents that cross-communicate and coordinate. Scaling out is where you need orchestration, and orchestration is what Gas City is. Beads, molecules, and the propulsion principle are how scale-out actually works under the hood.\n\n",
-            "doc_size": 35000,
+            "doc_size": 37000,
             "file_path": "_site/gas-city.html",
             "incoming_links": [
                 "/ai-journal",
                 "/gas-city-rig"
             ],
-            "last_modified": "2026-06-08T06:03:08-07:00",
+            "last_modified": "2026-06-09T07:32:23-07:00",
             "markdown_path": "_d/gas-city.md",
             "outgoing_links": [
                 "/gas-city-home",
@@ -6323,7 +6329,7 @@
         },
         "/synergize": {
             "description": "We’ve all got stuff we’re good at and stuff we’re bad at. Combine them right and the system is greater than the sum of the parts — sometimes a lot greater. Synergy is the payoff for everything that came before: independence, Win/Win, and seeking first to understand all converge here. These are my insights from 7 habits Chapter 6.\n\n",
-            "doc_size": 29000,
+            "doc_size": 28000,
             "file_path": "_site/synergize.html",
             "incoming_links": [
                 "/7-habits",
@@ -6406,7 +6412,7 @@
         },
         "/td/back_ref": {
             "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
-            "doc_size": 14000,
+            "doc_size": 13000,
             "file_path": "_site/td/back_ref.html",
             "incoming_links": [],
             "last_modified": "2022-04-16T15:22:43-07:00",
@@ -7488,7 +7494,7 @@
         },
         "/weeks": {
             "description": "\n\n",
-            "doc_size": 4348000,
+            "doc_size": 4347000,
             "file_path": "_site/weeks.html",
             "incoming_links": [
                 "/balance"

--- a/back-links.json
+++ b/back-links.json
@@ -3497,7 +3497,7 @@
                 "/ai-journal",
                 "/gas-city-rig"
             ],
-            "last_modified": "2026-06-07T17:46:46-07:00",
+            "last_modified": "2026-06-08T06:03:08-07:00",
             "markdown_path": "_d/gas-city.md",
             "outgoing_links": [
                 "/gas-city-home",
@@ -6323,7 +6323,7 @@
         },
         "/synergize": {
             "description": "We’ve all got stuff we’re good at and stuff we’re bad at. Combine them right and the system is greater than the sum of the parts — sometimes a lot greater. Synergy is the payoff for everything that came before: independence, Win/Win, and seeking first to understand all converge here. These are my insights from 7 habits Chapter 6.\n\n",
-            "doc_size": 28000,
+            "doc_size": 29000,
             "file_path": "_site/synergize.html",
             "incoming_links": [
                 "/7-habits",
@@ -6406,7 +6406,7 @@
         },
         "/td/back_ref": {
             "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
-            "doc_size": 13000,
+            "doc_size": 14000,
             "file_path": "_site/td/back_ref.html",
             "incoming_links": [],
             "last_modified": "2022-04-16T15:22:43-07:00",


### PR DESCRIPTION
Integrates DeepWiki's architecture concepts **inline** into `/gas-city`, per Igor — concepts woven into the post's flow, **no source-code pointers or links to DeepWiki**.

Three concepts folded in (the ones not already covered), tied to the existing beads/molecules/propulsion frame:

- **Controller/supervisor reconcile loop + convergence** — added to the Propulsion Principle section as the *system-side* engine. GUPP is the agent-side rule ("if work is on your hook, run it"); the reconcile loop is the governor that keeps the engine from stalling (desired state from config + open beads vs. actual running sessions; Kubernetes-style bounded convergence). Reframes the idle-polecat bug as a convergence gap, not just a GUPP violation.
- **Runtime providers** — the same `city.toml` runs across subprocess / tmux / Kubernetes; substrate is a swappable backend, the work shape is portable.
- **`city.toml` as declarative desired state** — reframed from "deployment config" to the desired state the controller reconciles toward.

Distill-don't-accrete: net +16/-10 lines, no new headings, TOC unchanged. Deliberately left out the five-primitives/four-derived breakdown (already covered in the post's "work is the primitive" section), mail/dispatch/sling (already covered), and orders (too granular for an overview).

Supersedes #686 — Igor wants the concepts folded in inline, not a source-code pointer link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Gas City explainer introduction with references to canonical sources and system overview.
  * Added clarification on controller-level reconciliation loops that maintain desired vs. actual runtime state.
  * Refined city.toml documentation to explain its role as declarative desired state.
  * Enhanced provider setting documentation to clarify swappable runtime backend configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->