### PR TITLE
Add 'sacrifice identity for consumption' epigraph (time-off + produce-consume)

### DIFF
--- a/_d/produce-consume.md
+++ b/_d/produce-consume.md
@@ -10,6 +10,10 @@ redirect_from:
 
 Remember when you finished binge-watching that entire series and felt... empty? Now remember the last time you made something — anything — even if it sucked. Which memory makes you smile? Yeah, me too. We live in the golden age of consumption, where infinite content is one thumb-swipe away, yet we're more anxious and less satisfied than ever. Here's the thing: you're not meant to be a consumer. You're meant to be a producer.
 
+> When you sacrifice identity for consumption, you end up with neither.
+
+Consumption doesn't just waste your time — it hollows out the producer you were meant to be.
+
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -10,6 +10,10 @@ redirect_from:
 
 22 days, 5 countries, 4 Dvorkins, one whirlwind tour. From Reykjavík to Amsterdam by way of Stockholm, Oslo, and the Norwegian fjords. This is the first time we've attempted a trip of this scope as a family — the kids are 16 and 12, both still home, and the window for "all four of us on the road together" closes faster than I'd like.
 
+> When you sacrifice identity for consumption, you end up with neither.
+
+The whole trap of time off in one sentence — vegetating _feels_ like rest, but it quietly starves the roles that make you _you_.
+
 > 🗺️ **Trip map & city guide:** [Scandinavian Whirlwind 2026 →](https://idvorkin-ai-tools.github.io/scandinavia-2026/) — one page per stop (Iceland → Copenhagen → Stockholm → Oslo → fjords → Amsterdam), with things to do, hours, and a live weather table.
 
 For context on why I take time off: [/time-off](/time-off).

--- a/_d/time_off.md
+++ b/_d/time_off.md
@@ -19,6 +19,10 @@ alias:
 
 Time off is critical, it's how we renew our energy, find our creativity, etc. Many people think of time off as synonymous with turning your 1 week off into an action-packed tour of Disneyland. But, there are other kinds of time off that we'll discuss too. Like most things, time off is a skill that can be improved by studying and applying your learnings. This post includes mine - note to self - read them!!
 
+> When you sacrifice identity for consumption, you end up with neither.
+
+The whole trap of time off in one sentence — vegetating _feels_ like rest, but it quietly starves the roles that make you _you_.
+
 <div class="alert alert-info" role="alert">
 ✈️ <strong>Next planned time-off — July 2026:</strong>
 <div class="summary-link body-only" href="/timeoff-2026-07"><a href="/timeoff-2026-07">Loading (/timeoff-2026-07)</a></div>


### PR DESCRIPTION
Adds Igor's aphorism as an epigraph near the top of /time-off (evergreen), the July 2026 Scandinavia trip post, and /produce-consume (where it's the thesis; pairs with the existing 'Identity Erosion' section).

> When you sacrifice identity for consumption, you end up with neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several articles with new reflective introductory passages.
  * Clarified messaging around identity, consumption, and the tension between rest and what sustains a person’s sense of self.
  * Added more emphasis to the emotional impact of time off and overconsumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->