### PR TITLE
Add real Iceland + Stockholm trip memories to timeoff-2026-07

### DIFF
--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -55,7 +55,7 @@ First one already banked: **meditation travels, and churches are the best place 
 
 ### 🇮🇸 Reykjavík
 
-The pools are the whole thing. You start in an 8°C cold plunge — the kind that empties your head — then climb through 40, 42, 44, one of the hot ones fed by a pipe running straight in from the ocean. Sauna with all four of us. One morning I banked 5am kettlebells before anyone woke up: only six minutes, because it was raining, but the keystone held — six honest minutes beats a skipped day. Sauna again after. We stayed in a hostel with a shared kitchen, and the best night was cooking dinner next to strangers and trading stories across the table.
+The pools are the whole thing. You start in an 8°C cold plunge — the kind that empties your head — then climb through 40, 42, 44, one of the hot ones fed by a pipe running straight in from the ocean. Sauna with all four of us. One morning I banked a full 5am kettlebell session before anyone woke up — drove to the gym and finished with about six minutes to spare before the rain moved in. The keystone held. Sauna again after. We stayed in a hostel with a shared kitchen, and the best night was cooking dinner next to strangers and trading stories across the table.
 
 Two things stuck with me about Iceland. Family is clearly the whole priority — a trampoline in every yard, kids everywhere. And nobody eats out; there are barely any restaurants, so everyone eats in.
 
@@ -69,7 +69,7 @@ Amelia did the zoo solo and out-prepared me — when my phone died she handed me
 
 We saw the Vasa, the warship that capsized in the harbor on its maiden voyage and got raised mostly intact three centuries later. Zach went on a tear at dinner: frog legs, ratatouille, escargot.
 
-Sunday we ducked into a Greek Orthodox church, and Zach got a blessing from the visiting bishop. I nearly got thrown out of the same church for doing magic in the pews. Standing there getting chewed out, I hit a Viktor Frankl beat — between what happens to you and how you respond there's a gap, and no one can take away the freedom inside it. So I didn't fire back. I stayed [proactive](/be-proactive) and chose my [response](/act) instead of handing it over.
+Sunday we ducked into a Greek Orthodox church, and Zach got a blessing from the visiting bishop. I nearly got thrown out of the same church for doing magic in the pews. Standing there getting chewed out, I hit a Viktor Frankl beat — between what happens to you and how you respond there's a gap, and no one can take away the freedom inside it. Two wins: I caught my fight-or-flight reaction multiple times and breathed through it instead of firing back, and I got some work in on my memorization practice. [Proactive](/be-proactive), not reactive — I [chose the response](/act).
 
 ## At a Glance
 

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -51,6 +51,26 @@ Ranking the trip made me ask the bigger version of the question: if that's the o
 
 First one already banked: **meditation travels, and churches are the best place to do it.** Duck into whatever old cathedral the city is proud of, take a pew, and just sit — cool stone, tall ceilings, nothing asked of you. The room is built to slow you down; let it.
 
+## How it's actually going
+
+### 🇮🇸 Reykjavík
+
+The pools are the whole thing. You start in an 8°C cold plunge — the kind that empties your head — then climb through 40, 42, 44, one of the hot ones fed by a pipe running straight in from the ocean. Sauna with all four of us. One morning I banked 5am kettlebells before anyone woke up: only six minutes, because it was raining, but the keystone held — six honest minutes beats a skipped day. Sauna again after. We stayed in a hostel with a shared kitchen, and the best night was cooking dinner next to strangers and trading stories across the table.
+
+Two things stuck with me about Iceland. Family is clearly the whole priority — a trampoline in every yard, kids everywhere. And nobody eats out; there are barely any restaurants, so everyone eats in.
+
+{% include alert.html content="🚗 Rental-car tip: buy the wind insurance in Iceland. The wind here can rip a car door clean off its hinges — get the sand-and-ash protection too. Add it at the counter, not after." style="warning" %}
+
+### 🇸🇪 Stockholm
+
+Skansen was the surprise. It's an open-air museum of an old Swedish village, and everyone stays in role. People were singing. A glassblower shaped a glass mouse. Off to the side a silversmith was raising a vase out of a flat disk of silver over a wood fire — a hundred hours of work, he told us, his whole summer in one object. One staffer had committed so hard to the part, mustache and all, that he was worth the ticket on his own.
+
+Amelia did the zoo solo and out-prepared me — when my phone died she handed me her spare battery. I'm supposed to be the one carrying that.
+
+We saw the Vasa, the warship that capsized in the harbor on its maiden voyage and got raised mostly intact three centuries later. Zach went on a tear at dinner: frog legs, ratatouille, escargot.
+
+Sunday we ducked into a Greek Orthodox church, and Zach got a blessing from the visiting bishop. I nearly got thrown out of the same church for doing magic in the pews. Standing there getting chewed out, I hit a Viktor Frankl beat — between what happens to you and how you respond there's a gap, and no one can take away the freedom inside it. So I didn't fire back. I stayed [proactive](/be-proactive) and chose my [response](/act) instead of handing it over.
+
 ## At a Glance
 
 | Leg                                   | Dates           | Nights | Country     |

