### PR TITLE
Add tech-bender + unexpected-realizations beats to Scandinavia trip post

### DIFF
--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -77,9 +77,11 @@ Confession: on the six-hour train from Stockholm to Oslo I went on a bit of a te
 
 ### 🤔 Unexpected realizations
 
-Before the trip I moved all my social apps onto my [work phone](/maybe#the-second-phone) and logged out of LinkedIn on my main one. Clean break. Except my thumb never got the memo — I keep catching myself opening the main phone and reaching for a LinkedIn that isn't there. Why do I keep checking that? What do I think I'm going to find? The app's gone, the reward's gone, and the habit still fires on schedule.
+Before the trip I moved my social apps onto my [work phone](/maybe#the-second-phone) — but LinkedIn stayed on my main phone the whole way. And all trip my thumb kept opening it on autopilot. Why do I keep checking that? What do I think I'm going to find? It was right there, so I kept finding it.
 
-It's got me curious about the [habit loop](/habits#habit-model) — cue, craving, response, reward. When you rip out the reward, which part is still pulling the trigger? I don't have the answer yet. I want to sit with that one.
+Tonight I finally locked it out. The funny part: going through the motions to block it, I somehow ended up at the LinkedIn login page anyway — like the habit walked me there on its own. Kind of weird to watch myself do it.
+
+It's got me curious about the [habit loop](/habits#habit-model) — cue, craving, response, reward. Now the app's gone and the reward with it, so which part keeps pulling the trigger? I don't have the answer yet. I want to sit with that one.
 
 ## At a Glance
 

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -55,7 +55,7 @@ First one already banked: **meditation travels, and churches are the best place 
 
 ### 🇮🇸 Reykjavík
 
-The pools are the whole thing. You start in an 8°C cold plunge — the kind that empties your head — then climb through 40, 42, 44, one of the hot ones fed by a pipe running straight in from the ocean. Sauna with all four of us. One morning I banked a full 5am kettlebell session before anyone woke up — drove to the gym and finished with about six minutes to spare before the rain moved in. The keystone held. Sauna again after. We stayed in a hostel with a shared kitchen, and the best night was cooking dinner next to strangers and trading stories across the table.
+The pools are the whole thing. You start in an 8°C cold plunge — the kind that empties your head — then climb through 40, 42, 44, one of the hot ones fed by a pipe running straight in from the ocean. Sauna with all four of us. One morning I banked a full 5am kettlebell session before anyone woke up. It was already pouring at 5, so instead of the five-minute walk I took the rental Tesla to the gym — felt a little lame driving something that short, but I made it happen. The keystone held. Sauna at 7. We stayed in a hostel with a shared kitchen, and the best night was cooking dinner next to strangers and trading stories across the table.
 
 Two things stuck with me about Iceland. Family is clearly the whole priority — a trampoline in every yard, kids everywhere. And nobody eats out; there are barely any restaurants, so everyone eats in.
 

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -75,6 +75,12 @@ Sunday we ducked into a Greek Orthodox church, and Zach got a blessing from the 
 
 Confession: on the six-hour train from Stockholm to Oslo I went on a bit of a tech bender. The kids watched TV; I sat there and banged out the whole trip site — the city deep-dives, the maps, the war pack, all of it — and logged the blitz in my [changelog](/changelog). Six hours of what I'd call super blogging time, and honestly I quite enjoyed it. At least it was [building, not scrolling](/produce-consume).
 
+### 🤔 Unexpected realizations
+
+Before the trip I moved all my social apps onto my [work phone](/maybe) and logged out of LinkedIn on my main one. Clean break. Except my thumb never got the memo — I keep catching myself opening the main phone and reaching for a LinkedIn that isn't there. Why do I keep checking that? What do I think I'm going to find? The app's gone, the reward's gone, and the habit still fires on schedule.
+
+It's got me curious about the [habit loop](/habits) — cue, craving, response, reward. When you rip out the reward, which part is still pulling the trigger? I don't have the answer yet. I want to sit with that one.
+
 ## At a Glance
 
 | Leg                                   | Dates           | Nights | Country     |

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -73,13 +73,13 @@ Sunday we ducked into a Greek Orthodox church, and Zach got a blessing from the 
 
 ### 🚂 The train to Oslo
 
-Confession: on the six-hour train from Stockholm to Oslo I went on a bit of a tech bender. The kids watched TV; I sat there and banged out the whole trip site — the city deep-dives, the maps, the war pack, all of it — and logged the blitz in my [changelog](/changelog). Six hours of what I'd call super blogging time, and honestly I quite enjoyed it. At least it was [building, not scrolling](/produce-consume).
+Confession: on the six-hour train from Stockholm to Oslo I went on a bit of a tech bender. The kids watched TV; I sat there and banged out the whole trip site — the city deep-dives, the maps, the war pack, all of it — and logged the blitz in my [changelog](/changelog#week-of-2026-07-06). Six hours of what I'd call super blogging time, and honestly I quite enjoyed it. At least it was [building, not scrolling](/produce-consume#the-production-advantage).
 
 ### 🤔 Unexpected realizations
 
-Before the trip I moved all my social apps onto my [work phone](/maybe) and logged out of LinkedIn on my main one. Clean break. Except my thumb never got the memo — I keep catching myself opening the main phone and reaching for a LinkedIn that isn't there. Why do I keep checking that? What do I think I'm going to find? The app's gone, the reward's gone, and the habit still fires on schedule.
+Before the trip I moved all my social apps onto my [work phone](/maybe#the-second-phone) and logged out of LinkedIn on my main one. Clean break. Except my thumb never got the memo — I keep catching myself opening the main phone and reaching for a LinkedIn that isn't there. Why do I keep checking that? What do I think I'm going to find? The app's gone, the reward's gone, and the habit still fires on schedule.
 
-It's got me curious about the [habit loop](/habits) — cue, craving, response, reward. When you rip out the reward, which part is still pulling the trigger? I don't have the answer yet. I want to sit with that one.
+It's got me curious about the [habit loop](/habits#habit-model) — cue, craving, response, reward. When you rip out the reward, which part is still pulling the trigger? I don't have the answer yet. I want to sit with that one.
 
 ## At a Glance
 

--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -71,6 +71,10 @@ We saw the Vasa, the warship that capsized in the harbor on its maiden voyage an
 
 Sunday we ducked into a Greek Orthodox church, and Zach got a blessing from the visiting bishop. I nearly got thrown out of the same church for doing magic in the pews. Standing there getting chewed out, I hit a Viktor Frankl beat — between what happens to you and how you respond there's a gap, and no one can take away the freedom inside it. Two wins: I caught my fight-or-flight reaction multiple times and breathed through it instead of firing back, and I got some work in on my memorization practice. [Proactive](/be-proactive), not reactive — I [chose the response](/act).
 
+### 🚂 The train to Oslo
+
+Confession: on the six-hour train from Stockholm to Oslo I went on a bit of a tech bender. The kids watched TV; I sat there and banged out the whole trip site — the city deep-dives, the maps, the war pack, all of it — and logged the blitz in my [changelog](/changelog). Six hours of what I'd call super blogging time, and honestly I quite enjoyed it. At least it was [building, not scrolling](/produce-consume).
+
 ## At a Glance
 
 | Leg                                   | Dates           | Nights | Country     |

--- a/back-links.json
+++ b/back-links.json
@@ -1669,7 +1669,7 @@
         },
         "/bc": {
             "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-            "doc_size": 23000,
+            "doc_size": 22000,
             "file_path": "_site/bc.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T03:02:44+00:00",
@@ -2020,8 +2020,10 @@
             "description": "A weekly summary of what changed on this blog and across my GitHub projects. Useful for returning readers who want to catch up on new content and updates.\n\n",
             "doc_size": 243000,
             "file_path": "_site/changelog.html",
-            "incoming_links": [],
-            "last_modified": "2026-07-07T12:09:40.505435+00:00",
+            "incoming_links": [
+                "/timeoff-2026-07"
+            ],
+            "last_modified": "2026-07-07T15:13:25+02:00",
             "markdown_path": "_d/changelog.md",
             "outgoing_links": [
                 "/42",
@@ -2704,7 +2706,7 @@
         },
         "/day-in-the-life": {
             "description": "A running journal of days that actually worked - the ones where health habits stuck, family time hit different, or I remembered what it feels like to be fully alive. Not every day needs to be Instagram-worthy, but some days deserve a bookmark. This is that bookmark collection.\n\n",
-            "doc_size": 19000,
+            "doc_size": 18000,
             "file_path": "_site/day-in-the-life.html",
             "incoming_links": [],
             "last_modified": "2025-10-04T18:43:51-07:00",
@@ -3699,7 +3701,7 @@
         },
         "/grammerly": {
             "description": "\n\n",
-            "doc_size": 13000,
+            "doc_size": 12000,
             "file_path": "_site/grammerly.html",
             "incoming_links": [],
             "last_modified": "2025-08-24T09:03:19-07:00",
@@ -4682,7 +4684,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 15000,
+            "doc_size": 14000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",
@@ -7269,7 +7271,7 @@
         },
         "/timeoff-2026-07": {
             "description": "22 days, 5 countries, 4 Dvorkins, one whirlwind tour. From Reykjavík to Amsterdam by way of Stockholm, Oslo, and the Norwegian fjords. This is the first time we’ve attempted a trip of this scope as a family — the kids are 16 and 12, both still home, and the window for “all four of us on the road together” closes faster than I’d like.\n\n",
-            "doc_size": 27000,
+            "doc_size": 28000,
             "file_path": "_site/timeoff-2026-07.html",
             "incoming_links": [
                 "/ai-policy",
@@ -7277,13 +7279,14 @@
                 "/timeoff",
                 "/y26"
             ],
-            "last_modified": "2026-07-07T12:17:51+02:00",
+            "last_modified": "2026-07-08T09:26:51+02:00",
             "markdown_path": "_d/time-off-2026-07.md",
             "outgoing_links": [
                 "/act",
                 "/ai-policy",
                 "/awareness",
                 "/be-proactive",
+                "/changelog",
                 "/eulogy",
                 "/four-healths",
                 "/joy",
@@ -7709,7 +7712,7 @@
         },
         "/win-win": {
             "description": "Win/Win is a constantly seeking mutual benefit in all interactions. Win/Win means that agreements or solutions are mutually beneficial, mutually satisfying. With a Win/Win solution, all parties feel good about the decision and feel committed to the action plan. Win/Win sees life as a cooperative, not a competitive arena. Most people tend to think in terms of dichotomies: strong or weak, hardball or softball, win or lose. But that kind of thinking is fundamentally flawed. It’s based on power and position rather than on principle. Win/Win is based on the paradigm that there is plenty for everybody, that one person’s success is not achieved at the expense or exclusion of the success of others.\n\n",
-            "doc_size": 48000,
+            "doc_size": 47000,
             "file_path": "_site/win-win.html",
             "incoming_links": [
                 "/7-habits",

--- a/back-links.json
+++ b/back-links.json
@@ -2615,6 +2615,7 @@
                 "/sharpen-the-saw",
                 "/slow",
                 "/switch",
+                "/timeoff-2026-07",
                 "/walking-with-god"
             ],
             "last_modified": "2025-12-07T02:40:46+00:00",
@@ -4628,7 +4629,9 @@
             "description": "A farmer’s horse runs away. His neighbors console him: “What terrible luck!” The farmer shrugs, “Maybe.” The next day the horse returns, leading a herd of wild horses behind it — “What wonderful luck!” “Maybe.” His son tries to tame one, is thrown, and breaks his leg — “How awful!” “Maybe.” A week later the army marches through, conscripting every able-bodied young man for a war most won’t return from, and the son, with his broken leg, is passed over — “How wonderful!” “Maybe.” Good luck, bad luck — who knows? The story is never finished, so the farmer never renders the verdict. He just keeps living.\n\n",
             "doc_size": 17000,
             "file_path": "_site/maybe.html",
-            "incoming_links": [],
+            "incoming_links": [
+                "/timeoff-2026-07"
+            ],
             "last_modified": "2026-07-06T23:30:18-07:00",
             "markdown_path": "_d/maybe.md",
             "outgoing_links": [
@@ -7287,10 +7290,12 @@
                 "/awareness",
                 "/be-proactive",
                 "/changelog",
+                "/d/habits",
                 "/eulogy",
                 "/four-healths",
                 "/joy",
                 "/life-journal",
+                "/maybe",
                 "/meta",
                 "/mind-at-work",
                 "/packing",


### PR DESCRIPTION
Two short first-person beats added to `_d/time-off-2026-07.md`, both in the "How it's actually going" section.

**1. Tech bender (`### 🚂 The train to Oslo`)** — on the six-hour Stockholm→Oslo train, Igor went on a "tech bender": banging out the whole trip site (deep-dives, maps, war pack) and wiring it into `/changelog`. Kids watched TV; he calls it "super blogging time" and quite enjoyed it. Links `/changelog` and `/produce-consume` (building, not scrolling).

**2. Unexpected realizations (`### 🤔 Unexpected realizations`)** — the two-phone move (social apps on the work phone, logged out of LinkedIn on the main one) and the vestigial habit of still reaching for a LinkedIn that isn't there. Curiosity about which part of the habit loop keeps firing once the reward is gone. Links `/maybe` (the second/work phone) and `/habits` (cue/craving/response/reward).

`back-links.json` regenerated for the new `/changelog`, `/maybe`, and `/habits` cross-links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)