### PR TITLE
Enrich Pleasure vs Enjoyment with sourced Brooks deep-dive

### DIFF
--- a/_d/build-the-life-you-want.md
+++ b/_d/build-the-life-you-want.md
@@ -78,7 +78,7 @@ Or in Brooks' own words, from his Atlantic column [Choose Enjoyment Over Pleasur
 - **Make it novel.** First-times and pattern-breaks encode hard; routine blurs into one gray smear you can't retrieve later. Want a day to be memorable? Do something you haven't done.
 - **Make it an occasion.** Name it, give it a start and an end, add a little ritual. A marked event gets filed as an event; an unmarked one dissolves into the background.
 - **Capture a little, on purpose.** One photo or one journal line—not doom-photographing the whole thing. Over-capturing pulls you out of the moment and weakens the very memory you're trying to keep.
-- **Engineer the peak and the ending.** We don't remember the average of an experience, we remember its best moment and how it ended—Kahneman's [peak-end rule](/happy#peak-end-rule). Build in one peak and land a good ending. (End the vacation with something great, not a fight at the airport.)
+- **Engineer the peak and the ending.** We don't remember the average of an experience, we remember its best moment and how it ended—Kahneman's [peak-end rule](/balance#peak-end-rule-and-moments). Build in one peak and land a good ending. (End the vacation with something great, not a fight at the airport.)
 - **Retell it.** Telling the story afterward consolidates the memory and lets you live it again—and it drags the experience back toward people, closing the loop.
 
 So converting pleasure into enjoyment is cheap and deliberate: add a person, and lay down a memory. Don't kill the pleasure—upgrade it.

--- a/_d/build-the-life-you-want.md
+++ b/_d/build-the-life-you-want.md
@@ -62,11 +62,35 @@ Brooks and Winfrey challenge our fundamental assumptions about happiness. Rather
 
 #### Pleasure vs Enjoyment
 
-Brooks makes a crucial distinction: **Pleasure happens to you; enjoyment is something you create.** Pleasure is fleeting and passive (eating ice cream, watching TV), while enjoyment requires two additional elements:
+Brooks draws a line I keep coming back to: **pleasure happens _to_ you; enjoyment is something you make.** Pleasure is the raw hit—ice cream, a beer, a scroll session. It runs on the dopamine reward circuit, it's usually solitary, and it fades the second it's over. Chase it on its own and you land on the hedonic treadmill, needing a bit more each time for the same buzz. Brooks' line on the Tim Ferriss show is blunt: if your goal is pleasure, you don't arrive at happiness—you wind up in rehab. Pleasure with nothing added slides toward compulsion.
+
+Enjoyment is what you get when you take that raw pleasure and add two things:
 
 **Enjoyment = Pleasure + People + Memory**
 
-Example: Beer ads never show someone drinking alone—they show friends creating memories together. That's because enjoyment, not mere pleasure, creates lasting happiness.
+Or in Brooks' own words, from his Atlantic column [Choose Enjoyment Over Pleasure](https://www.theatlantic.com/family/archive/2022/03/happiness-pleasure-enjoyment-consumption/629447/) (March 2022): "Enjoyment takes the source of pleasure and adds two things: people and memory."
+
+**People** is the obvious multiplier. It turns a private sensation into a shared one—the beer alone on the couch and the beer around a table with friends are not the same experience. Company recruits the social brain, ties the moment to a relationship, and acts as a brake: you overconsume alone, not in good company. That's why the beer ad never shows a guy drinking by himself; it's selling the table, not the bottle. My gut check for the whole thing: **if you're doing it alone, you're probably doing it wrong.**
+
+**Memory** is the multiplier people skip, and it's where the real leverage is. A pleasure you'll still be reliving next year keeps paying out long after the sensation is gone; a pleasure with no memory attached is just the treadmill asking for the next dose. The good news is you can lay down a memory on purpose:
+
+- **Be present.** You can't remember what you didn't attend to—memory needs encoding, and encoding needs attention. This is the real reason phone-in-hand kills the memory: you're photographing instead of encoding, so nothing lands.
+- **Make it novel.** First-times and pattern-breaks encode hard; routine blurs into one gray smear you can't retrieve later. Want a day to be memorable? Do something you haven't done.
+- **Make it an occasion.** Name it, give it a start and an end, add a little ritual. A marked event gets filed as an event; an unmarked one dissolves into the background.
+- **Capture a little, on purpose.** One photo or one journal line—not doom-photographing the whole thing. Over-capturing pulls you out of the moment and weakens the very memory you're trying to keep.
+- **Engineer the peak and the ending.** We don't remember the average of an experience, we remember its best moment and how it ended—Kahneman's [peak-end rule](/happy#peak-end-rule). Build in one peak and land a good ending. (End the vacation with something great, not a fight at the airport.)
+- **Retell it.** Telling the story afterward consolidates the memory and lets you live it again—and it drags the experience back toward people, closing the loop.
+
+So converting pleasure into enjoyment is cheap and deliberate: add a person, and lay down a memory. Don't kill the pleasure—upgrade it.
+
+Where this fits the bigger picture: enjoyment is one of three "macronutrients" of a happy life for Brooks, next to **satisfaction** (the reward that lands _after_ earned struggle) and **meaning/purpose**—the same [Happiness = Enjoyment + Satisfaction + Purpose](#equations-of-happiness) equation further down. Pleasure by itself isn't on that list, because pleasure by itself isn't food. It's the same spine as [producing vs consuming](/produce-consume): solitary consumption is the pleasure hit; creating and sharing is what turns it into something that lasts.
+
+**Two honest caveats,** because the tidy version oversells it:
+
+- The "pleasure = old limbic brain, enjoyment = the higher prefrontal brain" split that Brooks leans on with Ferriss is a handy heuristic, not neuroanatomy. The strict triune-brain model—reptilian / limbic / neocortex stacked like sediment—is outdated as literal wiring. Keep it as a metaphor for fast reflexive reward vs. slower integrative processing.
+- The distinction isn't originally Brooks'. Mihály Csíkszentmihályi split pleasure from enjoyment back in _Flow_ (1990). Brooks' contribution is the operationalization—the "+ people + memory" formula and the beer-ad framing that makes it stick.
+
+_Sources: Arthur Brooks & Oprah Winfrey, Build the Life You Want (2023); Brooks, ["Choose Enjoyment Over Pleasure," The Atlantic](https://www.theatlantic.com/family/archive/2022/03/happiness-pleasure-enjoyment-consumption/629447/) (Mar 2022); [The Tim Ferriss Show #692](https://tim.blog/2023/09/11/arthur-c-brooks/) (Sept 2023); Daniel Kahneman, Thinking, Fast and Slow (2011) for the peak-end rule._
 
 **Three Challenges Addressed:**
 

--- a/back-links.json
+++ b/back-links.json
@@ -1616,6 +1616,7 @@
             "incoming_links": [
                 "/7-habits",
                 "/7h-concepts",
+                "/build-life-you-want",
                 "/end-in-mind",
                 "/energy-abundance",
                 "/first-things-first",
@@ -1962,9 +1963,9 @@
             "last_modified": "2026-07-08T19:30:37.804599+00:00",
             "markdown_path": "_d/build-the-life-you-want.md",
             "outgoing_links": [
+                "/balance",
                 "/bucket-list",
                 "/emotions",
-                "/happy",
                 "/lonely",
                 "/produce-consume"
             ],
@@ -3817,7 +3818,6 @@
             "incoming_links": [
                 "/addiction",
                 "/awareness",
-                "/build-life-you-want",
                 "/chasing-daylight",
                 "/emotions",
                 "/hobby",
@@ -4685,7 +4685,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 15000,
+            "doc_size": 14000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",

--- a/back-links.json
+++ b/back-links.json
@@ -1669,7 +1669,7 @@
         },
         "/bc": {
             "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-            "doc_size": 23000,
+            "doc_size": 22000,
             "file_path": "_site/bc.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T03:02:44+00:00",
@@ -1953,18 +1953,20 @@
         },
         "/build-life-you-want": {
             "description": "Happiness isn’t a destination you arrive at—it’s a direction you choose to walk in daily. Build The Life YOU Want by Arthur Brooks and Oprah Winfrey demolishes the myth that happiness is something that happens to you, replacing it with the empowering truth that happiness is something you actively create. This isn’t another feel-good book promising easy answers; it’s a science-backed roadmap for building genuine fulfillment through intentional choices and sustainable practices.\n\n",
-            "doc_size": 40000,
+            "doc_size": 45000,
             "file_path": "_site/build-life-you-want.html",
             "incoming_links": [
                 "/happy",
                 "/spiritual-health"
             ],
-            "last_modified": "2026-03-22T19:07:49-07:00",
+            "last_modified": "2026-07-08T19:30:37.804599+00:00",
             "markdown_path": "_d/build-the-life-you-want.md",
             "outgoing_links": [
                 "/bucket-list",
                 "/emotions",
-                "/lonely"
+                "/happy",
+                "/lonely",
+                "/produce-consume"
             ],
             "redirect_url": "",
             "title": "Build The Life YOU Want",
@@ -2021,7 +2023,7 @@
             "doc_size": 243000,
             "file_path": "_site/changelog.html",
             "incoming_links": [],
-            "last_modified": "2026-07-07T12:09:40.505435+00:00",
+            "last_modified": "2026-07-07T15:13:25+02:00",
             "markdown_path": "_d/changelog.md",
             "outgoing_links": [
                 "/42",
@@ -3815,6 +3817,7 @@
             "incoming_links": [
                 "/addiction",
                 "/awareness",
+                "/build-life-you-want",
                 "/chasing-daylight",
                 "/emotions",
                 "/hobby",
@@ -5494,6 +5497,7 @@
             "incoming_links": [
                 "/ai-feed",
                 "/ai-journal",
+                "/build-life-you-want",
                 "/gap-year-igor",
                 "/slow",
                 "/timeoff-2026-07"
@@ -7277,7 +7281,7 @@
                 "/timeoff",
                 "/y26"
             ],
-            "last_modified": "2026-07-07T12:17:51+02:00",
+            "last_modified": "2026-07-08T09:26:51+02:00",
             "markdown_path": "_d/time-off-2026-07.md",
             "outgoing_links": [
                 "/act",


### PR DESCRIPTION
Expands the **Pleasure vs Enjoyment** section of [Build The Life YOU Want](/build-life-you-want) from the bare formula + beer-ad line into a sourced deep-dive of Arthur Brooks' enjoyment formula.

## What changed

- **Core distinction, expanded** — pleasure happens *to* you (dopamine reward circuit, solitary, fleeting → hedonic treadmill → "you don't arrive at happiness, you wind up in rehab"); enjoyment is something you make. Includes Brooks' verbatim Atlantic line: *"Enjoyment takes the source of pleasure and adds two things: people and memory."*
- **Why People multiplies** — private → shared sensation, recruits the social brain, acts as an over-consumption brake ("you overconsume alone, not in good company"). The beer-ad framing sells the table, not the bottle. Gut check: *if you're doing it alone, you're probably doing it wrong.*
- **The Memory half, fleshed out** (the non-obvious lever) — concrete, research-grounded techniques for deliberately laying down a memory: be present / encode (why phone-in-hand kills it), novelty, make it an occasion, capture a little on purpose (not doom-photographing), engineer the peak + ending (Kahneman's peak-end rule), and retell it.
- **Framework tie-in** — enjoyment as one of three happiness "macronutrients" alongside satisfaction and meaning/purpose, wired to the existing `Happiness = Enjoyment + Satisfaction + Purpose` equation.
- **Honest caveats** — (a) the tidy "old/limbic brain vs prefrontal" split is a useful heuristic but strict triune-brain layering is outdated as literal neuroanatomy; (b) the distinction predates Brooks (Csíkszentmihályi, *Flow*, 1990) — his contribution is the "+ people + memory" operationalization.

## Cross-links

- Adds a link to [/produce-consume](/produce-consume) — solitary consumption (pleasure hit) vs. creating/sharing (enjoyment that lasts) is the same spine.
- Links [/happy#peak-end-rule](/happy#peak-end-rule) for Kahneman's peak-end rule.
- `back-links.json` regenerated so both linked posts show the inbound reference.

## Sources cited

- Brooks & Winfrey, *Build the Life You Want* (2023)
- Brooks, ["Choose Enjoyment Over Pleasure," The Atlantic](https://www.theatlantic.com/family/archive/2022/03/happiness-pleasure-enjoyment-consumption/629447/) (Mar 2022)
- [The Tim Ferriss Show #692](https://tim.blog/2023/09/11/arthur-c-brooks/) (Sept 2023) — beer-ad + neuroscience
- Kahneman, *Thinking, Fast and Slow* (2011) — peak-end rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)