### PR TITLE
ai-journal: My API Key Was Public for a Year

### DIFF
--- a/_d/ai-journal.md
+++ b/_d/ai-journal.md
@@ -19,6 +19,8 @@ A journal of random explorations in AI. Keeping track of them so I don't get los
 - [What I wrote summary](#what-i-wrote-summary)
 - [Upcoming](#upcoming)
 - [Diary](#diary)
+  - [2026-06-13](#2026-06-13)
+    - [My API Key Was Public for a Year](#my-api-key-was-public-for-a-year)
   - [2026-05-31](#2026-05-31)
     - [Friction = Focus: When Attention Stops Being a Proxy for Value](#friction--focus-when-attention-stops-being-a-proxy-for-value)
   - [2026-05-11](#2026-05-11)
@@ -255,6 +257,23 @@ lets see if we can simulate him, step #1, lets bring the site down into markdown
 - AI Music: My eulogy as a rap
 
 ## Diary
+
+### 2026-06-13
+
+#### My API Key Was Public for a Year
+
+- **TOP Takeaway**: A live Anthropic API key of mine sat in a public GitHub repo for about a year. Auto-capture tooling that commits session logs to a public repo is a landmine — one of my chop-logs hooks saved an entire code-review session, `ps`/env dump and all, straight into a _tracked, public_ repo. Rotate the key, gitignore the logs (or add a secret filter), and assume any key that's been public for a year is already harvested.
+- **The Problem**: I was deep in a debugging session — [Gas City](/gas-city) was down — when a `ps` dump spilled every API key into the transcript, because the city's tmux env exports them. My shell pushes ~20 secrets into _every_ shell via [`export_secrets`](https://github.com/idvorkin/settings/blob/9025a60cccdfc3f41e01c88c7764c39303b2ced2/shared/zsh_include.sh#L389-L420) — `ANTHROPIC_API_KEY` and `ASSEMBLYAI_API_KEY` among them. Seeing them on screen made me nervous, so I asked the obvious question: "did we leak these anywhere?"
+- **What Worked** — the agent did the forensic grind I'd never sit down and do by hand:
+  - **Found it**: turned up the live Anthropic key in my public [`idvorkin/Settings`](https://github.com/idvorkin/settings) repo, inside an auto-captured code-review log [committed 2025-05-26 in `36b971f`](https://github.com/idvorkin/settings/blob/36b971f81d7a4d6ec2c08539de1995874d72a12d/zz-chop-logs/2025-05-26_17-06-code-review-y-py-vs-clean-code-principles.md). Public for ~12 months.
+  - **Proved it was live**: a read-only `GET /v1/models` returned `200`. A working key, not an expired one.
+  - **Mapped the blast radius**: diffed every value in my private `secretBox.json` against the public repo's _full_ git history, plus a secret-pattern sweep across tracked files and history. Found a second key — an AssemblyAI key — in the same commit. Everything else clean.
+  - **Confirmed the fix took**: I revoked the key in the console; the agent re-probed → `401`. Dead, verified.
+  - This is the journal-worthy part: diffing a year of public history against a private secret store, validating a key against a live endpoint, then confirming the revocation — tedious, systematic, exactly what an agent is good at. By hand I'd have eyeballed it and moved on.
+- **What Didn't** — the uncomfortable parts:
+  - **The key was never even needed.** Claude Code runs on my Max subscription; the inherited env key was silently forcing per-token API billing instead of my plan — the same [cheap-coding-isn't-cheap dynamic from the $230 Week](#the-230-week-when-cheap-coding-isnt). Dropping it fixed the leak _and_ the billing.
+  - **The auto-capture pipeline had no secret filter.** A hook that commits session transcripts to a tracked public repo is the exact opposite of the [one-token-one-repo blast-radius discipline](#one-repo-one-token-the-closest-you-can-get-to-write-only-on-github) — an unscoped, unfiltered firehose into public. Mine ran for a year before I noticed.
+  - And the honest part: a key public that long should be assumed harvested. Revoking it closes the door now; I have no idea who already walked through.
 
 ### 2026-05-31
 


### PR DESCRIPTION
New AI-journal entry (2026-06-13): a live Anthropic API key sat in my public `idvorkin/Settings` repo for ~a year, committed there by an auto-capture chop-logs hook. An agent did the forensic grind — found it, proved it was still live (`GET /v1/models` → 200), mapped the blast radius across the repo's full git history (turned up a second AssemblyAI key in the same commit), and confirmed the revocation took (re-probe → 401). The kicker: the key was never needed (Claude Code runs on the Max plan) and was silently forcing per-token billing.

Single-file change to `_d/ai-journal.md` (entry + TOC). No secret values appear in the post; the still-public leak file is linked at its commit but never quoted.

Tracking-bead: bl-cnf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new diary entry "My API Key Was Public for a Year" documenting a security incident investigation and remediation process with key insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->