### PR TITLE
Fix dead tirzepatide anchor in packing list (post-appendix-promotion)

### DIFF
--- a/_d/packing.md
+++ b/_d/packing.md
@@ -63,7 +63,7 @@ Minimum viable gear. The McGill Big 3 needs **zero** gear — no excuse on the t
 
 ### Meds
 
-- [ ] **Prescription continuity** — don't run out mid-trip; plan refills ahead and pack doses appropriately. For anything that needs a fridge, see [traveling with tirzepatide](/timeoff#traveling-with-tirzepatide-or-any-med-that-needs-a-fridge)
+- [ ] **Prescription continuity** — don't run out mid-trip; plan refills ahead and pack doses appropriately. For anything that needs a fridge, see [traveling with tirzepatide](/timeoff#appendix-traveling-with-tirzepatide-or-any-med-that-needs-a-fridge)
 - [ ] Sleep aid — for long flights
 - [ ] Decongestant — flight ear pressure
 - [ ] First aid: ibuprofen, band-aids, kid staples


### PR DESCRIPTION
#711 (packing list) and #729 (promote tirzepatide section to a top-level appendix) both merged to main. #729 changed the section's anchor, so #711's packing-list link is now a **dead anchor on main**.

## Fix (`_d/packing.md`, one line)
- Old: `/timeoff#traveling-with-tirzepatide-or-any-med-that-needs-a-fridge`
- New: `/timeoff#appendix-traveling-with-tirzepatide-or-any-med-that-needs-a-fridge`

## Verified
- The `id="appendix-traveling-with-tirzepatide-or-any-med-that-needs-a-fridge"` exists in the built `_site/timeoff.html`.
- Site-wide anchor-checker: **"All links valid!"** (352 files, 6055 links, 0 broken).

No cross-link target change (still `/timeoff`), so `back-links.json` is untouched.

https://github.com/idvorkin/idvorkin.github.io/pull/731/files
