### PR TITLE
Promote tirzepatide travel section to its own appendix in /timeoff

### DIFF
--- a/_d/time_off.md
+++ b/_d/time_off.md
@@ -64,8 +64,7 @@ The whole trap of time off in one sentence — vegetating _feels_ like rest, but
   - [Optimize for energy, not time](#optimize-for-energy-not-time)
   - [Can you have too much time off?](#can-you-have-too-much-time-off)
 - [Appendix: 9 Rules for a Happier Vacation (Arthur Brooks)](#appendix-9-rules-for-a-happier-vacation-arthur-brooks)
-- [Travel logistics](#travel-logistics)
-  - [Traveling with tirzepatide (or any med that needs a fridge)](#traveling-with-tirzepatide-or-any-med-that-needs-a-fridge)
+- [Appendix: Traveling with tirzepatide (or any med that needs a fridge)](#appendix-traveling-with-tirzepatide-or-any-med-that-needs-a-fridge)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
@@ -426,9 +425,7 @@ I struggle to take real time off, so this one hit home. Below is my distillation
 8. **Come home early.** Don't travel up to the last second — get back a few days before you have to return to work so you can ease in. That buffer becomes a mini second vacation. Brooks aims to be home before the weekend rather than landing Sunday night into a full work week. ("Living each day as if it were the first day of your honeymoon and the last day of your vacation." — Tolstoy.)
 9. **Brace yourself on return and manage your feelings.** A successful vacation sharpens the contrast with ordinary life, so the day-to-day can feel flat or frustrating coming back — like a carrot after candy. It's completely normal; expecting it defuses it. Brooks' policy: don't make significant life changes in the first week back. Not being surprised is how you keep your feelings from managing you.
 
-## Travel logistics
-
-### Traveling with tirzepatide (or any med that needs a fridge)
+## Appendix: Traveling with tirzepatide (or any med that needs a fridge)
 
 Tirzepatide — and plenty of other meds — wants to stay cold. Three things make travel painless:
 


### PR DESCRIPTION
PR #725 landed the "Traveling with tirzepatide (or any med that needs a fridge)" content in the evergreen `_d/time_off.md` essay, but as a `###` subsection under a `## Travel logistics` wrapper — so the TOC nested it as a sub-item rather than listing it as its own appendix.

## Fix
Promoted it to a top-level **`## Appendix: Traveling with tirzepatide (or any med that needs a fridge)`** — a proper sibling of the Arthur Brooks appendix, positioned right after it. Collapsed the now-redundant `## Travel logistics` wrapper (it contained only this one subsection). **Body content unchanged.**

- TOC regenerated: the entry now appears as a top-level appendix (not nested).
- No cross-link changes, so `back-links.json` is untouched (verified via `just back-links`).

**Note:** this changes the section's anchor from `#traveling-with-tirzepatide-or-any-med-that-needs-a-fridge` to `#appendix-traveling-with-tirzepatide-or-any-med-that-needs-a-fridge`. PR #711's packing list links the old anchor — flagged as a follow-up to update once this merges.

https://github.com/idvorkin/idvorkin.github.io/pull/729/files
