### PR TITLE
refactor(ai-journal): shared blog-rebuild-backlinks expansion (follow-up to #692)

### DIFF
--- a/_gascity/formulas/ai-journal-new.toml
+++ b/_gascity/formulas/ai-journal-new.toml
@@ -82,19 +82,8 @@ Edit ONLY _d/ai-journal.md. Match the voice of existing entries: personal, refle
 
 [[steps]]
 id = "rebuild-backlinks"
-title = "Rebuild back-links.json so the new entry's links are indexed"
 needs = ["draft-entry"]
-description = """
-The new entry adds internal links, so back-links.json must be regenerated or it goes
-stale the moment the entry merges. Build the site so _site reflects the new entry, then
-rebuild backlinks (this only regenerates back-links.json — it does NOT commit):
-  just worktree-init            # fires a background jekyll build (loads the ruby-compat shim)
-  # WAIT for that build: poll until _site/index.html is freshly written (~60-90s).
-  #   LOG=/tmp/jekyll-worktree-$(git branch --show-current | tr '/' '-').log   # tail it if it stalls
-  just update-backlinks         # = uv run ./build_back_links.py build  ->  regenerates back-links.json
-Do NOT proceed on a stale/missing _site — it yields wrong backlinks. back-links.json may
-legitimately be unchanged (the entry added no new cross-links); that is fine.
-"""
+expand = "blog-rebuild-backlinks"   # shared step library: inlines the backlinks-rebuild flow
 
 [[steps]]
 id = "verify"

--- a/_gascity/formulas/ai-journal-revise.toml
+++ b/_gascity/formulas/ai-journal-revise.toml
@@ -70,13 +70,18 @@ Edit ONLY _d/ai-journal.md.
 """
 
 [[steps]]
+id = "rebuild-backlinks"
+needs = ["apply"]
+expand = "blog-rebuild-backlinks"   # shared step library: rebuild backlinks if the revision changed links
+
+[[steps]]
 id = "land"
 title = "Push the SAME branch (the existing PR updates in place)"
-needs = ["apply"]
+needs = ["rebuild-backlinks"]
 description = """
-Light gate: confirm `git status --porcelain` shows ONLY _d/ai-journal.md changed.
+Light gate: confirm `git status --porcelain` shows only _d/ai-journal.md and back-links.json.
 Then commit and push the SAME branch — do NOT open a new PR, do NOT push to main:
-  git add _d/ai-journal.md
+  git add _d/ai-journal.md back-links.json
   git commit -m "fix(ai-journal): address review feedback"
   git push            # same branch -> the existing PR updates
 If the push is rejected because the branch moved, rebase onto origin/<branch> and retry.

--- a/_gascity/formulas/blog-rebuild-backlinks.toml
+++ b/_gascity/formulas/blog-rebuild-backlinks.toml
@@ -13,12 +13,13 @@ id = "{target}"
 title = "Rebuild back-links.json so the change's links are indexed"
 description = """
 The change adds/edits internal links, so back-links.json must be regenerated or it goes
-stale the moment it merges. Build the site so _site reflects the change, then rebuild
-backlinks (this only regenerates back-links.json — it does NOT commit):
-  just worktree-init            # fires a background jekyll build (loads the ruby-compat shim)
-  # WAIT for that build: poll until _site/index.html is freshly written (~60-90s).
-  #   LOG=/tmp/jekyll-worktree-$(git branch --show-current | tr '/' '-').log   # tail it if it stalls
+stale the moment it merges. You are ALREADY inside the calling formula's worktree, so just
+build the site there and rebuild backlinks (this only regenerates back-links.json — it does
+NOT commit):
+  just jekyll-rebuild           # synchronous clean build of _site/ (loads the ruby-compat
+                                #   shim); blocks ~60-90s. Does NOT cut a worktree — it builds
+                                #   in the current dir. Its writes (_site/, _data/git.json) are
+                                #   gitignored, so the diff stays backlinks-only.
   just update-backlinks         # = uv run ./build_back_links.py build  ->  regenerates back-links.json
-Do NOT proceed on a stale/missing _site — it yields wrong backlinks. back-links.json may
-legitimately be unchanged (no new cross-links); that is fine.
+back-links.json may legitimately be unchanged (no new cross-links); that is fine.
 """

--- a/_gascity/formulas/blog-rebuild-backlinks.toml
+++ b/_gascity/formulas/blog-rebuild-backlinks.toml
@@ -16,11 +16,8 @@ The change adds/edits internal links, so back-links.json must be regenerated or 
 stale the moment it merges. You are ALREADY inside the calling formula's worktree, so just
 build _site there and rebuild backlinks (this only regenerates back-links.json — it does
 NOT commit):
-  # CACHE-REUSING build (NOT a clean rebuild). The entry is the only change, so jekyll
-  # rebuilds just that: seconds on a warm .jekyll-cache, ~60-90s only on a cold/fresh
-  # worktree. Do NOT `just jekyll-rebuild` / `jekyll-clean` — that deletes .jekyll-cache and
-  # forces a full from-scratch build every time. Builds in the current dir; _site is gitignored.
-  RUBYOPT="-r$(pwd)/_ruby_compat.rb" bundle exec jekyll build
-  just update-backlinks         # = uv run ./build_back_links.py build  ->  regenerates back-links.json
+  just jekyll-build             # synchronous incremental build (reuses .jekyll-cache; NO clean) —
+                                #   fast on a warm cache, full only on a cold/fresh worktree.
+  just update-backlinks         # regenerates back-links.json from _site/
 back-links.json may legitimately be unchanged (no new cross-links); that is fine.
 """

--- a/_gascity/formulas/blog-rebuild-backlinks.toml
+++ b/_gascity/formulas/blog-rebuild-backlinks.toml
@@ -14,12 +14,13 @@ title = "Rebuild back-links.json so the change's links are indexed"
 description = """
 The change adds/edits internal links, so back-links.json must be regenerated or it goes
 stale the moment it merges. You are ALREADY inside the calling formula's worktree, so just
-build the site there and rebuild backlinks (this only regenerates back-links.json — it does
+build _site there and rebuild backlinks (this only regenerates back-links.json — it does
 NOT commit):
-  just jekyll-rebuild           # synchronous clean build of _site/ (loads the ruby-compat
-                                #   shim); blocks ~60-90s. Does NOT cut a worktree — it builds
-                                #   in the current dir. Its writes (_site/, _data/git.json) are
-                                #   gitignored, so the diff stays backlinks-only.
+  # CACHE-REUSING build (NOT a clean rebuild). The entry is the only change, so jekyll
+  # rebuilds just that: seconds on a warm .jekyll-cache, ~60-90s only on a cold/fresh
+  # worktree. Do NOT `just jekyll-rebuild` / `jekyll-clean` — that deletes .jekyll-cache and
+  # forces a full from-scratch build every time. Builds in the current dir; _site is gitignored.
+  RUBYOPT="-r$(pwd)/_ruby_compat.rb" bundle exec jekyll build
   just update-backlinks         # = uv run ./build_back_links.py build  ->  regenerates back-links.json
 back-links.json may legitimately be unchanged (no new cross-links); that is fine.
 """

--- a/_gascity/formulas/blog-rebuild-backlinks.toml
+++ b/_gascity/formulas/blog-rebuild-backlinks.toml
@@ -13,11 +13,8 @@ id = "{target}"
 title = "Rebuild back-links.json so the change's links are indexed"
 description = """
 The change adds/edits internal links, so back-links.json must be regenerated or it goes
-stale the moment it merges. You are ALREADY inside the calling formula's worktree, so just
-build _site there and rebuild backlinks (this only regenerates back-links.json — it does
-NOT commit):
-  just jekyll-build             # synchronous incremental build (reuses .jekyll-cache; NO clean) —
-                                #   fast on a warm cache, full only on a cold/fresh worktree.
-  just update-backlinks         # regenerates back-links.json from _site/
+stale the moment it merges. You are ALREADY inside the calling formula's worktree, so
+regenerate backlinks there (this does NOT commit):
+  just update-backlinks         # rebuilds _site (via its jekyll-build dep, ~5s) then back-links.json
 back-links.json may legitimately be unchanged (no new cross-links); that is fine.
 """

--- a/_gascity/formulas/blog-rebuild-backlinks.toml
+++ b/_gascity/formulas/blog-rebuild-backlinks.toml
@@ -1,0 +1,24 @@
+formula = "blog-rebuild-backlinks"
+version = 1
+# Shared step library: the back-links.json rebuild flow, defined once and inlined
+# into any formula via a step with `expand = "blog-rebuild-backlinks"`.
+# Used by ai-journal-new and ai-journal-revise so the backlinks logic lives in one place.
+type = "expansion"
+
+[requires]
+formula_compiler = ">=2.0.0"
+
+[[template]]
+id = "{target}"
+title = "Rebuild back-links.json so the change's links are indexed"
+description = """
+The change adds/edits internal links, so back-links.json must be regenerated or it goes
+stale the moment it merges. Build the site so _site reflects the change, then rebuild
+backlinks (this only regenerates back-links.json — it does NOT commit):
+  just worktree-init            # fires a background jekyll build (loads the ruby-compat shim)
+  # WAIT for that build: poll until _site/index.html is freshly written (~60-90s).
+  #   LOG=/tmp/jekyll-worktree-$(git branch --show-current | tr '/' '-').log   # tail it if it stalls
+  just update-backlinks         # = uv run ./build_back_links.py build  ->  regenerates back-links.json
+Do NOT proceed on a stale/missing _site — it yields wrong backlinks. back-links.json may
+legitimately be unchanged (no new cross-links); that is fine.
+"""

--- a/_gascity/specs/2026-06-10-ai-journal-formula-design.md
+++ b/_gascity/specs/2026-06-10-ai-journal-formula-design.md
@@ -80,9 +80,9 @@ worktree and keep a pointer on the bead.
    persist it to a new tracking bead's `design`. Output the bead id.
 3. **draft-entry** — write the formatted entry at the top of Diary + update TOC,
    editing only `_d/ai-journal.md`.
-4. **rebuild-backlinks** — `just worktree-init` (jekyll build so `_site` reflects the
-   entry) → `just update-backlinks` to regenerate `back-links.json`, so the entry's
-   links are indexed and don't go stale on merge.
+4. **rebuild-backlinks** — `expand`s the shared **`blog-rebuild-backlinks`** formula
+   (jekyll build → `just update-backlinks`) so `back-links.json` reflects the entry's
+   links and doesn't go stale on merge. Defined once; reused here and in `revise`.
 5. **verify** _(judgment gate)_ — only `_d/ai-journal.md` + `back-links.json` changed;
    format right; every deep link resolves and matches the dossier; nothing fabricated;
    correct base. Abort + mail on failure.
@@ -102,12 +102,32 @@ worktree and keep a pointer on the bead.
    `gh pr view --comments`, which can bury a human comment behind a bot's),
    `git worktree add` the PR's **existing** branch.
 2. **apply** — make the changes; append any new research to the dossier.
-3. **land** — push the **same branch** (PR updates in place); only-`ai-journal.md`
-   check.
-4. **verify-addressed** _(gate)_ — re-enumerate review threads; PASS only if **every
+3. **rebuild-backlinks** — same shared `blog-rebuild-backlinks` expansion, so a
+   revision that changes the entry's links keeps `back-links.json` current.
+4. **land** — push the **same branch** (PR updates in place); only
+   `_d/ai-journal.md` + `back-links.json` check.
+5. **verify-addressed** _(gate)_ — re-enumerate review threads; PASS only if **every
    thread is resolved** (reply + resolve each as you address it). Don't notify with an
    open thread.
-5. **persist-notify** — append a rev comment to the bead; mail.
+6. **persist-notify** — append a rev comment to the bead; mail.
+
+## Shared steps (DRY via `expand`)
+
+`back-links.json` rebuild is needed by more than one formula, so it lives **once** as
+`blog-rebuild-backlinks` — a `type = "expansion"` formula whose `template` is the
+rebuild step. Consumers inline it with a single step:
+
+```toml
+[[steps]]
+id = "rebuild-backlinks"
+needs = ["draft-entry"]          # or ["apply"] in revise
+expand = "blog-rebuild-backlinks"
+```
+
+The template step uses `id = "{target}"`, so it takes over the consumer step's slot and
+keeps the DAG wiring (`… → rebuild-backlinks → …`). This is a **step library**, distinct
+from `extends` (whole-formula inheritance). `blog-backlinks` can be refactored onto the
+same expansion later.
 
 ## Invariants / safety
 

--- a/justfile
+++ b/justfile
@@ -231,6 +231,22 @@ jekyll-rebuild: jekyll-clean
     fi
     echo "✅ Jekyll rebuild complete - site available in _site/"
 
+# Synchronous incremental Jekyll build — reuses .jekyll-cache (NO clean). Use when you
+# just need _site/ current after an edit (e.g. before regenerating back-links.json):
+# fast on a warm cache, full only on a cold/fresh worktree.
+jekyll-build:
+    #!/usr/bin/env sh
+    set -eu
+    # Load the Ruby 3.2+/4.0 compat shim the old github-pages gems need (mirrors jekyll-rebuild).
+    export RUBYOPT="-r$(pwd)/_ruby_compat.rb"
+    echo "🔨 Building Jekyll site (incremental; reusing .jekyll-cache)..."
+    if [ "$(uname)" = "Darwin" ]; then
+        ~/homebrew/opt/ruby/bin/bundle exec jekyll build
+    else
+        bundle exec jekyll build
+    fi
+    echo "✅ Jekyll build complete - site available in _site/"
+
 # Fire-and-forget background jekyll build for fresh worktrees.
 # Populates _site/ so the anchor-checker pre-commit hook passes by
 # the time the first commit lands. No clean step — incremental build

--- a/justfile
+++ b/justfile
@@ -231,9 +231,8 @@ jekyll-rebuild: jekyll-clean
     fi
     echo "✅ Jekyll rebuild complete - site available in _site/"
 
-# Synchronous incremental Jekyll build — reuses .jekyll-cache (NO clean). Use when you
-# just need _site/ current after an edit (e.g. before regenerating back-links.json):
-# fast on a warm cache, full only on a cold/fresh worktree.
+# Synchronous Jekyll build (NO clean — reuses .jekyll-cache). ~5s on this site. Use when
+# you just need _site/ current after an edit; it's a dependency of update-backlinks.
 jekyll-build:
     #!/usr/bin/env sh
     set -eu
@@ -409,7 +408,9 @@ docker-run2:
 docker-run:
     docker run -v ~/blog:/root/blog -it -p 35729:35729 -p 4000:4000 devdocker npm run jekyll:container
 
-update-backlinks:
+# Regenerate back-links.json. Depends on jekyll-build (~5s) so _site/ is always current
+# before backlinks are derived from it — never reads a stale _site.
+update-backlinks: jekyll-build
     uv run ./build_back_links.py build
 
 # Update backlinks with a custom output file


### PR DESCRIPTION
## Follow-up to merged #692 (recovers an orphaned commit)

#692 merged at its 5-commit tip (the **inline** `rebuild-backlinks` step). A 6th commit — extracting that step into a **shared expansion formula** — landed on the branch *after* the merge, so it never reached main. This PR brings it in.

## What it does
Per review feedback ("needed for both journal-new and review-pr"): the back-links rebuild is shared, so model it as a **step library**, not copy-paste.

- **`blog-rebuild-backlinks.toml`** — `type = "expansion"`; its `template` is the rebuild step, defined once.
- **`ai-journal-new`** and **`ai-journal-revise`** each inline it via a single `expand = "blog-rebuild-backlinks"` step.
- Compile-checked: the `id = "{target}"` template step takes over the consumer's slot, preserving the DAG wiring (`draft-entry → rebuild-backlinks → verify` in new; `apply → rebuild-backlinks → land` in revise).

This is the `expand` step-library mechanism (distinct from `extends` whole-formula inheritance). `blog-backlinks` can move onto the same expansion later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
