### PR TITLE
feat(gascity): ai-journal-new + ai-journal-revise formulas

### DIFF
--- a/_gascity/formulas/ai-journal-new.toml
+++ b/_gascity/formulas/ai-journal-new.toml
@@ -111,9 +111,14 @@ Land it. NEVER push to main:
   git add _d/ai-journal.md
   git commit -m "feat(ai-journal): add entry $(date +%Y-%m-%d)"
   git push -u origin HEAD            # push the branch to the fork (origin)
-  gh pr create --base main --fill    # PR against canonical main (idvorkin/*)
-Capture the PR URL, then anchor it on the tracking bead so revisions can find the PR
-and branch (confirm flags with `gc bd update --help`):
+Open the PR against canonical main, and PUT THE TRACKING BEAD ID IN THE PR DESCRIPTION
+on its own `Tracking-bead: <id>` line, so any reviser picks it up straight from the PR
+(nothing to remember or pass). For example:
+  gh pr create --base main --title "ai-journal: <entry title>" --body "<one-line summary of the entry>
+
+Tracking-bead: <tracking-bead-id>"
+Capture the PR URL. Keep the reverse link on the bead too (confirm flags with
+`gc bd update --help`):
   gc bd update <tracking-bead-id> --notes "PR: <PR-URL>  branch: <branch>"
 """
 
@@ -124,6 +129,6 @@ needs = ["land"]
 description = """
 Notify {{notify}} so nobody has to poll — and so revisions have their anchor:
   gc mail send {{notify}} -s "ai-journal-new: PR opened" -m "<PR-URL>/files
-  tracking bead: <id>  (revise from PR feedback: gc formula cook ai-journal-revise --var entry_bead=<id>)"
+  tracking bead: <id>  (revise from PR feedback: gc formula cook ai-journal-revise --var pr=<PR-number>)"
 (If you already mailed an abort in an earlier step, skip this.)
 """

--- a/_gascity/formulas/ai-journal-new.toml
+++ b/_gascity/formulas/ai-journal-new.toml
@@ -81,9 +81,25 @@ Edit ONLY _d/ai-journal.md. Match the voice of existing entries: personal, refle
 """
 
 [[steps]]
-id = "verify"
-title = "Verify the change is ai-journal-only and sound (USE JUDGMENT)"
+id = "rebuild-backlinks"
+title = "Rebuild back-links.json so the new entry's links are indexed"
 needs = ["draft-entry"]
+description = """
+The new entry adds internal links, so back-links.json must be regenerated or it goes
+stale the moment the entry merges. Build the site so _site reflects the new entry, then
+rebuild backlinks (this only regenerates back-links.json — it does NOT commit):
+  just worktree-init            # fires a background jekyll build (loads the ruby-compat shim)
+  # WAIT for that build: poll until _site/index.html is freshly written (~60-90s).
+  #   LOG=/tmp/jekyll-worktree-$(git branch --show-current | tr '/' '-').log   # tail it if it stalls
+  just update-backlinks         # = uv run ./build_back_links.py build  ->  regenerates back-links.json
+Do NOT proceed on a stale/missing _site — it yields wrong backlinks. back-links.json may
+legitimately be unchanged (the entry added no new cross-links); that is fine.
+"""
+
+[[steps]]
+id = "verify"
+title = "Verify the change is entry+backlinks-only and sound (USE JUDGMENT)"
+needs = ["rebuild-backlinks"]
 description = """
 This is the judgment gate — do not skip it. The intent is a single-file, new-entry-only
 change against {{base_branch}}. Check reality matches intent:
@@ -91,7 +107,7 @@ change against {{base_branch}}. Check reality matches intent:
   git diff --stat _d/ai-journal.md
 
 PASS only if ALL hold:
-  - the ONLY modified path is _d/ai-journal.md (no stray files),
+  - the only modified paths are _d/ai-journal.md and back-links.json (no stray files),
   - the entry matches the documented format and the TOC is updated,
   - EVERY deep link resolves and matches the dossier's claim->permalink map
     (spot-check that the hashes / line ranges actually exist),
@@ -108,8 +124,8 @@ title = "Commit + open a clean PR; anchor the tracking bead"
 needs = ["verify"]
 description = """
 Land it. NEVER push to main:
