### PR TITLE
ai-training: link the Deployment/serving section to /ai-inference

### DIFF
--- a/_d/ai-training.md
+++ b/_d/ai-training.md
@@ -94,7 +94,7 @@ How you actually do the fine-tuning above without retraining the whole model:
 
 ### Deployment: quantization and serving
 
-Not training, but it's where the model you actually run comes from, so it lands here.
+Not training, but it's where the model you actually run comes from, so it lands here. Serving _is_ inference, and the full serving/inference story is its own post: [/ai-inference](/ai-inference).
 
 - **Quantization** — compress the weights from 16 bits per parameter down to ~4 bits or less (`Q4_0`, `IQ2_XXS`, and friends). [How the methods work](https://www.reddit.com/r/LocalLLaMA/comments/1ba55rj/overview_of_gguf_quantization_methods/), and a [scorecard comparing them](https://huggingface.co/datasets/christopherthompson81/quant_exploration). It's _lossy_ compression, so you have to eval the damage — a common check is comparing the difference in answers via embeddings.
 - **GGUF (GPT-Generated Unified Format)** — the file format these models are stored in (GGUF is GGML's successor). It's what you download when you grab a quantized model to run locally.

--- a/_d/ai-training.md
+++ b/_d/ai-training.md
@@ -94,7 +94,9 @@ How you actually do the fine-tuning above without retraining the whole model:
 
 ### Deployment: quantization and serving
 
-Not training, but it's where the model you actually run comes from, so it lands here. Serving _is_ inference, and the full serving/inference story is its own post: [/ai-inference](/ai-inference).
+Not training, but it's where the model you actually run comes from, so it lands here. Serving _is_ inference, and the full serving/inference story is its own post:
+
+{% include summarize-page.html src="/ai-inference" %}
 
 - **Quantization** — compress the weights from 16 bits per parameter down to ~4 bits or less (`Q4_0`, `IQ2_XXS`, and friends). [How the methods work](https://www.reddit.com/r/LocalLLaMA/comments/1ba55rj/overview_of_gguf_quantization_methods/), and a [scorecard comparing them](https://huggingface.co/datasets/christopherthompson81/quant_exploration). It's _lossy_ compression, so you have to eval the damage — a common check is comparing the difference in answers via embeddings.
 - **GGUF (GPT-Generated Unified Format)** — the file format these models are stored in (GGUF is GGML's successor). It's what you download when you grab a quantized model to run locally.

--- a/back-links.json
+++ b/back-links.json
@@ -1356,7 +1356,7 @@
             "incoming_links": [
                 "/ai-inference"
             ],
-            "last_modified": "2026-06-07T18:30:20.669501+00:00",
+            "last_modified": "2026-06-08T13:34:13.844785+00:00",
             "markdown_path": "_d/ai-training.md",
             "outgoing_links": [
                 "/ai-art",


### PR DESCRIPTION
Serving a model **is** inference, so the `### Deployment: quantization and serving` section now points to the dedicated [/ai-inference](/ai-inference) post (previously that link only appeared far down in the Appendix).

One-sentence addition to the section's intro line. `back-links.json` gets a `last_modified` bump for `/ai-training` (the link pair already existed via the Appendix, so no inbound-link-graph change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced deployment documentation with clearer explanations that serving = inference and where the runnable model originates.
  * Embedded/linked the dedicated AI inference resource for more comprehensive guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->