### PR TITLE
Add ranked 'why I'm taking this time off' priorities to the 2026 trip post

### DIFF
--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -61,6 +61,8 @@ First one already banked: **meditation travels, and churches are the best place 
 
 📍 [See the full route on Google Maps](https://www.google.com/maps/dir/Reykjav%C3%ADk/Copenhagen/Stockholm/Oslo/Aurland/Voss/Bergen/Amsterdam) — 8 stops in one view.
 
+> 🧳 **Packing:** my reusable [packing master list](/packing) — the durable checklist every trip is trimmed from.
+
 ## Who's coming
 
 All 4 Dvorkins (Igor, Tori, Zach, Amelia). Iceland and Copenhagen legs are just us; Stockholm onward we're traveling with friends.

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -18,6 +18,18 @@ The whole trap of time off in one sentence — vegetating _feels_ like rest, but
 
 For context on why I take time off: [/time-off](/time-off).
 
+## Why I'm taking this time off — ranked
+
+[When you sacrifice identity for consumption, you end up with neither](/produce-consume). So I wrote down what I'm actually here for, in order:
+
+1. **Deepen my relationship with Amelia and Tori.**
+2. **Really meet whoever we're traveling with** — I put reasonable odds our kids end up woven into each other's lives for a long while. (Zach excepted — that bond I get for free.)
+3. **Escape** — except it turns out I have nothing to escape from.
+4. **Let the addiction dissolve** — social media and vibe-coding went quiet out here, more than I expected.
+5. **Get the jovial me back** — to my genuine and thrilled surprise, the itch to do balloons, magic, and just *be* fun came roaring back.
+
+The bottom three caught me off guard. Take away the consuming and there was nothing left to run from — and the guy underneath was someone I'd been missing.
+
 ## At a Glance
 
 | Leg                                   | Dates           | Nights | Country     |

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -20,15 +20,22 @@ For context on why I take time off: [/time-off](/time-off).
 
 ## Why I'm taking this time off — ranked
 
-[When you sacrifice identity for consumption, you end up with neither](/produce-consume). So I wrote down what I'm actually here for, in order:
+[When you sacrifice identity for consumption, you end up with neither](/produce-consume). So I wrote down what I'm actually here for, in order — and then the trip rearranged the list on me.
+
+**What I expected:**
 
 1. **Deepen my relationship with Amelia and Tori.**
 2. **Really meet whoever we're traveling with** — I put reasonable odds our kids end up woven into each other's lives for a long while. (Zach excepted — that bond I get for free.)
-3. **Escape** — except it turns out I have nothing to escape from.
-4. **Let the addiction dissolve** — social media and vibe-coding went quiet out here, more than I expected.
-5. **Get the jovial me back** — to my genuine and thrilled surprise, the itch to do balloons, magic, and just _be_ fun came roaring back.
+3. **Escape.**
 
-The bottom three caught me off guard. Take away the consuming and there was nothing left to run from — and the guy underneath was someone I'd been missing.
+**But it turns out** — on #3, I had nothing to escape from. Amazingly, no work stress and no PSC stress: for once my [body was home and my mind stayed home too](/mind-at-work). Take away the consuming and there was simply nothing left to run from.
+
+**What I didn't expect:**
+
+4. **The addiction dissolved** — social media and vibe-coding went quiet out here, more than I thought they could.
+5. **The jovial me came back** — to my genuine and thrilled surprise, the itch to do balloons, magic, and just _be_ fun came roaring back.
+
+4 and 5 are the interesting ones, and they're linked: the one real sacrifice I've made to AI is that the [Dealer of Smiles and Wonder](/joy) just stopped showing up. Out here, with the screens quiet, he walked right back in — the guy underneath was someone I'd been missing.
 
 ## Re-stacking the roles
 

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -26,9 +26,23 @@ For context on why I take time off: [/time-off](/time-off).
 2. **Really meet whoever we're traveling with** — I put reasonable odds our kids end up woven into each other's lives for a long while. (Zach excepted — that bond I get for free.)
 3. **Escape** — except it turns out I have nothing to escape from.
 4. **Let the addiction dissolve** — social media and vibe-coding went quiet out here, more than I expected.
-5. **Get the jovial me back** — to my genuine and thrilled surprise, the itch to do balloons, magic, and just *be* fun came roaring back.
+5. **Get the jovial me back** — to my genuine and thrilled surprise, the itch to do balloons, magic, and just _be_ fun came roaring back.
 
 The bottom three caught me off guard. Take away the consuming and there was nothing left to run from — and the guy underneath was someone I'd been missing.
+
+## Re-stacking the roles
+
+Ranking the trip made me ask the bigger version of the question: if that's the order for 22 days, what's the stack for every day? So I re-sorted the roles into three honest tiers.
+
+**Non-negotiables — protect first, daily.** The two foundational [Healths](/four-healths): _Physical_, banked before the family wakes up, and _Emotional_ — awareness and compassion, handled as it happens. Everything else is built on these.
+
+**Frequently starved — feed these.** _Father / Husband_, and the _Joy Giver_ — the balloons-and-magic guy from [the eulogy](/eulogy). The roles I'd grieve losing, and the exact ones I let go hungry when work gets loud. The trip already proved the Joy Giver comes roaring back the moment I stop starving him.
+
+**Over-invested — dial back.** _Technologist_, and honestly everything else, parked way below where they've been running. Not because the work doesn't matter — because it's the finished room, and I keep redecorating it instead of walking into the ones that aren't.
+
+## A learning to bring home
+
+First one already banked: **meditation travels, and churches are the best place to do it.** Duck into whatever old cathedral the city is proud of, take a pew, and just sit — cool stone, tall ceilings, nothing asked of you. The room is built to slow you down; let it.
 
 ## At a Glance
 

--- a/back-links.json
+++ b/back-links.json
@@ -3212,6 +3212,7 @@
                 "/sharpen-the-saw",
                 "/spiritual-health",
                 "/timeoff",
+                "/timeoff-2026-07",
                 "/todo_enjoy",
                 "/walking-with-god",
                 "/work-satisfaction"
@@ -3388,7 +3389,8 @@
                 "/mortality-software",
                 "/operating-manual",
                 "/sharpen-the-saw",
-                "/spiritual-health"
+                "/spiritual-health",
+                "/timeoff-2026-07"
             ],
             "last_modified": "2026-07-03T12:06:45-07:00",
             "markdown_path": "_d/four-healths.md",
