### PR TITLE
Deepen memory-making guidance in /happy enjoyment section

### DIFF
--- a/_posts/2017-04-12-happy.md
+++ b/_posts/2017-04-12-happy.md
@@ -201,9 +201,13 @@ Position and anchor experiences with others. For example this incredible sign:
 
 Be committed to having a great experience, not attached to a specific one. You can't control the exact experience, but you can maximize your influence—especially by sharing it with others and framing it as memorable.
 
+Novelty is what sticks. A first-time experience encodes hard; routine blurs together—I remember my first trip somewhere, but last Tuesday is gone. So when I want a day to be memorable, I deliberately break the pattern: a new place, a new dish, a detour off the usual route.
+
 #### Savor
 
-Be present in the moment. Notice what you're experiencing. Share observations with others—this adds both the "people" and "memory" components while you're still in the experience.
+Be present in the moment—being present is the memory-making act. A memory only forms if you encode it, and you can't encode what you didn't attend to. A phone in your hand during the moment kills that: you're not there to lay the memory down. Notice what you're experiencing. Share observations with others—this adds the "people" and "memory" components while you're still in the experience.
+
+Capture a little, on purpose. One photo, or a line in my journal, helps the memory consolidate. But doom-photographing the whole thing does the opposite—it pulls me out of the moment and weakens the very memory I'm trying to keep.
 
 #### Reminisce
 
@@ -213,7 +217,7 @@ Actively recall experiences with the people who shared them. This is why looking
 
 #### Peak end rule
 
-We remember according to the peak end rule, the average of the peak event and the last event. This is why you should end your vacations with something awesome (as opposed to fighting with your family). The most cited example of the peak end rule e comes from the world of colonoscopies. Normally the colonoscopy takes 60 minutes and ends with 'maximum pain', if the surgeon artificially extend your colonoscopy to 90 minutes at low pain, the patient remembers the colonoscopy as less painful, even though it contained the "painful colonoscopy" followed by additional less painful colonoscopy.
+We remember according to the peak end rule, the average of the peak event and the last event. This is why you should end your vacations with something awesome (as opposed to fighting with your family). Read the other way, peak-end is a memory-design tool: engineer one peak and a good ending on purpose. The most cited example of the peak end rule e comes from the world of colonoscopies. Normally the colonoscopy takes 60 minutes and ends with 'maximum pain', if the surgeon artificially extend your colonoscopy to 90 minutes at low pain, the patient remembers the colonoscopy as less painful, even though it contained the "painful colonoscopy" followed by additional less painful colonoscopy.
 
 ### [Moments](/moments)
 


### PR DESCRIPTION
## What

Igor asked to deepen the **memory-making** lever in the "Maximize Enjoyment (Not Just Pleasure)" section of `/happy`. The formula (`Enjoyment = Pleasure + People + Memory`), the beer-ad example, the `/build-life-you-want` include, and the peak-end subsection already existed — "People" was obvious, but "Memory" was thin. This folds the encoding insights into the existing Anticipate / Savor / Peak-end subsections without adding new headings.

## Changes (all integrated into existing subsections — tightened, not bloated)

- **Anticipate** — added the novelty beat: novel/first-time experiences encode far harder than routine (which blurs together), so deliberately break the pattern to make a day memorable.
- **Savor** — reworked to make the core point that *being present is the memory-making act*: a memory only forms if you encode it, you can't encode what you didn't attend to, and a phone in your hand kills it. Added a "capture a little, on purpose" beat — one photo or a journal line consolidates the memory, but doom-photographing pulls you out and weakens it.
- **Peak end rule** — one-liner reframing it as a memory-*design* tool: engineer one peak and a good ending on purpose.

## Notes

- No subsection headings added and no cross-links changed → TOC and `back-links.json` are unchanged. Verified `toc.py --max 4` produces the existing TOC.
- Voice kept in Igor's plain first-person; checked against `content_guidelines.md` § Avoiding AI Writing Patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)