### PR TITLE
Add /maybe — the "good luck, bad luck, who knows?" post

### DIFF
--- a/_d/maybe.md
+++ b/_d/maybe.md
@@ -45,4 +45,4 @@ After three great years at Amazon, I ended up on a team that was just a really b
 
 I went through a really rough stretch in my thirties — mental-breakdown territory, honestly, the worst I've ever felt. But it's what pushed me to treat sleep as sacred, build my [emotional-health habits](/emotional-health) (gratitude, meditation, the daily practices), discover the [7 Habits](/7h-concepts), and write my [eulogy](/eulogy) — the whole operating system I run my life on now. I wouldn't have built any of it if I hadn't needed to. Bad luck? Maybe.
 
-Good luck, bad luck — who knows? I've stopped rushing to render the verdict. The story is never finished, so instead of grading each turn I try to just keep living. You don't get the last word from life. But you always get to say: maybe.
+I still panic first, but I've been wrong so many times about which turns were good and which were bad that I wish I could remember you never can tell.

--- a/_d/maybe.md
+++ b/_d/maybe.md
@@ -18,6 +18,7 @@ There are a lot of these in my life — where I thought something was bad, but i
 - [The shoulder](#the-shoulder)
 - [The second phone](#the-second-phone)
 - [Amazon](#amazon)
+- [My thirties](#my-thirties)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
@@ -37,3 +38,7 @@ I didn't upgrade to the latest iPhone, and around the same time I decided to air
 ### Amazon
 
 I spent four years at Amazon, and it was just a bad fit. I wasn't happy, and that unhappiness got me pushed out — I didn't get the best review, which was genuinely stressful at the time. But the upside was that it made me realize I was in the wrong culture for me. So I went to Facebook, which was fantastic. Bad luck? Maybe.
+
+### My thirties
+
+I went through a really rough stretch in my thirties — mental-breakdown territory, honestly, the worst I've ever felt. But it's what taught me to treat sleep as sacred and to build the [emotional-health habits](/emotional-health) — the gratitude, the meditation, the daily practices — that I run my life on now. I wouldn't have built any of it if I hadn't needed to. Bad luck? Maybe.

--- a/_d/maybe.md
+++ b/_d/maybe.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Bad News — Maybe"
+title: "Bad News. Maybe Not."
 permalink: /maybe
 tags:
   - psychology
@@ -46,3 +46,5 @@ After three great years at Amazon, I ended up on a team that was just a really b
 I went through a really rough stretch in my thirties — mental-breakdown territory, honestly, the worst I've ever felt. But it's what pushed me to treat sleep as sacred, build my [emotional-health habits](/emotional-health) (gratitude, meditation, the daily practices), discover the [7 Habits](/7h-concepts), and write my [eulogy](/eulogy) — the whole operating system I run my life on now. I wouldn't have built any of it if I hadn't needed to. Bad luck? Maybe.
 
 I still panic first, but I've been wrong so many times about which turns were good and which were bad that I wish I could remember you never can tell.
+
+ps. I know every one of these ran bad-news-to-good-news. The reverse is just as true — the good news passes too. One of my affirmations is "this too shall pass," and it applies just as much in the good times as the bad.

--- a/_d/maybe.md
+++ b/_d/maybe.md
@@ -41,4 +41,4 @@ I spent four years at Amazon, and it was just a bad fit. I wasn't happy, and tha
 
 ### My thirties
 
-I went through a really rough stretch in my thirties — mental-breakdown territory, honestly, the worst I've ever felt. But it's what taught me to treat sleep as sacred and to build the [emotional-health habits](/emotional-health) — the gratitude, the meditation, the daily practices — that I run my life on now. I wouldn't have built any of it if I hadn't needed to. Bad luck? Maybe.
+I went through a really rough stretch in my thirties — mental-breakdown territory, honestly, the worst I've ever felt. But it's what pushed me to treat sleep as sacred, build my [emotional-health habits](/emotional-health) (gratitude, meditation, the daily practices), discover the [7 Habits](/7h-concepts), and write my [eulogy](/eulogy) — the whole operating system I run my life on now. I wouldn't have built any of it if I hadn't needed to. Bad luck? Maybe.

--- a/_d/maybe.md
+++ b/_d/maybe.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Maybe"
+title: "Bad News — Maybe"
 permalink: /maybe
 tags:
   - psychology
@@ -8,6 +8,8 @@ tags:
 ---
 
 A farmer's horse runs away. His neighbors console him: "What terrible luck!" The farmer shrugs, "Maybe." The next day the horse returns, leading a herd of wild horses behind it — "What wonderful luck!" "Maybe." His son tries to tame one, is thrown, and breaks his leg — "How awful!" "Maybe." A week later the army marches through, conscripting every able-bodied young man for a war most won't return from, and the son, with his broken leg, is passed over — "How wonderful!" "Maybe." Good luck, bad luck — who knows? The story is never finished, so the farmer never renders the verdict. He just keeps living.
+
+{% include ai-slop.html percent="30" %}
 
 There are a lot of these in my life — where I thought something was bad, but it turned out good.
 
@@ -18,27 +20,29 @@ There are a lot of these in my life — where I thought something was bad, but i
 - [The shoulder](#the-shoulder)
 - [The second phone](#the-second-phone)
 - [Amazon](#amazon)
-- [My thirties](#my-thirties)
+- [Mental breakdown in my thirties](#mental-breakdown-in-my-thirties)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
 
-### The latex allergy
+## The latex allergy
 
 I developed a latex allergy — a real problem when [balloon twisting](/balloon) is your thing. But it forced me to learn to twist wearing leather gloves, and leather gloves turn out to be wonderful: they don't squeak against the balloons the way bare hands do, so I can make balloons anywhere without that rubbery screech announcing me first. Bad luck? Maybe.
 
-### The shoulder
+## The shoulder
 
 I tweaked my shoulder doing Turkish get-ups — and discovered I'd been grinding the same sloppy form for years without realizing it. The injury forced me to rebuild my kettlebell technique from the ground up: now every rep is crisp, aligned, and dialed in. Bad luck? Maybe.
 
-### The second phone
+## The second phone
 
-I didn't upgrade to the latest iPhone, and around the same time I decided to air-gap my work onto a separate phone. It stressed me out — I hate carrying two phones, I was sure I'd lose one, I figured it'd be a hassle I'd regret. Then, on vacation, two phones turned out to be a gift: when Amelia forgets her phone or lets the battery die, I just hand her my spare — now she's reachable, trackable, and covered. Bad luck? Maybe.
+Work was starting to monitor my devices, and Facebook was getting aggressive about hunting for leaks — firing people even when it was likely a false positive or an accidental leak. I figured I'm sloppy enough that sooner or later I'd be one of those accidental leaks, so I air-gapped my work onto a separate laptop and phone. The laptop I didn't mind. But a second phone? I was sure that would be absolutely miserable — I hate carrying two phones, I figured I'd lose one, I figured I'd regret it. Then, on vacation, the second phone turned out to be a gift: when Amelia forgets her phone or lets the battery die, I just hand her my spare — now she's reachable, trackable, and covered. Bad luck? Maybe.
 
-### Amazon
+## Amazon
 
-I spent four years at Amazon, and it was just a bad fit. I wasn't happy, and that unhappiness got me pushed out — I didn't get the best review, which was genuinely stressful at the time. But the upside was that it made me realize I was in the wrong culture for me. So I went to Facebook, which was fantastic. Bad luck? Maybe.
+After three great years at Amazon, I ended up on a team that was just a really bad fit for me. That mismatch resulted in a very not-great review, which was genuinely stressful at the time. But it lit a fire under me: I studied hard and ended up with offers from Facebook, Google, Zillow, Indeed, and a couple of smaller companies. I picked Facebook — and have had an amazing six-year-and-counting career there. Bad luck? Maybe.
 
-### My thirties
+## Mental breakdown in my thirties
 
 I went through a really rough stretch in my thirties — mental-breakdown territory, honestly, the worst I've ever felt. But it's what pushed me to treat sleep as sacred, build my [emotional-health habits](/emotional-health) (gratitude, meditation, the daily practices), discover the [7 Habits](/7h-concepts), and write my [eulogy](/eulogy) — the whole operating system I run my life on now. I wouldn't have built any of it if I hadn't needed to. Bad luck? Maybe.
+
+Good luck, bad luck — who knows? I've stopped rushing to render the verdict. The story is never finished, so instead of grading each turn I try to just keep living. You don't get the last word from life. But you always get to say: maybe.

--- a/_d/maybe.md
+++ b/_d/maybe.md
@@ -1,0 +1,39 @@
+---
+layout: post
+title: "Maybe"
+permalink: /maybe
+tags:
+  - psychology
+  - emotional intelligence
+---
+
+A farmer's horse runs away. His neighbors console him: "What terrible luck!" The farmer shrugs, "Maybe." The next day the horse returns, leading a herd of wild horses behind it — "What wonderful luck!" "Maybe." His son tries to tame one, is thrown, and breaks his leg — "How awful!" "Maybe." A week later the army marches through, conscripting every able-bodied young man for a war most won't return from, and the son, with his broken leg, is passed over — "How wonderful!" "Maybe." Good luck, bad luck — who knows? The story is never finished, so the farmer never renders the verdict. He just keeps living.
+
+There are a lot of these in my life — where I thought something was bad, but it turned out good.
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [The latex allergy](#the-latex-allergy)
+- [The shoulder](#the-shoulder)
+- [The second phone](#the-second-phone)
+- [Amazon](#amazon)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+### The latex allergy
+
+I developed a latex allergy — a real problem when [balloon twisting](/balloon) is your thing. But it forced me to learn to twist wearing leather gloves, and leather gloves turn out to be wonderful: they don't squeak against the balloons the way bare hands do, so I can make balloons anywhere without that rubbery screech announcing me first. Bad luck? Maybe.
+
+### The shoulder
+
+I tweaked my shoulder doing Turkish get-ups — and discovered I'd been grinding the same sloppy form for years without realizing it. The injury forced me to rebuild my kettlebell technique from the ground up: now every rep is crisp, aligned, and dialed in. Bad luck? Maybe.
+
+### The second phone
+
+I didn't upgrade to the latest iPhone, and around the same time I decided to air-gap my work onto a separate phone. It stressed me out — I hate carrying two phones, I was sure I'd lose one, I figured it'd be a hassle I'd regret. Then, on vacation, two phones turned out to be a gift: when Amelia forgets her phone or lets the battery die, I just hand her my spare — now she's reachable, trackable, and covered. Bad luck? Maybe.
+
+### Amazon
+
+I spent four years at Amazon, and it was just a bad fit. I wasn't happy, and that unhappiness got me pushed out — I didn't get the best review, which was genuinely stressful at the time. But the upside was that it made me realize I was in the wrong culture for me. So I went to Facebook, which was fantastic. Bad luck? Maybe.

--- a/back-links.json
+++ b/back-links.json
@@ -4613,7 +4613,7 @@
                 "/eulogy"
             ],
             "redirect_url": "",
-            "title": "Bad News — Maybe",
+            "title": "Bad News. Maybe Not.",
             "url": "/maybe"
         },
         "/mental-pain": {

--- a/back-links.json
+++ b/back-links.json
@@ -435,7 +435,7 @@
         },
         "/4dx": {
             "description": "The 4 Disciplines of Execution (4DX) is a proven framework for executing your most important strategic priorities in the midst of the whirlwind of day-to-day demands. This framework has been tested and refined by hundreds of organizations and thousands of teams over many years.\n\n",
-            "doc_size": 21000,
+            "doc_size": 20000,
             "file_path": "_site/4dx.html",
             "incoming_links": [
                 "/first-things-first",
@@ -1649,6 +1649,7 @@
                 "/eulogy",
                 "/joy",
                 "/life-journal",
+                "/maybe",
                 "/timeoff"
             ],
             "last_modified": "2026-04-18T15:20:24.085147+00:00",
@@ -2688,7 +2689,7 @@
         },
         "/day-in-the-life": {
             "description": "A running journal of days that actually worked - the ones where health habits stuck, family time hit different, or I remembered what it feels like to be fully alive. Not every day needs to be Instagram-worthy, but some days deserve a bookmark. This is that bookmark collection.\n\n",
-            "doc_size": 19000,
+            "doc_size": 18000,
             "file_path": "_site/day-in-the-life.html",
             "incoming_links": [],
             "last_modified": "2025-10-04T18:43:51-07:00",
@@ -3386,7 +3387,7 @@
                 "/sharpen-the-saw",
                 "/spiritual-health"
             ],
-            "last_modified": "2026-02-01T10:48:25-08:00",
+            "last_modified": "2026-07-03T12:06:45-07:00",
             "markdown_path": "_d/four-healths.md",
             "outgoing_links": [
                 "/7-habits",
@@ -3677,7 +3678,7 @@
         },
         "/grammerly": {
             "description": "\n\n",
-            "doc_size": 13000,
+            "doc_size": 12000,
             "file_path": "_site/grammerly.html",
             "incoming_links": [],
             "last_modified": "2025-08-24T09:03:19-07:00",
@@ -4405,7 +4406,7 @@
                 "/ai-operator",
                 "/larry"
             ],
-            "last_modified": "2026-06-06T10:30:21-07:00",
+            "last_modified": "2026-07-01T13:05:11+02:00",
             "markdown_path": "_d/life-journal.md",
             "outgoing_links": [
                 "/ai-operator",
@@ -4595,6 +4596,20 @@
             "title": "Mania: It's like a free cocaine drip",
             "url": "/mania"
         },
+        "/maybe": {
+            "description": "A farmer’s horse runs away. His neighbors console him: “What terrible luck!” The farmer shrugs, “Maybe.” The next day the horse returns, leading a herd of wild horses behind it — “What wonderful luck!” “Maybe.” His son tries to tame one, is thrown, and breaks his leg — “How awful!” “Maybe.” A week later the army marches through, conscripting every able-bodied young man for a war most won’t return from, and the son, with his broken leg, is passed over — “How wonderful!” “Maybe.” Good luck, bad luck — who knows? The story is never finished, so the farmer never renders the verdict. He just keeps living.\n\n",
+            "doc_size": 16000,
+            "file_path": "_site/maybe.html",
+            "incoming_links": [],
+            "last_modified": "2026-07-06T16:15:51.147230+00:00",
+            "markdown_path": "_d/maybe.md",
+            "outgoing_links": [
+                "/balloon"
+            ],
+            "redirect_url": "",
+            "title": "Maybe",
+            "url": "/maybe"
+        },
         "/mental-pain": {
             "description": "Pain is in the brain as they say, which is especially true for mental pains. Pain isn’t the enemy though, pain is a signal. The pain system, when working properly draws our attention to a problem so that we can deal with it. However, our pain can evolve into unnecessary suffering, be phantom pain, meaning it is being applied when it should not be, or chronic pain, which flares up even though it is no longer providing value.\n\n",
             "doc_size": 37000,
@@ -4638,7 +4653,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 15000,
+            "doc_size": 14000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",
@@ -6368,7 +6383,7 @@
         },
         "/synergize": {
             "description": "We’ve all got stuff we’re good at and stuff we’re bad at. Combine them right and the system is greater than the sum of the parts — sometimes a lot greater. Synergy is the payoff for everything that came before: independence, Win/Win, and seeking first to understand all converge here. These are my insights from 7 habits Chapter 6.\n\n",
-            "doc_size": 29000,
+            "doc_size": 28000,
             "file_path": "_site/synergize.html",
             "incoming_links": [
                 "/7-habits",
@@ -6453,7 +6468,7 @@
         },
         "/td/back_ref": {
             "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
-            "doc_size": 14000,
+            "doc_size": 13000,
             "file_path": "_site/td/back_ref.html",
             "incoming_links": [],
             "last_modified": "2022-04-16T15:22:43-07:00",
@@ -6896,7 +6911,7 @@
                 "/timeoff-2025-08",
                 "/timeoff-2026-07"
             ],
-            "last_modified": "2026-06-23T07:20:47-07:00",
+            "last_modified": "2026-07-02T16:24:49+02:00",
             "markdown_path": "_d/time_off.md",
             "outgoing_links": [
                 "/addiction",
@@ -6926,7 +6941,7 @@
         },
         "/timeoff-2020-03": {
             "description": "In March 2020, I took a 2 month sabbatical between leaving Amazon and joining Facebook. Given it was a substantial amount of time, I came up with some big plans, and wrote them down. It was a great plan, BUT my time off correlated perfectly to the Corona Virus and as a result I wasted lots of my mental energy thinking about the Corona Virus, and adjusting to being in pseudo-quarantine. Took me a while, but I finally realized I should ignore corona virus, or at least minimize my time thinking about it.\n\n",
-            "doc_size": 31000,
+            "doc_size": 30000,
             "file_path": "_site/timeoff-2020-03.html",
             "incoming_links": [
                 "/timeoff"
@@ -7555,7 +7570,7 @@
         },
         "/weeks": {
             "description": "\n\n",
-            "doc_size": 4348000,
+            "doc_size": 4347000,
             "file_path": "_site/weeks.html",
             "incoming_links": [
                 "/balance"
@@ -7630,7 +7645,7 @@
         },
         "/win-win": {
             "description": "Win/Win is a constantly seeking mutual benefit in all interactions. Win/Win means that agreements or solutions are mutually beneficial, mutually satisfying. With a Win/Win solution, all parties feel good about the decision and feel committed to the action plan. Win/Win sees life as a cooperative, not a competitive arena. Most people tend to think in terms of dichotomies: strong or weak, hardball or softball, win or lose. But that kind of thinking is fundamentally flawed. It’s based on power and position rather than on principle. Win/Win is based on the paradigm that there is plenty for everybody, that one person’s success is not achieved at the expense or exclusion of the success of others.\n\n",
-            "doc_size": 48000,
+            "doc_size": 47000,
             "file_path": "_site/win-win.html",
             "incoming_links": [
                 "/7-habits",

--- a/back-links.json
+++ b/back-links.json
@@ -4601,7 +4601,7 @@
         },
         "/maybe": {
             "description": "A farmer’s horse runs away. His neighbors console him: “What terrible luck!” The farmer shrugs, “Maybe.” The next day the horse returns, leading a herd of wild horses behind it — “What wonderful luck!” “Maybe.” His son tries to tame one, is thrown, and breaks his leg — “How awful!” “Maybe.” A week later the army marches through, conscripting every able-bodied young man for a war most won’t return from, and the son, with his broken leg, is passed over — “How wonderful!” “Maybe.” Good luck, bad luck — who knows? The story is never finished, so the farmer never renders the verdict. He just keeps living.\n\n",
-            "doc_size": 16000,
+            "doc_size": 17000,
             "file_path": "_site/maybe.html",
             "incoming_links": [],
             "last_modified": "2026-07-06T16:15:51.147230+00:00",
@@ -4613,7 +4613,7 @@
                 "/eulogy"
             ],
             "redirect_url": "",
-            "title": "Maybe",
+            "title": "Bad News — Maybe",
             "url": "/maybe"
         },
         "/mental-pain": {

--- a/back-links.json
+++ b/back-links.json
@@ -504,6 +504,7 @@
                 "/7-habits",
                 "/advice",
                 "/greek-orthodox",
+                "/maybe",
                 "/podcast",
                 "/writing"
             ],
@@ -898,7 +899,7 @@
         },
         "/ai-cockpit": {
             "description": "Agents are slow. Not slow like “wait a second,” slow like “go make coffee and come back.” So you run several in parallel. But now you’ve got a different problem: you’re an air traffic controller with no radar. You need a cockpit - a physical and software control surface that gives you visibility into what your agents are doing and lets you switch between them instantly.\n\n",
-            "doc_size": 32000,
+            "doc_size": 31000,
             "file_path": "_site/ai-cockpit.html",
             "incoming_links": [
                 "/ai-feed",
@@ -3204,6 +3205,7 @@
                 "/irl",
                 "/joy",
                 "/life-journal",
+                "/maybe",
                 "/operating-manual",
                 "/raccoon-history",
                 "/retire",
@@ -4605,8 +4607,10 @@
             "last_modified": "2026-07-06T16:15:51.147230+00:00",
             "markdown_path": "_d/maybe.md",
             "outgoing_links": [
+                "/7h-concepts",
                 "/balloon",
-                "/emotional-health"
+                "/emotional-health",
+                "/eulogy"
             ],
             "redirect_url": "",
             "title": "Maybe",

--- a/back-links.json
+++ b/back-links.json
@@ -2942,6 +2942,7 @@
                 "/gap-year-igor",
                 "/irl",
                 "/mania",
+                "/maybe",
                 "/mind-at-work",
                 "/operating-manual",
                 "/process-journal",
@@ -4604,7 +4605,8 @@
             "last_modified": "2026-07-06T16:15:51.147230+00:00",
             "markdown_path": "_d/maybe.md",
             "outgoing_links": [
-                "/balloon"
+                "/balloon",
+                "/emotional-health"
             ],
             "redirect_url": "",
             "title": "Maybe",


### PR DESCRIPTION
New personal post at `/maybe` reflecting on the Taoist farmer parable ("good luck, bad luck — who knows?") through five moments in Igor's life that looked like bad luck and turned out good:

- **The latex allergy** — forced learning to twist balloons in leather gloves (which turn out to be better; links to [/balloon](/balloon))
- **The shoulder** — a Turkish get-up tweak that forced rebuilding kettlebell form
- **The second phone** — the air-gapped work phone that became a vacation gift
- **Amazon** — the bad fit that led to Facebook
- **My thirties** — the rough stretch that built the emotional-health habits he runs his life on (links to [/emotional-health](/emotional-health))

Front matter: `layout: post`, `title: "Maybe"`, `permalink: /maybe`, tags. TOC auto-generated (vim-markdown-toc markers). `back-links.json` rebuilt so `/balloon` and `/emotional-health` register `/maybe` as an incoming link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJeRpNydrorWy5a2QHwgud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new article, “Maybe,” with multiple sections and a short reflection on rethinking bad-luck moments.
* **Documentation**
  * Updated site link metadata so the new article appears in related content and navigation across several pages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->