-  git add _d/ai-journal.md
-  git commit -m "feat(ai-journal): add entry $(date +%Y-%m-%d)"
+  git add _d/ai-journal.md back-links.json
+  git commit -m "feat(ai-journal): add entry $(date +%Y-%m-%d) + backlinks"
   git push -u origin HEAD            # push the branch to the fork (origin)
 Open the PR against canonical main, and PUT THE TRACKING BEAD ID IN THE PR DESCRIPTION
 on its own `Tracking-bead: <id>` line, so any reviser picks it up straight from the PR

--- a/_gascity/formulas/ai-journal-new.toml
+++ b/_gascity/formulas/ai-journal-new.toml
@@ -1,0 +1,129 @@
+formula = "ai-journal-new"
+description = "Draft a new dated AI-journal entry from rough notes in an isolated worktree: research and persist a dossier to a tracking bead, write the formatted entry, verify it is ai-journal-only, open a clean PR, and mail the PR + bead id. Never pushes to main."
+
+# vapor = root-only wisp so a scale-from-zero pool wakes; one agent runs the
+# steps in sequence.
+phase = "vapor"
+
+[vars.notes_file]
+description = "Absolute path to a markdown scratch file holding the author's rough notes — the seed and the voice for the entry."
+default = ""
+
+[vars.sources]
+description = "Optional sources to mine for deep permalinks: repo paths, PR/issue URLs, gist URLs, transcript files. Space- or newline-separated."
+default = ""
+
+[vars.blog_repo]
+description = "Absolute path to the blog repo checkout (worktree base)."
+default = "/home/developer/gits/idvorkin.github.io"
+
+[vars.base_branch]
+description = "Cut the worktree from this ref (canonical, freshest). The PR opens against canonical main, the same ref, so the diff stays new-entry-only."
+default = "upstream/main"
+
+[vars.notify]
+description = "gc mail recipient to notify on completion (e.g. mayor, or a human)."
+default = "mayor"
+
+[[steps]]
+id = "fresh-worktree"
+title = "Cut a fresh worktree off {{base_branch}}"
+description = """
+Your working directory is the blog repo (CLAUDE.md is already loaded — follow it).
+Cut an isolated worktree from {{base_branch}} so the draft is clean and the PR base
+matches the branch base:
+  git -C {{blog_repo}} fetch upstream --prune
+  TS=$(date +%Y%m%d-%H%M%S); BR="ai-journal-entry-$TS"
+  git -C {{blog_repo}} worktree add "{{blog_repo}}/.worktrees/$BR" {{base_branch}} -b "$BR"
+  cd "{{blog_repo}}/.worktrees/$BR"
+Report the worktree path + branch. Do ALL remaining steps inside this worktree.
+"""
+
+[[steps]]
+id = "research"
+title = "Research the entry and persist a dossier to a tracking bead"
+needs = ["fresh-worktree"]
+description = """
+Read the rough notes at {{notes_file}} (the author's voice + the insight) and the
+"## Instructions for Claude: Creating Journal Entries" section of _d/ai-journal.md
+(the entry format + deep-link rules). Mine {{sources}} for the exact facts and links
+the entry needs.
+
+Build a structured RESEARCH DOSSIER — this is the durable working memory that lets ANY
+later revision rehydrate without redoing the research:
+  - claim -> source map: each factual claim with its exact commit permalink
+    (repo/blob/<sha>/path#Lx-Ly). Walk git history to find real hashes + line ranges.
+  - sources read + the key extract pulled from each
+  - links considered and rejected (and why)
+  - open questions / things still to verify
+  - the reasoning behind the structure you will use
+
+Create a long-lived TRACKING BEAD for this entry and store the dossier on its design
+field (run `gc bd --help` / `gc bd update --help` to confirm exact flags):
+  gc bd create --type task --title "ai-journal: <entry-slug>" --labels ai-journal,blog
+  gc bd update <id> --design "<the dossier markdown>"
+Report the tracking bead id — every later step and every revision keys off it.
+"""
+
+[[steps]]
+id = "draft-entry"
+title = "Write the formatted entry + update the TOC"
+needs = ["research"]
+description = """
+Using ONLY the dossier + notes (do not invent facts), write the new entry into
+_d/ai-journal.md following the documented format:
+  - a new `### YYYY-MM-DD` heading at the TOP of the Diary section (today's date)
+  - `#### <Catchy Title>`
+  - **TOP Takeaway**, **The Problem**, **What Worked** (with the deep permalinks
+    from the dossier), **What Didn't**
+  - add the entry to the table-of-contents section
+Edit ONLY _d/ai-journal.md. Match the voice of existing entries: personal, reflective, honest.
+"""
+
+[[steps]]
+id = "verify"
+title = "Verify the change is ai-journal-only and sound (USE JUDGMENT)"
+needs = ["draft-entry"]
+description = """
+This is the judgment gate — do not skip it. The intent is a single-file, new-entry-only
+change against {{base_branch}}. Check reality matches intent:
+  git status --porcelain          # which files changed?
+  git diff --stat _d/ai-journal.md
+
+PASS only if ALL hold:
+  - the ONLY modified path is _d/ai-journal.md (no stray files),
+  - the entry matches the documented format and the TOC is updated,
+  - EVERY deep link resolves and matches the dossier's claim->permalink map
+    (spot-check that the hashes / line ranges actually exist),
+  - nothing is asserted that is not backed by the notes or the dossier,
+  - `git log --oneline {{base_branch}}..HEAD` is empty BEFORE you commit (right base).
+
+If ANY check fails, ABORT: do not commit, do not open a PR. Mail {{notify}} with subject
+"ai-journal-new: ABORTED" and a 1-2 line explanation of what looked wrong, then stop.
+"""
+
+[[steps]]
+id = "land"
+title = "Commit + open a clean PR; anchor the tracking bead"
+needs = ["verify"]
+description = """
+Land it. NEVER push to main:
+  git add _d/ai-journal.md
+  git commit -m "feat(ai-journal): add entry $(date +%Y-%m-%d)"
+  git push -u origin HEAD            # push the branch to the fork (origin)
+  gh pr create --base main --fill    # PR against canonical main (idvorkin/*)
+Capture the PR URL, then anchor it on the tracking bead so revisions can find the PR
+and branch (confirm flags with `gc bd update --help`):
+  gc bd update <tracking-bead-id> --notes "PR: <PR-URL>  branch: <branch>"
+"""
+
+[[steps]]
+id = "notify"
+title = "Mail the outcome (PR link + tracking bead id)"
+needs = ["land"]
+description = """
+Notify {{notify}} so nobody has to poll — and so revisions have their anchor:
+  gc mail send {{notify}} -s "ai-journal-new: PR opened" -m "<PR-URL>/files
+  tracking bead: <id>  (revise from PR feedback: gc formula cook ai-journal-revise --var entry_bead=<id>)"
+(If you already mailed an abort in an earlier step, skip this.)
+"""

