### PR TITLE
time-off: work-stress drain now takes a day, not a week

### DIFF
--- a/_d/time_off.md
+++ b/_d/time_off.md
@@ -86,7 +86,7 @@ These phases become even more pronounced with extended time off. For a deep expl
 
 ### Vegetation
 
-Work is stressful, it follows me home, and it takes several days to "[drain](/mind-at-work)". I think there's a relation between "draining my work stress" and vegetation. It takes me a solid week to get over that.
+Work is stressful, it follows me home, and it takes several days to "[drain](/mind-at-work)". I think there's a relation between "draining my work stress" and vegetation. It used to take me a solid week to get over that — but these days I can do it in about a day. I guess I'm getting better at work-life balance.
 
 ### TODO list
 


### PR DESCRIPTION
Small body-only edit to the Vegetation section of `_d/time_off.md`.

The old line said it takes a solid week to drain work stress. Updated to reflect that Igor now does it in about a day, crediting improved work-life balance.

**Before:**
> Work is stressful, it follows me home, and it takes several days to "[drain](/mind-at-work)". I think there's a relation between "draining my work stress" and vegetation. It takes me a solid week to get over that.

**After:**
> Work is stressful, it follows me home, and it takes several days to "[drain](/mind-at-work)". I think there's a relation between "draining my work stress" and vegetation. It used to take me a solid week to get over that — but these days I can do it in about a day. I guess I'm getting better at work-life balance.

No heading, TOC, or link changes — the `/mind-at-work` link is preserved. No backlink/TOC regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJeRpNydrorWy5a2QHwgud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Vegetation” section with refreshed wording about recovery time after work stress.
  * Added a note highlighting improved work-life balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->