### PR TITLE
Add raccoon shrug header to /maybe

### DIFF
--- a/_d/maybe.md
+++ b/_d/maybe.md
@@ -2,12 +2,15 @@
 layout: post
 title: "Bad News. Maybe Not."
 permalink: /maybe
+imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-maybe.webp
 tags:
   - psychology
   - emotional intelligence
 ---
 
 A farmer's horse runs away. His neighbors console him: "What terrible luck!" The farmer shrugs, "Maybe." The next day the horse returns, leading a herd of wild horses behind it — "What wonderful luck!" "Maybe." His son tries to tame one, is thrown, and breaks his leg — "How awful!" "Maybe." A week later the army marches through, conscripting every able-bodied young man for a war most won't return from, and the son, with his broken leg, is passed over — "How wonderful!" "Maybe." Good luck, bad luck — who knows? The story is never finished, so the farmer never renders the verdict. He just keeps living.
+
+{% include blob_image_float_right.html src="blog/raccoon-maybe.webp" %}
 
 {% include ai-slop.html percent="30" %}
 


### PR DESCRIPTION
Adds the header illustration for **/maybe** ("Bad News. Maybe Not.").

- Curious lopsided-shrug raccoon (shirt: "WHO KNOWS") — matches the farmer's parable "Maybe" refrain.
- Sets `imagefeature` (social/header card) and a `blob_image_float_right` include placed **immediately after the opening parable paragraph** (keeps the excerpt intact — never above the first paragraph).

Image lives in `idvorkin/blob`: **PR https://github.com/idvorkin/blob/pull/28** → `blog/raccoon-maybe.webp`.
Renders live once that blob PR merges (raw URL: https://github.com/idvorkin/blob/raw/master/blog/raccoon-maybe.webp).

Diff: https://github.com/idvorkin/idvorkin.github.io/pull/721/files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJeRpNydrorWy5a2QHwgud