--- a/_gascity/formulas/ai-journal-revise.toml
+++ b/_gascity/formulas/ai-journal-revise.toml
@@ -1,11 +1,16 @@
 formula = "ai-journal-revise"
-description = "Revise an existing AI-journal entry PR from review feedback: rehydrate the research dossier + PR comments + existing branch, apply the changes, push the SAME branch so the PR updates in place, append the rev to the dossier, and mail. Never pushes to main, never opens a second PR."
+description = "Revise an existing AI-journal entry PR from review feedback: read the tracking bead id from the PR description, rehydrate the research dossier + PR comments + existing branch, apply the changes, push the SAME branch so the PR updates in place, append the rev to the dossier, and mail. Never pushes to main, never opens a second PR."
 
-# vapor = root-only wisp; one agent runs the steps in sequence.
+# vapor = root-only wisp; ONE agent runs the steps in sequence, so the bead id
+# resolved in `hydrate` is carried in-context through the later steps.
 phase = "vapor"
 
+[vars.pr]
+description = "PR number or URL to revise (e.g. 692). The tracking bead id is read from the PR description's `Tracking-bead:` line — so you only need the PR, nothing to remember."
+default = ""
+
 [vars.entry_bead]
-description = "Tracking bead id from ai-journal-new. Holds the research dossier (design field) plus the PR URL + branch (notes). The revision rehydrates entirely from it."
+description = "Optional override of the tracking bead id. Normally left blank: hydrate reads it from the PR's `Tracking-bead:` line. Set only for legacy PRs that predate that convention."
 default = ""
 
 [vars.blog_repo]
@@ -18,20 +23,28 @@ default = "mayor"
 
 [[steps]]
 id = "hydrate"
