### PR TITLE
produce-consume: turn Pleasure into Enjoyment (Arthur Brooks)

### DIFF
--- a/_d/produce-consume.md
+++ b/_d/produce-consume.md
@@ -21,6 +21,7 @@ Consumption doesn't just waste your time — it hollows out the producer you wer
   - [The Dopamine Treadmill](#the-dopamine-treadmill)
   - [If you're gonna consume, take the easiest drug you can](#if-youre-gonna-consume-take-the-easiest-drug-you-can)
   - [The Identity Erosion](#the-identity-erosion)
+- [You Don't Have to Quit Consuming — Upgrade It](#you-dont-have-to-quit-consuming--upgrade-it)
 - [The Production Advantage](#the-production-advantage)
   - [Artifacts: Your Digital Legacy](#artifacts-your-digital-legacy)
   - [When Someone Gets Value: The True Measure of Production](#when-someone-gets-value-the-true-measure-of-production)
@@ -62,6 +63,25 @@ The easier something is to stop, the more control you maintain. Choose your cons
 You are what you repeatedly do. If you repeatedly consume, you become... what exactly? A really good scroller? A professional watcher? Your identity becomes a patchwork of other people's thoughts, other people's experiences, other people's lives. You become a walking, talking amalgamation of your YouTube algorithm.
 
 When someone asks "What do you do?" and you struggle to answer beyond your job title, that's the consumption trap. When your personality is just references to things you've watched, that's the consumption trap. When you have strong opinions about strangers' drama but no opinion about your own life direction, that's the consumption trap.
+
+## You Don't Have to Quit Consuming — Upgrade It
+
+So far this reads like a binary: consume and rot, or produce and thrive. It isn't. There's a move in the middle that Arthur Brooks handed me, and it's the most realistic lever most people can actually pull today.
+
+Brooks splits the good feelings that add up to [happiness](/happy) into two piles: **pleasure** and **enjoyment**. Pleasure happens _to_ you — the dopamine hit, the auto-play episode, the scroll. It's solitary, it's animal, and it evaporates the second it's over. That's the [dopamine treadmill](#the-dopamine-treadmill) from earlier: you keep chasing it because it never actually stays. Enjoyment is different. Enjoyment you _build_, and his formula for it is dead simple:
+
+> Enjoyment = Pleasure + People + Memory
+
+Same raw pleasure, plus two ingredients — and now it lasts. Which means you don't have to nuke every guilty pleasure to escape the trap. You can take a thing you were already going to consume and upgrade it in place by adding what's missing:
+
+- **Add people.** Watch the show _with_ someone and argue about it after. Eat the meal at a table, not standing over the sink. Brooks' rule of thumb: "if you're doing it alone, you're probably doing it wrong." The solo scroll becomes a shared thing, and the shared ones are the ones that stick.
+- **Add memory.** Make it an occasion instead of background noise. Be present enough to actually encode it, then retell it later — to a friend, in your journal, at dinner. The retelling is what converts a disappearing hour into something you keep.
+
+Here's the tell for which one you're in: **solitary and memoryless is pleasure — the trap. Shared and remembered is enjoyment.** Same two hours of TV; wildly different outcome for the person you are next week.
+
+This still isn't the top of the mountain — producing is. But it's the switchback most people can reach from where they're standing. Between mindless solo consumption and shipping something of your own, there's this middle rung, and it costs you almost nothing to step onto it today.
+
+{%include summarize-page.html src="/build-life-you-want"%}
 
 ## The Production Advantage
 

--- a/back-links.json
+++ b/back-links.json
@@ -1670,7 +1670,7 @@
         },
         "/bc": {
             "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-            "doc_size": 22000,
+            "doc_size": 23000,
             "file_path": "_site/bc.html",
             "incoming_links": [],
             "last_modified": "2025-12-07T03:02:44+00:00",
@@ -1958,6 +1958,7 @@
             "file_path": "_site/build-life-you-want.html",
             "incoming_links": [
                 "/happy",
+                "/produce-consume",
                 "/spiritual-health"
             ],
             "last_modified": "2026-07-08T19:30:37.804599+00:00",
@@ -2417,6 +2418,7 @@
                 "/first-understand",
                 "/get-to-yes-with-yourself",
                 "/greek-orthodox",
+                "/happy",
                 "/manager-book",
                 "/negotiate",
                 "/operating-manual",
@@ -2706,7 +2708,7 @@
         },
         "/day-in-the-life": {
             "description": "A running journal of days that actually worked - the ones where health habits stuck, family time hit different, or I remembered what it feels like to be fully alive. Not every day needs to be Instagram-worthy, but some days deserve a bookmark. This is that bookmark collection.\n\n",
-            "doc_size": 18000,
+            "doc_size": 19000,
             "file_path": "_site/day-in-the-life.html",
             "incoming_links": [],
             "last_modified": "2025-10-04T18:43:51-07:00",
@@ -3701,7 +3703,7 @@
         },
         "/grammerly": {
             "description": "\n\n",
-            "doc_size": 12000,
+            "doc_size": 13000,
             "file_path": "_site/grammerly.html",
             "incoming_links": [],
             "last_modified": "2025-08-24T09:03:19-07:00",
@@ -3822,6 +3824,7 @@
                 "/hobby",
                 "/joy",
                 "/mood",
+                "/produce-consume",
                 "/siy",
                 "/timeoff",
                 "/timeoff-2020-12",
@@ -3843,15 +3846,15 @@
                 "/addiction",
                 "/anxiety",
                 "/build-life-you-want",
-                "/compassion",
+                "/curious",
                 "/eulogy",
-                "/gty",
                 "/hobby",
-                "/idle-loop",
+                "/idle",
                 "/joy",
                 "/mental-pain",
                 "/moments",
                 "/mood",
+                "/negotiate",
                 "/new-skills",
                 "/spiritual-health"
             ],
@@ -4021,6 +4024,7 @@
                 "/awareness",
                 "/depression",
                 "/gtd",
+                "/happy",
                 "/psychic-weight"
             ],
             "last_modified": "2025-12-06T18:03:28-08:00",
@@ -4683,7 +4687,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 14000,
+            "doc_size": 15000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",
@@ -5013,6 +5017,7 @@
             "incoming_links": [
                 "/curious",
                 "/get-to-yes-with-yourself",
+                "/happy",
                 "/productive",
                 "/sell",
                 "/synergize",
@@ -5489,7 +5494,7 @@
         },
         "/produce-consume": {
             "description": "Remember when you finished binge-watching that entire series and felt… empty? Now remember the last time you made something — anything — even if it sucked. Which memory makes you smile? Yeah, me too. We live in the golden age of consumption, where infinite content is one thumb-swipe away, yet we’re more anxious and less satisfied than ever. Here’s the thing: you’re not meant to be a consumer. You’re meant to be a producer.\n\n",
-            "doc_size": 24000,
+            "doc_size": 26000,
             "file_path": "_site/produce-consume.html",
             "incoming_links": [
                 "/ai-feed",
@@ -5503,7 +5508,9 @@
             "markdown_path": "_d/produce-consume.md",
             "outgoing_links": [
                 "/activation",
-                "/addiction"
+                "/addiction",
+                "/build-life-you-want",
+                "/happy"
             ],
             "redirect_url": "",
             "title": "The Producer's Paradox: Why Creating Beats Consuming Every Time",
@@ -6437,7 +6444,7 @@
         },
         "/synergize": {
             "description": "We’ve all got stuff we’re good at and stuff we’re bad at. Combine them right and the system is greater than the sum of the parts — sometimes a lot greater. Synergy is the payoff for everything that came before: independence, Win/Win, and seeking first to understand all converge here. These are my insights from 7 habits Chapter 6.\n\n",
-            "doc_size": 28000,
+            "doc_size": 29000,
             "file_path": "_site/synergize.html",
             "incoming_links": [
                 "/7-habits",
@@ -6522,7 +6529,7 @@
         },
         "/td/back_ref": {
             "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
-            "doc_size": 13000,
+            "doc_size": 14000,
             "file_path": "_site/td/back_ref.html",
             "incoming_links": [],
             "last_modified": "2022-04-16T15:22:43-07:00",
@@ -7710,7 +7717,7 @@
         },
         "/win-win": {
             "description": "Win/Win is a constantly seeking mutual benefit in all interactions. Win/Win means that agreements or solutions are mutually beneficial, mutually satisfying. With a Win/Win solution, all parties feel good about the decision and feel committed to the action plan. Win/Win sees life as a cooperative, not a competitive arena. Most people tend to think in terms of dichotomies: strong or weak, hardball or softball, win or lose. But that kind of thinking is fundamentally flawed. It’s based on power and position rather than on principle. Win/Win is based on the paradigm that there is plenty for everybody, that one person’s success is not achieved at the expense or exclusion of the success of others.\n\n",
-            "doc_size": 47000,
+            "doc_size": 48000,
             "file_path": "_site/win-win.html",
             "incoming_links": [
                 "/7-habits",


### PR DESCRIPTION
## What

Adds a new `##` section to `/produce-consume` ("The Producer's Paradox"), placed as the redemptive turn **between** `## The Consumption Trap` and `## The Production Advantage`:

**"You Don't Have to Quit Consuming — Upgrade It"**

The section reframes consumption using Arthur Brooks' pleasure-vs-enjoyment distinction (Atlantic, "Choose Enjoyment Over Pleasure" / *Build the Life You Want*):

- **Pleasure** happens *to* you — solitary, animal, evaporates. That's the dopamine treadmill already described earlier in the post (ties back via an in-page anchor link).
- **Enjoyment** you build: **Pleasure + People + Memory**, and it lasts.
- The move: you don't have to nuke all consumption — convert a given consumption from empty pleasure into enjoyment by **adding people** (watch/eat *with* someone — Brooks: "if you're doing it alone, you're probably doing it wrong") and **adding memory** (make it an occasion, encode it, retell it).
- The tell: solitary + memoryless = pleasure (the trap); shared + remembered = enjoyment.
- Bridges to the rest of the post: producing is still the top of the mountain, but this is the middle rung most people can actually step onto today.

## Cross-links added
- `/happy` (his happiness study)
- `/build-life-you-want` (his Brooks deep-dive, via `summarize-page` include)

## Housekeeping
- Regenerated TOC (`toc.py`)
- Regenerated `back-links.json` (`just back-links`) — `/happy` and `/build-life-you-want` now list `/produce-consume` as an incoming link
- Voice matched to the post's existing second-person register; checked against `content_guidelines.md` § Avoiding AI Writing Patterns
- Markdown-anchor pre-commit hook passes (in-page `#the-dopamine-treadmill` link + new section anchor resolve against a fresh `_site`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new section to the “Produce vs. Consume” article exploring how to turn solitary consumption into richer enjoyment through people and memories.
  - Added a table-of-contents link to the new section.
  - Linked the article to related guidance on building the life you want.
  - Improved navigation between related articles and updated backlink metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->