### PR TITLE
time-off-2026-07: add Marble Church to Copenhagen list

### DIFF
--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -49,6 +49,7 @@ All 4 Dvorkins (Igor, Tori, Zach, Amelia). Iceland and Copenhagen legs are just 
 
 - Hang with Ammon — 2 days, no fixed agenda.
 - Walk Nyhavn + canals
+- **Marble Church (Marmorkirken)** — climb the dome tower for the Amalienborg→Opera axis + Sweden view
 - One nice meal as a family
 
 ### 🇸🇪 Stockholm (Jul 3–7) · [📍 map](https://www.google.com/maps/place/Stockholm)


### PR DESCRIPTION
Adds one Copenhagen bullet to the July 2026 Scandinavia trip post:

```
- **Marble Church (Marmorkirken)** — climb the dome tower for the Amalienborg→Opera axis + Sweden view
```

Placed in the *Things we want to do → 🇩🇰 Copenhagen* list (after the Nyhavn bullet), matching the bold-attraction bullet style used in the other legs. Mirrors the fuller entry added to the [scandinavia-2026 trip site](https://idvorkin-ai-tools.github.io/scandinavia-2026/) Copenhagen page.

Single-line addition to `_d/time-off-2026-07.md`. No new links/anchors, so no TOC or backlinks rebuild needed.

Diff: https://github.com/idvorkin/idvorkin.github.io/pull/716/files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJeRpNydrorWy5a2QHwgud