--- a/back-links.json
+++ b/back-links.json
@@ -604,7 +604,9 @@
             "description": "My back goes out a few times a year. My mood tracks the Meta stock price more than I’d like to admit. Twenty years ago I’d meet those moments with a thrash cycle — fused with the pain, angry at my body, tangled up in a story about why this was unfair — which made the experience much worse than the sensation itself. Now I aspire to be calm like water, be present, remember that this too shall pass, and work the problem. I still catch myself mid-thrash often enough to know it’s aspiration, not habit.\n\n",
             "doc_size": 290000,
             "file_path": "_site/act.html",
-            "incoming_links": [],
+            "incoming_links": [
+                "/timeoff-2026-07"
+            ],
             "last_modified": "2026-04-15T03:24:18.354841+00:00",
             "markdown_path": "_d/act.md",
             "outgoing_links": [
@@ -1699,6 +1701,7 @@
                 "/raccoon-history",
                 "/regrets",
                 "/siy",
+                "/timeoff-2026-07",
                 "/untangled",
                 "/words-we-dont-have"
             ],
@@ -7262,7 +7265,7 @@
         },
         "/timeoff-2026-07": {
             "description": "22 days, 5 countries, 4 Dvorkins, one whirlwind tour. From Reykjavík to Amsterdam by way of Stockholm, Oslo, and the Norwegian fjords. This is the first time we’ve attempted a trip of this scope as a family — the kids are 16 and 12, both still home, and the window for “all four of us on the road together” closes faster than I’d like.\n\n",
-            "doc_size": 25000,
+            "doc_size": 27000,
             "file_path": "_site/timeoff-2026-07.html",
             "incoming_links": [
                 "/ai-policy",
@@ -7273,8 +7276,10 @@
             "last_modified": "2026-07-07T12:17:51+02:00",
             "markdown_path": "_d/time-off-2026-07.md",
             "outgoing_links": [
+                "/act",
                 "/ai-policy",
                 "/awareness",
+                "/be-proactive",
                 "/eulogy",
                 "/four-healths",
                 "/joy",


### PR DESCRIPTION
Adds a lived-experience section to the Scandinavia trip post now that the first legs have happened.

## What's added

New `## How it's actually going` section (after "A learning to bring home", before the reference plan), in Igor's plain first-person voice:

- **🇮🇸 Reykjavík** — the pools (8°C plunge → 40/42/44, one fed straight from the ocean), sauna with the family, 5am kettlebells (6 min in the rain — keystone held), the hostel shared-kitchen dinner. Plus two observations (family-first culture, nobody eats out) and a rental-car **wind-insurance tip** as a warning alert.
- **🇸🇪 Stockholm** — Skansen craftspeople (glassblower, ~100-hr silversmith, the in-role staffer), Amelia's solo zoo run + lending her dad a battery, the Vasa, Zach's frog-legs/escargot dinner, and the Greek Orthodox church Frankl moment (blessing for Zach; nearly ejected for doing magic → chose response over reaction), linked to [/be-proactive](/be-proactive) and [/act](/act).

## Housekeeping

- Backlinks regenerated for the two new cross-links (`/be-proactive`, `/act` now list this post as an incoming link; minimal, hand-scoped `back-links.json` diff to avoid unrelated drift).
- No TOC block in this post, so none to regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)