### PR TITLE
maybe: reposition raccoon float below TOC (re-land, prior PR merged)

### DIFF
--- a/_d/maybe.md
+++ b/_d/maybe.md
@@ -10,8 +10,6 @@ tags:
 
 A farmer's horse runs away. His neighbors console him: "What terrible luck!" The farmer shrugs, "Maybe." The next day the horse returns, leading a herd of wild horses behind it — "What wonderful luck!" "Maybe." His son tries to tame one, is thrown, and breaks his leg — "How awful!" "Maybe." A week later the army marches through, conscripting every able-bodied young man for a war most won't return from, and the son, with his broken leg, is passed over — "How wonderful!" "Maybe." Good luck, bad luck — who knows? The story is never finished, so the farmer never renders the verdict. He just keeps living.
 
-{% include blob_image_float_right.html src="blog/raccoon-maybe.webp" %}
-
 {% include ai-slop.html percent="30" %}
 
 There are a lot of these in my life — where I thought something was bad, but it turned out good.
@@ -27,6 +25,8 @@ There are a lot of these in my life — where I thought something was bad, but i
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
+
+{% include blob_image_float_right.html src="blog/raccoon-maybe.webp" %}
 
 ## The latex allergy
 


### PR DESCRIPTION
## What

Re-lands a fix that was orphaned: commit `1ce0941eb` was pushed to the `maybe-raccoon-header` branch **after** its PR #721 had already merged, so the change never reached `main`.

Moves the raccoon float include in `_d/maybe.md` from just-after-the-opening-paragraph (where it collides with the full-width `ai-slop.html` box) to **below** the vim-markdown-toc block, right before `## The latex allergy`.

## Why

At the top position the floated raccoon overlaps the `ai-slop` info box. Below the TOC it floats cleanly alongside the first body section.

## Verification

- Exactly one `blob_image_float_right.html src="blog/raccoon-maybe.webp"` include remains.
- It now sits after `<!-- vim-markdown-toc-end -->` and before `## The latex allergy`.
- The opening-paragraph Jekyll excerpt is no longer preceded by an include (keeps RSS / social cards clean).

Branched fresh off `upstream/main`; cherry-picked the orphaned commit cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJeRpNydrorWy5a2QHwgud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Adjusted the placement of an image in the article so it now appears later in the page, closer to the table of contents section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->