### PR TITLE
content: train-ride context note on week-of-2026-07-06 changelog

### DIFF
--- a/_d/changelog.md
+++ b/_d/changelog.md
@@ -157,6 +157,8 @@ A weekly summary of what changed on this blog and across my GitHub projects. Use
 
 _39 commits this week_
 
+_Confession: I built most of this week's blitz on a 6-hour train ride across Scandinavia — a break from the vacation, while the kids watched TV._
+
 ### Bad News. Maybe Not. (new post!)
 
 **[/maybe](/maybe)** — a new post on the "good luck, bad luck, who knows?" reframe. [<i class="fa fa-github"></i>](https://github.com/idvorkin/idvorkin.github.io/commit/e355c3979)


### PR DESCRIPTION
Adds a one-line italic context note to the current week's changelog entry (Week of 2026-07-06), right after the commit-count line.

The note conveys, in Igor's plain first-person voice, that most of this week's blog + trip-site blitz was built on a 6-hour train ride across Scandinavia — a break from vacation, while the kids watched TV.

Content-only, single file (`_d/changelog.md`), 2 insertions. No new heading (TOC unchanged) and no new cross-links (back-links.json untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog with a new week-specific note for 2026-07-06.
  * Added a brief “Confession” entry describing how most of that week’s content was created during a train ride across Scandinavia.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->