### PR TITLE
Recover orphaned evergreen diet + /packing additions to /timeoff

### DIFF
--- a/_d/time_off.md
+++ b/_d/time_off.md
@@ -284,6 +284,11 @@ Here are the combined learnings from my time offs. Igor needs to read and intern
 
 - Bring a cooler. Buy fruits/vegetables and keep them in the cooler and hotel fridge.
 
+##### Where to eat
+
+- **Shop the grocery store.** Some of my best travel meals come straight out of a supermarket — there's nothing wrong with a cucumber, some fruit, and a rotisserie chicken. Cheaper, healthier, and you skip the wait.
+- **Skip the tourist areas.** The food ringing the big sights is overpriced and mediocre. Walk a few blocks out, or eat where the locals do — the meal is better and so is the bill.
+
 #### Breakfast
 
 Family loves the free hotel breakfast (and it is a great deal), but I can't afford the calories. See detailed guidance under [Diet → Hotel breakfast](/diet#hotel-breakfast).
@@ -361,6 +366,8 @@ Ensure I don't run out of terzepatide during trips/time off. Plan refills ahead 
   - Pack and pre-configure it to bypass flaky captive portals; keep SSID/password noted and the admin password saved.
 
 #### Packing Checklist
+
+The full, durable version lives in my [packing master list](/packing) — every trip is trimmed from it. The quick summary:
 
 - Tech: chargers, power bank, travel router, Insta360 + mounts, extra SD cards
 - Fitness: kettlebells, heavy club, bands, peanut ball, foam roller, gripper

--- a/back-links.json
+++ b/back-links.json
@@ -6890,7 +6890,7 @@
         },
         "/timeoff": {
             "description": "Time off is critical, it’s how we renew our energy, find our creativity, etc. Many people think of time off as synonymous with turning your 1 week off into an action-packed tour of Disneyland. But, there are other kinds of time off that we’ll discuss too. Like most things, time off is a skill that can be improved by studying and applying your learnings. This post includes mine - note to self - read them!!\n\n",
-            "doc_size": 47000,
+            "doc_size": 48000,
             "file_path": "_site/timeoff.html",
             "incoming_links": [
                 "/activation",
@@ -6936,6 +6936,7 @@
                 "/kettlebell",
                 "/magic",
                 "/mind-at-work",
+                "/packing",
                 "/parkinson",
                 "/siy",
                 "/terzepatide",


### PR DESCRIPTION
Two small durable additions to the evergreen `_d/time_off.md` essay that were **dropped by a merge-UI race** when PR #726 was merged (the merge landed only the role-re-stack/churches commit; the follow-up diet + packing commits never reached main).

## What changed
- **Diet → `##### Where to eat`** (under Travel Nutrition): shop the grocery store (nothing wrong with a cucumber, some fruit, a rotisserie chicken); skip tourist-area restaurants — better meal, better bill.
- **Packing Checklist**: adds a lead-in linking the durable [packing master list](/packing) — the inline list is the quick summary every trip is trimmed from.

`back-links.json`: `/timeoff` outgoing +`/packing` (focused). Evergreen voice, no TOC-level headings changed.

Companion to the already-merged #726. The `/packing` page itself lands via #711.

https://github.com/idvorkin/idvorkin.github.io/pull/728/files