-title = "Rehydrate research + content + feedback (do NOT redo the research)"
+title = "Resolve the bead from the PR, then rehydrate research + content + feedback"
 description = """
-Load everything the prior agent learned so this fresh session starts with full context:
-  gc bd show {{entry_bead}}      # dossier is in the design field; PR URL + branch in notes
-  gh pr view <PR> --comments     # the review feedback to address (use the PR from the bead)
+The PR is self-describing: ai-journal-new writes a `Tracking-bead: <id>` line into the
+PR description. Resolve the bead from the PR (or use the {{entry_bead}} override):
+  BEAD="{{entry_bead}}"
+  [ -n "$BEAD" ] || BEAD=$(gh pr view {{pr}} --json body -q .body | sed -n 's/^Tracking-bead:[[:space:]]*//p' | head -1)
+  echo "tracking bead = $BEAD"   # report this; the later steps act on this same bead
 
-Cut a worktree on the EXISTING branch (NOT a new one) so the PR updates in place:
+Load everything the prior agent learned so this fresh session starts with full context
+— do NOT redo the research:
+  gc bd show "$BEAD"             # dossier is in the design field; PR URL + branch in notes
+  gh pr view {{pr}} --comments   # the review feedback to address
+
+Cut a worktree on the PR's EXISTING branch (NOT a new one) so the PR updates in place:
+  BR=$(gh pr view {{pr}} --json headRefName -q .headRefName)
   git -C {{blog_repo}} fetch origin --prune
-  git -C {{blog_repo}} worktree add "{{blog_repo}}/.worktrees/<branch>" <branch>
-  cd "{{blog_repo}}/.worktrees/<branch>"
+  git -C {{blog_repo}} worktree add "{{blog_repo}}/.worktrees/$BR" "$BR"
+  cd "{{blog_repo}}/.worktrees/$BR"
 
-Report: a one-paragraph dossier summary, the list of open feedback items, and the
-worktree path. If the dossier already answers a feedback item, note that — you will not
-re-research it.
+Report: the resolved bead id, a one-paragraph dossier summary, the open feedback items,
+and the worktree path. If the dossier already answers a feedback item, note that — you
+will not re-research it.
 """
 
 [[steps]]
@@ -41,9 +54,9 @@ needs = ["hydrate"]
 description = """
 Make the requested changes to _d/ai-journal.md, addressing each feedback item and
 keeping the author's voice. If a feedback item needs NEW research (a number or a link
-the dossier does not already have), find it ONCE and APPEND it to the dossier so future
-revisions inherit it instead of re-deriving it:
-  gc bd update {{entry_bead}} --design "<updated dossier markdown>"
+the dossier does not already have), find it ONCE and APPEND it to the tracking bead's
+dossier (the bead id resolved in hydrate) so future revisions inherit it:
+  gc bd update <tracking-bead> --design "<updated dossier markdown>"
 Edit ONLY _d/ai-journal.md.
 """
 
@@ -65,8 +78,8 @@ id = "persist-notify"
 title = "Log the rev on the bead + mail the outcome"
 needs = ["land"]
 description = """
-Append a short decision-log entry so the NEXT revision sees this rev's history
-(confirm the exact comment subcommand with `gc bd --help`):
-  gc bd comment {{entry_bead}} "rev: <what changed>  (addressed: <feedback items>)"
+Append a short decision-log entry to the tracking bead (resolved in hydrate) so the NEXT
+revision sees this rev's history (confirm the exact comment subcommand with `gc bd --help`):
+  gc bd comment <tracking-bead> "rev: <what changed>  (addressed: <feedback items>)"
   gc mail send {{notify}} -s "ai-journal-revise: PR updated" -m "<PR-URL>/files  <one-line summary>"
 """

