### PR TITLE
ai-security: link the Red-Teaming + AI-Safety explainer maps

### DIFF
--- a/_d/ai-security.md
+++ b/_d/ai-security.md
@@ -49,6 +49,8 @@ Security is super interesting, AI is super interesting, the combination, is supe
 
 ## Attack Vectors
 
+If you're a security person crossing into AI, I built a [Red Teaming ramp-up map](https://idvorkin-ai-tools.github.io/red-teaming-ramp-up/) that lays out the territory below — the OWASP LLM Top 10, the jailbreak canon, tooling, and evals — as a single field map to ramp up on.
+
 ### Leaked System Prompts
 
 A bunch of [leaked prompts](https://github.com/wunderwuzzi23/scratch/tree/master/system_prompts). You can see of the attack mitigations in them.
@@ -182,6 +184,8 @@ As mapped to chapters in :qa
 - LLM10: Model theft | Unauthorized access and extraction of LLM models can lead to economic losses and data breaches. | Chapter 8 (discussed as model cloning)
 
 ## AI Safety/Ethics
+
+Safety is its own field, adjacent to security but not the same. I built an [AI Safety field map](https://idvorkin-ai-tools.github.io/ai-safety-field-map/) covering the failure modes, the alignment canon, interpretability, evals, and governance — a companion to the red-teaming map above for the safety side of the house.
 
 ### Protecting Users from Mental Harm
 


### PR DESCRIPTION
Adds pointers to two explainer sites Igor built, integrated into existing sections (no raw link dump):

- **[Red Teaming ramp-up map](https://idvorkin-ai-tools.github.io/red-teaming-ramp-up/)** — woven into the top of the **Attack Vectors** section as a field map (OWASP LLM Top 10, jailbreak canon, tooling, evals) for security folks crossing into AI.
- **[AI Safety field map](https://idvorkin-ai-tools.github.io/ai-safety-field-map/)** — added to the **AI Safety/Ethics** section (failure modes, alignment canon, interpretability, evals, governance).

Body-only edits to an existing post; no new permalinks, no TOC-heading changes, no internal cross-links touched (both links are external), so backlinks/TOC rebuilds are no-ops. Both URLs verified live (HTTP 200).

[Diff](https://github.com/idvorkin/idvorkin.github.io/pull/files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced AI security documentation with newly added external resource references.
  * Integrated a red-teaming ramp-up map link in the Attack Vectors section to guide security and penetration testing practitioners.
  * Added an AI safety field map reference in the AI Safety/Ethics section as a companion resource for building trustworthy and ethical AI systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->