@@ -5449,9 +5451,10 @@
                 "/ai-feed",
                 "/ai-journal",
                 "/gap-year-igor",
-                "/slow"
+                "/slow",
+                "/timeoff-2026-07"
             ],
-            "last_modified": "2026-05-28T07:10:46-07:00",
+            "last_modified": "2026-07-07T02:18:48-07:00",
             "markdown_path": "_d/produce-consume.md",
             "outgoing_links": [
                 "/activation",
@@ -7221,19 +7224,22 @@
         },
         "/timeoff-2026-07": {
             "description": "22 days, 5 countries, 4 Dvorkins, one whirlwind tour. From Reykjavík to Amsterdam by way of Stockholm, Oslo, and the Norwegian fjords. This is the first time we’ve attempted a trip of this scope as a family — the kids are 16 and 12, both still home, and the window for “all four of us on the road together” closes faster than I’d like.\n\n",
-            "doc_size": 21000,
+            "doc_size": 24000,
             "file_path": "_site/timeoff-2026-07.html",
             "incoming_links": [
                 "/ai-policy",
                 "/timeoff",
                 "/y26"
             ],
-            "last_modified": "2026-06-26T17:48:58-07:00",
+            "last_modified": "2026-07-07T02:23:37-07:00",
             "markdown_path": "_d/time-off-2026-07.md",
             "outgoing_links": [
                 "/ai-policy",
                 "/awareness",
+                "/eulogy",
+                "/four-healths",
                 "/meta",
+                "/produce-consume",
                 "/timeoff",
                 "/y26"
             ],

--- a/back-links.json
+++ b/back-links.json
@@ -7231,7 +7231,7 @@
                 "/timeoff",
                 "/y26"
             ],
-            "last_modified": "2026-07-07T02:23:37-07:00",
+            "last_modified": "2026-07-07T03:27:43-07:00",
             "markdown_path": "_d/time-off-2026-07.md",
             "outgoing_links": [
                 "/ai-policy",
@@ -7239,6 +7239,7 @@
                 "/eulogy",
                 "/four-healths",
                 "/meta",
+                "/packing",
                 "/produce-consume",
                 "/timeoff",
                 "/y26"

--- a/back-links.json
+++ b/back-links.json
@@ -4206,6 +4206,7 @@
                 "/magic",
                 "/mood",
                 "/sublime",
+                "/timeoff-2026-07",
                 "/tribe"
             ],
             "last_modified": "2026-03-21T13:54:36-07:00",
@@ -4710,6 +4711,7 @@
                 "/addiction",
                 "/timeoff",
                 "/timeoff-2022-11",
+                "/timeoff-2026-07",
                 "/work-satisfaction"
             ],
             "last_modified": "2025-12-07T02:26:29+00:00",
@@ -7238,7 +7240,9 @@
                 "/awareness",
                 "/eulogy",
                 "/four-healths",
+                "/joy",
                 "/meta",
+                "/mind-at-work",
                 "/packing",
                 "/produce-consume",
                 "/timeoff",


### PR DESCRIPTION
Adds Igor's ranked time-off priority list near the top of the Scandinavia trip post — the 'role prioritization' insight. Ties into the /produce-consume epigraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new ranked section and a closing “learning” note to the time-off page, giving it more structured personal reflection content.

* **Documentation**
  * Updated site link metadata so related pages now surface the new time-off page as an incoming link, and the time-off page now links out to additional related pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->