--- a/_gascity/formulas/ai-journal-revise.toml
+++ b/_gascity/formulas/ai-journal-revise.toml
@@ -1,0 +1,72 @@
+formula = "ai-journal-revise"
+description = "Revise an existing AI-journal entry PR from review feedback: rehydrate the research dossier + PR comments + existing branch, apply the changes, push the SAME branch so the PR updates in place, append the rev to the dossier, and mail. Never pushes to main, never opens a second PR."
+
+# vapor = root-only wisp; one agent runs the steps in sequence.
+phase = "vapor"
+
+[vars.entry_bead]
+description = "Tracking bead id from ai-journal-new. Holds the research dossier (design field) plus the PR URL + branch (notes). The revision rehydrates entirely from it."
+default = ""
+
+[vars.blog_repo]
+description = "Absolute path to the blog repo checkout (worktree base)."
+default = "/home/developer/gits/idvorkin.github.io"
+
+[vars.notify]
+description = "gc mail recipient to notify on completion."
+default = "mayor"
+
+[[steps]]
+id = "hydrate"
+title = "Rehydrate research + content + feedback (do NOT redo the research)"
+description = """
+Load everything the prior agent learned so this fresh session starts with full context:
+  gc bd show {{entry_bead}}      # dossier is in the design field; PR URL + branch in notes
+  gh pr view <PR> --comments     # the review feedback to address (use the PR from the bead)
+
+Cut a worktree on the EXISTING branch (NOT a new one) so the PR updates in place:
+  git -C {{blog_repo}} fetch origin --prune
+  git -C {{blog_repo}} worktree add "{{blog_repo}}/.worktrees/<branch>" <branch>
+  cd "{{blog_repo}}/.worktrees/<branch>"
+
+Report: a one-paragraph dossier summary, the list of open feedback items, and the
+worktree path. If the dossier already answers a feedback item, note that — you will not
+re-research it.
+"""
+
+[[steps]]
+id = "apply"
+title = "Apply the feedback (research once, persist forever)"
+needs = ["hydrate"]
+description = """
+Make the requested changes to _d/ai-journal.md, addressing each feedback item and
+keeping the author's voice. If a feedback item needs NEW research (a number or a link
+the dossier does not already have), find it ONCE and APPEND it to the dossier so future
+revisions inherit it instead of re-deriving it:
+  gc bd update {{entry_bead}} --design "<updated dossier markdown>"
+Edit ONLY _d/ai-journal.md.
+"""
+
+[[steps]]
+id = "land"
+title = "Push the SAME branch (the existing PR updates in place)"
+needs = ["apply"]
+description = """
+Light gate: confirm `git status --porcelain` shows ONLY _d/ai-journal.md changed.
+Then commit and push the SAME branch — do NOT open a new PR, do NOT push to main:
+  git add _d/ai-journal.md
+  git commit -m "fix(ai-journal): address review feedback"
+  git push            # same branch -> the existing PR updates
+If the push is rejected because the branch moved, rebase onto origin/<branch> and retry.
+"""
+
+[[steps]]
+id = "persist-notify"
+title = "Log the rev on the bead + mail the outcome"
+needs = ["land"]
+description = """
+Append a short decision-log entry so the NEXT revision sees this rev's history
+(confirm the exact comment subcommand with `gc bd --help`):
+  gc bd comment {{entry_bead}} "rev: <what changed>  (addressed: <feedback items>)"
+  gc mail send {{notify}} -s "ai-journal-revise: PR updated" -m "<PR-URL>/files  <one-line summary>"
+"""

--- a/_gascity/formulas/ai-journal-revise.toml
+++ b/_gascity/formulas/ai-journal-revise.toml
@@ -34,7 +34,16 @@ PR description. Resolve the bead from the PR (or use the {{entry_bead}} override
 Load everything the prior agent learned so this fresh session starts with full context
 — do NOT redo the research:
   gc bd show "$BEAD"             # dossier is in the design field; PR URL + branch in notes
-  gh pr view {{pr}} --comments   # the review feedback to address
+
+Gather ALL feedback robustly — this is where a naive fetch fails. Do NOT rely on
+`gh pr view --comments` alone, and do NOT trust a bot's "N actionable comments" summary
+as the total: one verbose bot comment can bury a human one, and a truncated fetch hides
+the rest. Enumerate every review THREAD with its resolution state via GraphQL (nothing
+truncated, humans and bots equally visible), then address every thread where isResolved
+is false:
+  gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{isResolved path comments(first:5){nodes{author{login} body}}}}}}}' -F o=<owner> -F r=<repo> -F n=<pr-number>
+Resolved/outdated threads are done; isResolved=false threads are your TODO list — reply
+to and resolve each one as you address it.
 
 Cut a worktree on the PR's EXISTING branch (NOT a new one) so the PR updates in place:
   BR=$(gh pr view {{pr}} --json headRefName -q .headRefName)
@@ -74,9 +83,23 @@ If the push is rejected because the branch moved, rebase onto origin/<branch> an
 """
 
 [[steps]]
+id = "verify-addressed"
+title = "Verify NO review thread is left unaddressed (USE JUDGMENT)"
+needs = ["land"]
+description = """
+Before declaring the rev done, prove you addressed everything — re-enumerate the review
+threads and assert NONE is still unresolved:
+  gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{isResolved comments(first:1){nodes{author{login} body}}}}}}}' -F o=<owner> -F r=<repo> -F n=<pr-number>
+PASS only if EVERY thread has isResolved=true. For each thread you addressed, post a
+reply and resolve it. If any thread is still isResolved=false you are NOT done: address
+it now, or — if it is genuinely out of scope / a non-issue — reply explaining why and
+resolve it. Do NOT proceed to notify while any thread is open.
+"""
+
+[[steps]]
 id = "persist-notify"
 title = "Log the rev on the bead + mail the outcome"
-needs = ["land"]
+needs = ["verify-addressed"]
 description = """
 Append a short decision-log entry to the tracking bead (resolved in hydrate) so the NEXT
 revision sees this rev's history (confirm the exact comment subcommand with `gc bd --help`):

