### PR TITLE
time-off-2026-07: link the Scandinavian trip map/site

### DIFF
--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -10,6 +10,8 @@ redirect_from:
 
 22 days, 5 countries, 4 Dvorkins, one whirlwind tour. From Reykjavík to Amsterdam by way of Stockholm, Oslo, and the Norwegian fjords. This is the first time we've attempted a trip of this scope as a family — the kids are 16 and 12, both still home, and the window for "all four of us on the road together" closes faster than I'd like.
 
+> 🗺️ **Trip map & city guide:** [Scandinavian Whirlwind 2026 →](https://idvorkin-ai-tools.github.io/scandinavia-2026/) — one page per stop (Iceland → Copenhagen → Stockholm → Oslo → fjords → Amsterdam), with things to do, hours, and a live weather table.
+
 For context on why I take time off: [/time-off](/time-off).
 
 ## At a Glance


### PR DESCRIPTION
Adds a prominent callout near the top of the July 2026 time-off page linking to the standalone Scandinavian trip site (one page per stop: Iceland → Copenhagen → Stockholm → Oslo → fjords → Amsterdam, with things to do, hours, and a live weather table).

Body-only edit to `_d/time-off-2026-07.md` — external github.io link, so no backlinks index change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Trip map & city guide” callout to the time-off travel plan.
  * Included a link to a city-by-city guide covering each stop on the itinerary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->