### PR TITLE
trusts: rewrite intro in Igor's article voice

### DIFF
--- a/_d/trusts.md
+++ b/_d/trusts.md
@@ -9,7 +9,9 @@ comments: true
 permalink: /trusts
 ---
 
-_General information, not legal or tax advice — see disclaimer at the end. All figures verified against current sources as of June 2026._
+Most estate-planning advice on the web is either lawyer-jargon written for other lawyers, or generic "everyone needs a trust!" content that ignores where you actually live. This post is the trusts slice of my notes — what a plain revocable living trust actually does, what a credit shelter trust is, and why Washington's own estate tax (a low ~$3M exemption and, critically, **no spousal portability**) is the difference between your family keeping one exemption or two. It also covers the "qualified" trusts people half-remember (QTIP, and QDOT for a non-citizen / green-card spouse), the income-tax and step-up tradeoffs, and worked examples — including the break-even math on when a trust _isn't_ worth it.
+
+For capital gains, step-up in basis, and retirement-account mechanics, see the companion [taxes post](/taxes). _Not legal or tax advice — see the disclaimer at the end. Figures are current as of June 2026, and Washington's rules just changed, so confirm specifics with a WA estate attorney + CPA._
 
 <!-- prettier-ignore-start -->
 

--- a/back-links.json
+++ b/back-links.json
@@ -6387,7 +6387,8 @@
                 "/gap-year-igor",
                 "/money",
                 "/raccoon-history",
-                "/stock-concentration"
+                "/stock-concentration",
+                "/trusts"
             ],
             "last_modified": "2026-06-26T16:58:15.700461+00:00",
             "markdown_path": "_d/taxes.md",
@@ -7281,15 +7282,17 @@
             "url": "/tribe"
         },
         "/trusts": {
-            "description": "General information, not legal or tax advice — see disclaimer at the end. All figures verified against current sources as of June 2026.\n\n",
+            "description": "Most estate-planning advice on the web is either lawyer-jargon written for other lawyers, or generic “everyone needs a trust!” content that ignores where you actually live. This post is the trusts slice of my notes — what a plain revocable living trust actually does, what a credit shelter trust is, and why Washington’s own estate tax (a low ~$3M exemption and, critically, no spousal portability) is the difference between your family keeping one exemption or two. It also covers the “qualified” trusts people half-remember (QTIP, and QDOT for a non-citizen / green-card spouse), the income-tax and step-up tradeoffs, and worked examples — including the break-even math on when a trust isn’t worth it.\n\n",
             "doc_size": 72000,
             "file_path": "_site/trusts.html",
             "incoming_links": [
                 "/taxes"
             ],
-            "last_modified": "2026-06-26T17:09:31.015345+00:00",
+            "last_modified": "2026-06-26T17:38:41.065528+00:00",
             "markdown_path": "_d/trusts.md",
-            "outgoing_links": [],
+            "outgoing_links": [
+                "/taxes"
+            ],
             "redirect_url": "",
             "title": "Trusts in Washington: Living Trust & Credit Shelter Trust",
             "url": "/trusts"


### PR DESCRIPTION
## Why a new PR

The intended target, #706, was already **merged** (merge commit `4259c6d1`, merged 17:36Z) before this intro rewrite could be pushed — so the follow-up commit on the fork branch became an orphan that would never reach `main` via #706. This PR carries the same change against current `main` instead.

## What changed

Replaces the weak opening of `/trusts` — a single italic "_General information, not legal or tax advice…_" disclaimer line — with a two-paragraph intro in your article voice:

- Frames what the post covers: revocable living trust, credit shelter trust, WA's ~$3M exemption with **no spousal portability**, QTIP/QDOT, the income-tax & step-up tradeoffs, and worked examples (incl. the break-even math).
- Points to the companion [`/taxes`](/taxes) post for capital gains, step-up in basis, and retirement-account mechanics.
- Keeps the "not legal or tax advice" framing inline and still references the full disclaimer at the end.

No headings changed, so the TOC stays valid. The end-of-article disclaimer is untouched. `back-links.json` regenerated for the new `trusts → taxes` edge.

[See the diff](https://github.com/idvorkin/idvorkin.github.io/pull/707/files)