--- a/_gascity/specs/2026-06-10-ai-journal-formula-design.md
+++ b/_gascity/specs/2026-06-10-ai-journal-formula-design.md
@@ -80,12 +80,15 @@ worktree and keep a pointer on the bead.
    persist it to a new tracking bead's `design`. Output the bead id.
 3. **draft-entry** — write the formatted entry at the top of Diary + update TOC,
    editing only `_d/ai-journal.md`.
-4. **verify** _(judgment gate)_ — only `_d/ai-journal.md` changed; format right;
-   every deep link resolves and matches the dossier; nothing fabricated; correct
-   base. Abort + mail on failure.
-5. **land** — commit, push branch to fork, open PR vs canonical main **with a
+4. **rebuild-backlinks** — `just worktree-init` (jekyll build so `_site` reflects the
+   entry) → `just update-backlinks` to regenerate `back-links.json`, so the entry's
+   links are indexed and don't go stale on merge.
+5. **verify** _(judgment gate)_ — only `_d/ai-journal.md` + `back-links.json` changed;
+   format right; every deep link resolves and matches the dossier; nothing fabricated;
+   correct base. Abort + mail on failure.
+6. **land** — commit both files, push branch to fork, open PR vs canonical main **with a
    `Tracking-bead: <id>` line in the PR body**; stamp PR + branch back on the bead.
-6. **notify** — mail the PR link + bead id.
+7. **notify** — mail the PR link + bead id.
 
 ## Formula 2: `ai-journal-revise`
 

--- a/_gascity/specs/2026-06-10-ai-journal-formula-design.md
+++ b/_gascity/specs/2026-06-10-ai-journal-formula-design.md
@@ -1,0 +1,119 @@
+# AI Journal Formula — Design Spec
+
+- **Date:** 2026-06-10
+- **Status:** Design approved; formulas authored (not yet cook-tested)
+- **Scope:** Two Gas City formulas in the blog rig that draft and revise entries
+  in `_d/ai-journal.md`.
+
+## Goal
+
+Let the author drop **rough notes** and get back a **polished, deep-linked
+journal entry as a PR** — then drive revisions from PR feedback without the
+revising agent having to redo the original research. State (especially the
+research) lives in beads and the PR, so **any session can run any revision**.
+
+Modeled directly on the existing, battle-tested `blog-backlinks` formula
+(`_gascity/formulas/blog-backlinks.toml`): `vapor` phase, parameterized
+`[vars]`, `[[steps]]` with `needs`, a real judgment gate, worktree isolation,
+**never pushes to main**, opens a clean PR, mails the outcome.
+
+## What already exists (reused, not reinvented)
+
+- **`blog-backlinks` formula** — the proven mechanical pattern. We swap its
+  "rebuild backlinks" middle for "research + draft entry"; the
+  worktree/verify/land/notify mechanics are unchanged.
+- **`_d/ai-journal.md` → `## Instructions for Claude: Creating Journal Entries`**
+  — the content spec the agent reads at runtime: new `### YYYY-MM-DD` at the top
+  of Diary, `#### Title`, **TOP Takeaway / The Problem / What Worked / What
+  Didn't**, deep GitHub commit-permalinks with line numbers, update the TOC.
+
+## Decisions (from brainstorm)
+
+1. **Job:** draft & add a new dated entry.
+2. **Input:** author pastes rough notes (via a `notes_file` var).
+3. **Review:** in the PR. The PR is the gate; nothing reaches main without a
+   human merge.
+4. **State across revisions:** persisted in beads + the PR; the agent is
+   stateless and rehydrated each rev.
+5. **Research persistence:** a **research dossier** stored on a tracking bead,
+   loaded at the start of every rev so research is never redone or drifted.
+
+## State model (the heart of the design)
+
+Three layers, each in the place that survives a dead session:
+
+| Layer                         | Lives in           | Holds                                                                                   |
+| ----------------------------- | ------------------ | --------------------------------------------------------------------------------------- |
+| Final content                 | the branch         | the entry itself                                                                        |
+| Feedback                      | PR review comments | what to change                                                                          |
+| **Research / working memory** | **tracking bead**  | claim→permalink map, sources read, links considered/rejected, open questions, reasoning |
+
+**Tracking bead** — a dedicated, long-lived bead (NOT the ephemeral molecule
+root, which closes when a cook completes). Created by `ai-journal-new`, it
+carries:
+
+- title/slug of the entry,
+- **PR URL + branch name** (the anchor revisions use),
+- **`design` field = the current research dossier** (replaceable, updated each
+  rev),
+- **comments = append-only per-rev decision log** ("rev 2: tightened takeaway,
+  dropped the Telegram tangent per reviewer").
+
+If a dossier outgrows the `design` field, spill it to a scratch file in the
+worktree and keep a pointer on the bead.
+
+## Formula 1: `ai-journal-new`
+
+**`[vars]`**: `notes_file` (required), `sources` (optional), `blog_repo`,
+`base_branch`, `notify` (defaults match `blog-backlinks`).
+
+**`[[steps]]`**
+
+1. **fresh-worktree** — isolated worktree off `{{base_branch}}`.
+2. **research** — read notes + the `Instructions for Claude` spec + mine
+   `{{sources}}`; walk git history for exact permalinks; build the dossier and
+   persist it to a new tracking bead's `design`. Output the bead id.
+3. **draft-entry** — write the formatted entry at the top of Diary + update TOC,
+   editing only `_d/ai-journal.md`.
+4. **verify** _(judgment gate)_ — only `_d/ai-journal.md` changed; format right;
+   every deep link resolves and matches the dossier; nothing fabricated; correct
+   base. Abort + mail on failure.
+5. **land** — commit, push branch to fork, PR vs canonical main; stamp PR +
+   branch on the tracking bead.
+6. **notify** — mail the PR link + bead id.
+
+## Formula 2: `ai-journal-revise`
+
+**`[vars]`**: `entry_bead` (required), `blog_repo`, `notify`.
+
+**`[[steps]]`**
+
+1. **hydrate** — load the bead (dossier + PR + branch), `gh pr view --comments`,
+   `git worktree add` the **existing** branch.
+2. **apply** — make the changes; append any new research to the dossier.
+3. **land** — push the **same branch** (PR updates in place); only-`ai-journal.md`
+   check.
+4. **persist-notify** — append a rev comment to the bead; mail.
+
+## Invariants / safety
+
+- **Never push to main.** Worktree isolation. Judgment gate in `new`, light
+  check in `revise`. NDI: all durable state in the bead + PR; the agent holds
+  none.
+
+## Out of scope / future
+
+- Autonomous rev loop: an **Order** gated on a "PR review submitted" event that
+  auto-cooks `ai-journal-revise` (needs PR events on the bus). Deferred.
+
+## Status / how to use once merged
+
+```
+# new entry
+gc formula cook ai-journal-new --var notes_file=~/tmp/agent/ai-journal/notes-<slug>.md
+# revise from PR feedback (bead id comes from the new-entry mail)
+gc formula cook ai-journal-revise --var entry_bead=<id>
+```
+
+These formulas are authored against the `blog-backlinks` pattern but have not yet
+been cook-tested end-to-end; first run should be watched.

--- a/_gascity/specs/2026-06-10-ai-journal-formula-design.md
+++ b/_gascity/specs/2026-06-10-ai-journal-formula-design.md
@@ -95,12 +95,16 @@ worktree and keep a pointer on the bead.
 **`[[steps]]`**
 
 1. **hydrate** — read the bead id from the PR's `Tracking-bead:` line, load the
-   bead (dossier), `gh pr view --comments`, `git worktree add` the PR's
-   **existing** branch.
+   bead (dossier), **enumerate every review thread via GraphQL** (not
+   `gh pr view --comments`, which can bury a human comment behind a bot's),
+   `git worktree add` the PR's **existing** branch.
 2. **apply** — make the changes; append any new research to the dossier.
 3. **land** — push the **same branch** (PR updates in place); only-`ai-journal.md`
    check.
-4. **persist-notify** — append a rev comment to the bead; mail.
+4. **verify-addressed** _(gate)_ — re-enumerate review threads; PASS only if **every
+   thread is resolved** (reply + resolve each as you address it). Don't notify with an
+   open thread.
+5. **persist-notify** — append a rev comment to the bead; mail.
 
 ## Invariants / safety
 

--- a/_gascity/specs/2026-06-10-ai-journal-formula-design.md
+++ b/_gascity/specs/2026-06-10-ai-journal-formula-design.md
@@ -108,7 +108,7 @@ worktree and keep a pointer on the bead.
 
 ## Status / how to use once merged
 
-```
+```shell
 # new entry
 gc formula cook ai-journal-new --var notes_file=~/tmp/agent/ai-journal/notes-<slug>.md
 # revise from PR feedback (bead id comes from the new-entry mail)

--- a/_gascity/specs/2026-06-10-ai-journal-formula-design.md
+++ b/_gascity/specs/2026-06-10-ai-journal-formula-design.md
@@ -53,11 +53,16 @@ root, which closes when a cook completes). Created by `ai-journal-new`, it
 carries:
 
 - title/slug of the entry,
-- **PR URL + branch name** (the anchor revisions use),
+- **PR URL + branch name** (bead → PR),
 - **`design` field = the current research dossier** (replaceable, updated each
   rev),
 - **comments = append-only per-rev decision log** ("rev 2: tightened takeaway,
   dropped the Telegram tangent per reviewer").
+
+**The link is bidirectional.** `ai-journal-new` also writes a
+`Tracking-bead: <id>` line into the **PR description** (PR → bead), so
+`ai-journal-revise` needs only the PR number — it reads the bead id straight from
+the PR and rehydrates. Nothing to remember or pass.
 
 If a dossier outgrows the `design` field, spill it to a scratch file in the
 worktree and keep a pointer on the bead.
@@ -78,18 +83,20 @@ worktree and keep a pointer on the bead.
 4. **verify** _(judgment gate)_ — only `_d/ai-journal.md` changed; format right;
    every deep link resolves and matches the dossier; nothing fabricated; correct
    base. Abort + mail on failure.
-5. **land** — commit, push branch to fork, PR vs canonical main; stamp PR +
-   branch on the tracking bead.
+5. **land** — commit, push branch to fork, open PR vs canonical main **with a
+   `Tracking-bead: <id>` line in the PR body**; stamp PR + branch back on the bead.
 6. **notify** — mail the PR link + bead id.
 
 ## Formula 2: `ai-journal-revise`
 
-**`[vars]`**: `entry_bead` (required), `blog_repo`, `notify`.
+**`[vars]`**: `pr` (required — PR number/URL), `entry_bead` (optional override),
+`blog_repo`, `notify`.
 
 **`[[steps]]`**
 
-1. **hydrate** — load the bead (dossier + PR + branch), `gh pr view --comments`,
-   `git worktree add` the **existing** branch.
+1. **hydrate** — read the bead id from the PR's `Tracking-bead:` line, load the
+   bead (dossier), `gh pr view --comments`, `git worktree add` the PR's
+   **existing** branch.
 2. **apply** — make the changes; append any new research to the dossier.
 3. **land** — push the **same branch** (PR updates in place); only-`ai-journal.md`
    check.


### PR DESCRIPTION
## What this adds

Two Gas City formulas in the blog rig to **draft and revise AI-journal entries**, modeled directly on the existing `blog-backlinks` formula (same `vapor`/vars/steps/judgment-gate/never-push-main/PR/mail mechanics).

- **`ai-journal-new`** — you paste rough notes (`notes_file`); the agent researches in an isolated worktree, **persists a research dossier to a tracking bead**, drafts the entry in the documented `ai-journal.md` format with deep commit-permalinks, runs a judgment gate (only `ai-journal.md` changed, links resolve), and opens a clean PR. Mails the PR link + bead id.
- **`ai-journal-revise`** — keyed on the tracking bead; **rehydrates the dossier + PR comments + existing branch**, applies feedback, and pushes the **same branch** so the PR updates in place. Never opens a second PR.

## The point: state survives across revisions

The agent is **stateless and replaceable**. Durable state lives where it survives a dead session:

| Layer | Lives in |
|---|---|
| Final content | the branch |
| Feedback | PR comments |
| **Research / working memory** | **tracking-bead dossier** (loaded every rev) |

So rev 2 — even a different agent days later — rehydrates the full research and never redoes the digging or drifts.

Design spec: `_gascity/specs/2026-06-10-ai-journal-formula-design.md`. Deferred: an Order-gated autonomous rev loop (needs PR events on the event bus).

## Status

Authored against the `blog-backlinks` pattern; **not yet cook-tested end-to-end** — first run should be watched. Reviewing here in the PR is the intended gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow for creating new AI journal entries with automated research documentation and pull request management.
  * Added workflow for revising existing AI journal entries by incorporating feedback while maintaining research context.
  * Both workflows include automated content verification, branch isolation, and email notifications upon completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->