### PR TITLE
Tier-4 quick fixes: 7 Habits series

### DIFF
--- a/_d/7h-c0.md
+++ b/_d/7h-c0.md
@@ -30,7 +30,7 @@ To talk about the 7 habits I need the foundation that comes before the habits st
 - [Assets: Physical, Financial, Human](#assets-physical-financial-human)
 - [Mental Models: Map vs Terrain](#mental-models-map-vs-terrain)
 - [Teach others to teach yourself](#teach-others-to-teach-yourself)
-- [How we "see" the problem, becomes our subjective problem.](#how-we-see-the-problem-becomes-our-subjective-problem)
+- [How we "see" the problem becomes our subjective problem](#how-we-see-the-problem-becomes-our-subjective-problem)
 - [Around and around - Feedback loop](#around-and-around---feedback-loop)
 
 <!-- vim-markdown-toc-end -->
@@ -174,7 +174,7 @@ The PC principle for organizations: _treat your employees exactly as you want th
 
 Using your eyes you can look at the road outside your house. It has a color, a specific width, perhaps some potholes. This is the terrain, the physical reality, but you won't see any of this on Google Maps. Your eyes won't let you see the networks of sewers underneath your street. For that, there are maps that show the sewers, but those maps lack houses.
 
-Maps are required as the world is infinitely complex, and we need simpler models to understand what is going on. A similar thing happens at the restaurant — your order off the menu, which is a simplification of the food. To understand the world, we need mental models, like the ones in most non-fiction books.
+Maps are required as the world is infinitely complex, and we need simpler models to understand what is going on. A similar thing happens at the restaurant — you order off the menu, which is a simplification of the food. To understand the world, we need mental models, like the ones in most non-fiction books.
 
 While maps are useful, they are not the terrain. In some dimensions the map is always wrong, and classifying the edges is hard.
 
@@ -182,7 +182,7 @@ There will be several maps to understand the terrain — the street map, the sew
 
 Maps are also limited by the map maker:
 
-_A group of blind men heard that a strange animal, called an elephant, had been brought to the town, but none of them were aware of its shape and form. Out of curiosity, they said: "We must inspect and know it by touch, of which we are capable". So, they sought it out, and when they found it they groped about it. The first person, whose hand landed on the trunk, said, "This being is like a thick snake". For another one whose hand reached its ear, it seemed like a kind of fan. As for another person, whose hand was upon its leg, said, the elephant is a pillar like a tree-trunk. The blind man who placed his hand upon its side said the elephant, "is a wall". Another who felt its tail, described it as a rope. The last felt its tusk, stating the elephant is that which is hard, smooth and like a spear._
+_Six blind men inspect an elephant by touch. The one at the trunk reports a thick snake; the ear, a fan; the leg, a pillar; the side, a wall; the tail, a rope; the tusk, a spear._
 
 When two smart people disagree, the question I want to ask is rarely "who is right" and almost always "which part of the elephant is each of us touching."
 
@@ -196,7 +196,7 @@ Same principle as [coaching](/curious): you don't really know it until you can g
 
 This is also why I write these summaries. The post is the act of teaching, and I find the holes in my understanding by trying to put them into words.
 
-### How we "see" the problem, becomes our subjective problem.
+### How we "see" the problem becomes our subjective problem
 
 From [Sleight of Mouth](/sleight-of-mouth):
 
@@ -220,5 +220,7 @@ Inside-out isn't a checklist you complete once. It's an upward spiral:
 Each habit feeds the next. Being proactive (Habit 1) is what lets me begin with the end in mind (Habit 2), which is what lets me put first things first (Habit 3). Independence opens the door to Win/Win (4). Win/Win is the prerequisite for empathic listening (5). Both are required for synergy (6). And Habit 7 — sharpen the saw — is what keeps the whole spiral spinning instead of grinding flat.
 
 Einstein: _"The significant problems we face cannot be solved at the same level of thinking we were at when we created them."_ Each rotation of the spiral is a small jump in level. That's the whole game.
+
+Where's my spiral pointed? At the person described in my eulogy.
 
 {% include summarize-page.html src="/eulogy" %}

--- a/_d/7h-c1.md
+++ b/_d/7h-c1.md
@@ -16,11 +16,9 @@ redirect_from:
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c1.webp
 ---
 
-I choose '.' I am responsible for my own life '.' My behavior is a function of my decisions, not my conditions '.' I can subordinate feelings to values '.' I have the initiative and the responsibility to make things happen. These are my insights from [7 habits](/7h) Chapter 1.
+I choose. I am responsible for my own life. My behavior is a function of my decisions, not my conditions. I can subordinate feelings to values. I have the initiative and the responsibility to make things happen. These are my insights from [7 habits](/7-habits) Chapter 1.
 
 {% include ai-slop.html percent="50" %}
-
-TODO: Link to videos
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
@@ -55,8 +53,6 @@ TODO: Link to videos
 Before I can be proactive I need a self I can hear. The whole habit rests on one uniquely human capacity: I can think about my own thinking. I can stand apart from a feeling, look at it, name it, and decide what to do with it. Animals can't. Most of the time, neither can I — but I can train it.
 
 {%include summarize-page.html src='/siy' %}
-
-{%include summarize-page.html src='/four-healths' %}
 
 ### See ourselves - independent of feeling and mood and others
 
@@ -102,11 +98,11 @@ The technologies for widening the gap are old: a breath, a pause, naming the fee
 
 Inside the gap are four endowments that animals don't have:
 
-| Endowment       | What it does                                            |
-| --------------- | ------------------------------------------------------- |
-| Self-awareness  | I can examine my own thoughts and patterns              |
-| Imagination     | I can simulate responses I haven't tried before         |
-| Conscience      | I can sense whether a response aligns with my values    |
+| Endowment        | What it does                                             |
+| ---------------- | -------------------------------------------------------- |
+| Self-awareness   | I can examine my own thoughts and patterns               |
+| Imagination      | I can simulate responses I haven't tried before          |
+| Conscience       | I can sense whether a response aligns with my values     |
 | Independent will | I can act on my values, even against feelings or scripts |
 
 Eleanor Roosevelt: _"No one can hurt you without your consent."_ Gandhi: _"They cannot take away our self respect if we do not give it to them."_ These are not denials of the original injury — physical or economic harm is real. They're claims about the second-order effect: my consent is what lets the harm continue to bruise me long after the moment is over.
@@ -145,22 +141,20 @@ If I'm not acting, the world is acting on me. There's no neutral state.
 
 The fastest diagnostic for whether I'm being proactive: listen to my own language.
 
-| Reactive (determined)         | Proactive (chosen)                       |
-| ----------------------------- | ---------------------------------------- |
-| There's nothing I can do      | Let's look at our alternatives           |
-| That's just the way I am      | I can choose a different approach        |
-| He makes me so mad            | I control my own feelings                |
-| They won't allow that         | I can create an effective presentation   |
-| I have to do that             | I will choose an appropriate response    |
-| I can't                       | I choose                                 |
-| I must                        | I prefer                                 |
-| If only…                      | I will                                   |
+| Reactive (determined)    | Proactive (chosen)                     |
+| ------------------------ | -------------------------------------- |
+| There's nothing I can do | Let's look at our alternatives         |
+| That's just the way I am | I can choose a different approach      |
+| He makes me so mad       | I control my own feelings              |
+| They won't allow that    | I can create an effective presentation |
+| I have to do that        | I will choose an appropriate response  |
+| I can't                  | I choose                               |
+| I must                   | I prefer                               |
+| If only…                 | I will                                 |
 
 "I have to go on a tennis trip" really means "I _choose_ to go because I want the consequence of staying on the team." The word _have_ launders the choice and the responsibility right out of the sentence. The cost is real — I lose the felt sense of agency. The dial drifts toward _I am being lived_.
 
 Proactive language isn't a verbal tic to swap in. The words follow the paradigm. But the words also reinforce the paradigm. So both directions matter — change the paradigm to change the words, and watch the words to catch the paradigm slipping.
-
-{%include summarize-page.html src='/essentialism' %}
 
 {%include summarize-page.html src='/affirmations' %}
 

--- a/_d/7h-c2.md
+++ b/_d/7h-c2.md
@@ -11,11 +11,6 @@ permalink: /end-in-mind
 redirect_from:
   - /7h-c2
   - /begin-with-the-end-in-mind
-
-alias:
-  - /end-in-mind
-  - /7h-c2
-  - /begin-with-the-end-in-mind
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c2.webp
 ---
 
@@ -103,6 +98,8 @@ Instead of being principle-centered, people often organize their lives around al
 
 The principle-centered alternative: security from correct principles, guidance from conscience, wisdom from accurate maps, power from alignment.
 
+Which row is mine? Whatever can knock a whole day sideways — the test I run in [A Principle Center](#a-principle-center) below.
+
 ## A Principle Center
 
 Every center supplies the same four things: security (worth and identity), guidance (direction for decisions), wisdom (perspective and balance), and power (capacity to act). The false centers above each supply some of these, badly — work gives identity but no perspective, money gives a kind of power but no wisdom, friends give belonging but no stable guidance.
@@ -156,8 +153,6 @@ My current rough cut:
 For each role I write what I'm trying to be in it, not just what I'm trying to do. _Husband: a partner she can trust with the hard truths, not just the easy logistics._ _Father (per kid): the person who saw who they actually were, not who I wanted them to be._ _Engineer: the one who left the system better than I found it and explained it well enough that the next person could keep going._
 
 Then weekly planning becomes legible. I look at the roles, ask which ones got starved last week, and seed the calendar with one concrete commitment for each. Not "spend more time with the kids" — too vague to track. Specific: a one-on-one date with each kid this month, a long bike ride with my friend, a 30-minute self-review on Sunday night. The role frame catches the imbalance before the eulogy does.
-
-{% include summarize-page.html src='/four-healths' %}
 
 {% include summarize-page.html src='/balance' %}
 

--- a/_d/7h-c6.md
+++ b/_d/7h-c6.md
@@ -13,7 +13,7 @@ redirect_from:
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c6.webp
 ---
 
-We've all got stuff we're good at and stuff we're bad at. Combine them right and the system is greater than the sum of the parts — sometimes a lot greater. Synergy is the payoff for everything that came before: independence, [Win/Win](/win-win), and [seeking first to understand](/first-understand) all converge here. These are my insights from [7 habits](/7h) Chapter 6.
+I've got stuff I'm good at and stuff I'm bad at — so does everyone I work and live with. Combine them right and the system is greater than the sum of the parts — sometimes a lot greater. Synergy is the payoff for everything that came before: independence, [Win/Win](/win-win), and [seeking first to understand](/first-understand) all converge here. These are my insights from [7 habits](/7-habits) Chapter 6.
 
 {% include ai-slop.html percent="60" %}
 
@@ -23,6 +23,7 @@ We've all got stuff we're good at and stuff we're bad at. Combine them right and
 - [What Makes Synergy Possible](#what-makes-synergy-possible)
 - [Examples of Synergy in Action](#examples-of-synergy-in-action)
 - [Finding that Third Alternative](#finding-that-third-alternative)
+  - [Win/Win vs. the Third Alternative](#winwin-vs-the-third-alternative)
 - [Negative Synergy](#negative-synergy)
 - [Valuing the Differences](#valuing-the-differences)
 - [Force Field Analysis](#force-field-analysis)
@@ -33,7 +34,7 @@ We've all got stuff we're good at and stuff we're bad at. Combine them right and
 
 {% include blob_image_float_right.html src="blog/raccoon-7h-c6.webp" alt="Raccoon synergizing" %}
 
-### What Makes Synergy Possible
+## What Makes Synergy Possible
 
 Synergy is when 1 + 1 = 3. Or 8. Or 1,600. The classic frame: plant two trees close together and the roots co-mingle, the soil improves, both trees grow taller than they would have alone. That's the picture I keep in my head — interdependence isn't compromise, it's compounding.
 
@@ -45,7 +46,7 @@ Three things have to be true for it to fire:
 
 The first three habits give me the internal security to handle the risk of being open. The next two — Win/Win and empathic listening — give me the right motive and the right skill. Synergy is what falls out when all of that is in place.
 
-### Examples of Synergy in Action
+## Examples of Synergy in Action
 
 The clearest example I have is at work. When I'm running a project well, the engineer I'd never want to lose isn't the one who agrees with me — it's the one who pushes back in a way I can't dismiss. We both leave the conversation with something neither of us walked in with. That's the goose that lays the golden eggs of a team.
 
@@ -57,7 +58,7 @@ A few other places I see it land:
 
 The half-form of this — respectful but uncreative — is compromise. Compromise is 1 + 1 = 1.5. Both sides give and take, the conversation is polite, and nothing new is created. That's not synergy; that's just a draw.
 
-### Finding that Third Alternative
+## Finding that Third Alternative
 
 The third alternative is the heart of the habit. It's not my way. It's not your way. It's a third way that neither of us could have reached alone.
 
@@ -74,7 +75,7 @@ The rough recipe I use:
 
 The output is almost never one of the original two options. It's a thing nobody walked in with.
 
-#### Win/Win vs. the Third Alternative
+### Win/Win vs. the Third Alternative
 
 People conflate this with [Think Win/Win (Habit 4)](/win-win). They're related but not the same.
 
@@ -88,15 +89,11 @@ People conflate this with [Think Win/Win (Habit 4)](/win-win). They're related b
 
 Win/Win is the prerequisite — without the abundance mindset I'm playing zero-sum in my head, and synergy can't fire. But it's only the table stakes. The third alternative is what's possible once both people have that mindset _and_ the empathic listening to use it.
 
-For more on how I apply this in negotiations, see my notes on [Getting to yes](/gty), which is essentially third-alternative thinking applied to deal-making.
+For more on how I apply this in negotiations, see my notes on [Getting to yes](/negotiate), which is essentially third-alternative thinking applied to deal-making.
 
-{% include summarize-page.html src='/win-win' %}
+{% include summarize-page.html src='/negotiate' %}
 
-{% include summarize-page.html src='/first-understand' %}
-
-{% include summarize-page.html src='/gty' %}
-
-### Negative Synergy
+## Negative Synergy
 
 Negative synergy is what most meetings actually produce. It's the meeting where everyone leaves dumber than they came in. The same energy that could compound creativity is being burned on protecting backsides, scoring points, and second-guessing.
 
@@ -109,7 +106,7 @@ The shape I recognize:
 
 The diagnostic on myself is honest: when I'm in negative-synergy mode, it's almost always because I've stopped feeling secure enough to be wrong in public. The fix lives in the first three habits, not in better meeting facilitation.
 
-### Valuing the Differences
+## Valuing the Differences
 
 The cornerstone insight: **people don't see the world as it is — they see it as they are**. If I think I'm objective and everyone else is biased, I'll never get anything from anyone. I'll be limited to the size of my own conditioning.
 
@@ -119,7 +116,7 @@ Same with my marriage. Tammy and I are different in ways that I sometimes wish a
 
 The internal version of this matters too. The analytical, verbal, left-brain part of me wants facts and bullet points. The intuitive, image-based, right-brain part of me wants to feel into a thing before naming it. When I treat one of those as the only legitimate way to think, I'm running on half a brain. Synergy starts inside.
 
-### Force Field Analysis
+## Force Field Analysis
 
 Kurt Lewin's frame, and one of the more useful tools I've kept from this chapter. Any current state — a team's morale, my fitness level, the climate at home, the tone of a 1:1 — is an equilibrium between two sets of forces:
 
@@ -134,8 +131,6 @@ This is why synergy beats willpower in interdependent situations. Willpower can 
 
 {% include summarize-page.html src='/coaching' %}
 
-### Books
+## Books
 
 {% include amazon.html asin="0743269519" %}
-
-For deeper exploration of synergy and the third alternative, Stephen Covey's _The 3rd Alternative_ expands on these concepts with practical applications for finding breakthrough solutions in personal and professional contexts.

--- a/_d/7h-c7.md
+++ b/_d/7h-c7.md
@@ -14,7 +14,9 @@ redirect_from:
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c7.webp
 ---
 
-A young man saw a woodcutter cutting down a tree and asked “What are you doing?” “Are you blind?” the woodcutter replied. “I’m cutting down this tree.” The young man continued. “You look exhausted! Take a break. Sharpen your saw.” The woodcutter explained he'd been sawing for hours and did not have time to take a break. The young man pushed back… “If you sharpen the saw, you would cut down the tree much faster.” The woodcutter said “I don’t have time to sharpen the saw. Don’t you see I’m too busy. These are my insights based on the [7 habits](/7h) Chapter 7.
+A young man saw a woodcutter cutting down a tree and asked “What are you doing?” “Are you blind?” the woodcutter replied. “I’m cutting down this tree.” The young man continued. “You look exhausted! Take a break. Sharpen your saw.” The woodcutter explained he'd been sawing for hours and did not have time to take a break. The young man pushed back… “If you sharpen the saw, you would cut down the tree much faster.” The woodcutter said “I don’t have time to sharpen the saw. Don’t you see I’m too busy.”
+
+These are my insights based on the [7 habits](/7-habits) Chapter 7.
 
 {% include ai-slop.html percent="50" %}
 
@@ -33,7 +35,6 @@ A young man saw a woodcutter cutting down a tree and asked “What are you doing
 - [Identity Health](#identity-health)
 - [Scripting others](#scripting-others)
 - [Balance and the upward spiral](#balance-and-the-upward-spiral)
-- [Sometimes you need to stop sharpening the saw, and start cutting the shit.](#sometimes-you-need-to-stop-sharpening-the-saw-and-start-cutting-the-shit)
 - [Books](#books)
 
 <!-- vim-markdown-toc-end -->
@@ -43,7 +44,7 @@ A young man saw a woodcutter cutting down a tree and asked “What are you doing
 
 ## The four dimensions of renewal
 
-Habit 7 is personal PC. The asset I'm preserving is _me_ — the only instrument I have for doing any of the other six habits. There are four dimensions to keep sharp, and skipping any one will eventually drag the others down:
+Habit 7 is personal PC — production capability, [the goose that lays the golden eggs](/7h-concepts#effectiveness-ppc-balance). The asset I'm preserving is _me_ — the only instrument I have for doing any of the other six habits. There are four dimensions to keep sharp, and skipping any one will eventually drag the others down:
 
 | Dimension            | What I'm renewing                          | Habit it powers        |
 | -------------------- | ------------------------------------------ | ---------------------- |
@@ -140,11 +141,11 @@ The renewal itself follows an upward spiral: _learn, commit, do — learn, commi
 
 The Daily Private Victory — an hour a day across physical, mental, and identity — is what keeps the spiral spinning. Skip too many days and the spiral grinds flat into a treadmill.
 
-## Sometimes you need to stop sharpening the saw, and start cutting the shit.
-
-That's in fact the core of effectiveness, balancing production, and production capacity
+The counterpoint keeps me honest: sometimes you need to stop sharpening the saw and start cutting the shit. Renewal is PC in service of P — if all I ever do is sharpen, I'm not a woodcutter, I'm a saw collector.
 
 ## Books
 
 - [Atomic Habits](/atomic-habits)
 - [Search Inside Yourself](/siy)
+
+{% include amazon.html asin="0743269519" %}

--- a/_posts/2018-01-04-7-habits.md
+++ b/_posts/2018-01-04-7-habits.md
@@ -3,8 +3,6 @@ layout: post
 title: "Seven Habits: A manual for life"
 date: "2018-01-04 05:46:41 Pacific Standard Time"
 comments: true
-inprogress: true
-collapsable: true
 
 tags:
   - emotional intelligence
@@ -37,13 +35,13 @@ Need a user manual for life? For me, that's The 7 Habits of Highly Effective Peo
 - [First things first](/first-things-first)
 
 <div/>
-* l3
-* [Win Win or No Deal](/win-win)
-* [Seek First to Understand Then to be understood](/first-understand)
-* [Synergize](/synergize)
+- l3
+- [Win Win or No Deal](/win-win)
+- [Seek First to Understand Then to be understood](/first-understand)
+- [Synergize](/synergize)
 
 <div/>
-* l4
+- l4
 - [Sharpen the saw](/sharpen-the-saw)
 
 Very funny, in the 7 habits of highly effective teens they list the anti-habits. Very funny when you see them listed out ...
@@ -81,9 +79,13 @@ A little picture I drew when I'd just discovered the 7 habits ...
 
 ![igor_life_infographic](/images/igor-life-infographic.jpg)
 
-### Sharpen the saw
+### Be Proactive
 
-- Did you do your habits today?
+- Pause between stimulus and response
+- Who has helped me grow?
+- Stop using reactive language
+- Use empowering language (I choose, I will)
+- Is this in my circle of influence, or circle of concern?
 
 ### Begin with the end in mind
 
@@ -102,26 +104,23 @@ A little picture I drew when I'd just discovered the 7 habits ...
 - What quadrant am I spending most of my time in? What is the consequence?
 - How many of my crisis could be avoided if I spent more time in quadrant 2?
 
-### Sharpen the Saw
-
-- Is technology helping me, or is it hurting me?
-
-### Be Proactive
-
-- Pause between stimulus and response
-- Who has helped me be grow?
-- Stop using reactive language
-- Use empowering language (I choose, I will)
-- Is this in my circle of influence, or circle of concern?
-
-### Synergize
-
-- How can I complement someone around me?
-
 ### Think Win/Win
 
 - If it's not WIN/WIN, it's LOSE/LOSE.
+- Where am I trying to win at someone else's expense this week?
+- Is there a deal here at all, or is [no deal](/win-win) the honest answer?
 
 ### First Understand
 
 - Imagine an eye doctor tried to make you use their glasses
+
+### Synergize
+
+- How can I complement someone around me?
+- Whose difference am I treating as a deficit instead of a strength?
+- What [third alternative](/synergize) haven't we looked for yet?
+
+### Sharpen the Saw
+
+- Did you do your habits today?
+- Is technology helping me, or is it hurting me?


### PR DESCRIPTION
Minutes-effort fixes from the 2026-07-13 full-blog quality audit for the 7 Habits series set. Tracked: blog-npm.

## Per-post changes

- **/7h-concepts** (`_d/7h-c0.md`): fixed the "your order off the menu" typo, removed the comma splice and trailing period from the 'How we "see" the problem' heading (anchor slug unchanged), cut the blind-men-and-elephant parable from ~150 words to two sentences while keeping the payoff line, and added a one-line intro so the trailing /eulogy include no longer reads as an orphaned paste.
- **/be-proactive** (`_d/7h-c1.md`): rewrote the broken opening paragraph — the literal `'.'` artifacts that shipped to the page, RSS, and social cards for this 17-inbound-link hub are gone; deleted the raw `TODO: Link to videos`; thinned the stacked summarize-page includes (kept /siy in Equanimity, /affirmations in Proactive Language) and removed the mid-post /essentialism duplicate (it stays in Books).
- **/end-in-mind** (`_d/7h-c2.md`): deleted the nonstandard `alias:` frontmatter block that duplicated the permalink and redirects; cut the triple include stack after "Identifying your roles" to two (/balance, /chapters); added a short line to False Centers pulling the reactive-intensity diagnostic forward from the A Principle Center section.
- **/synergize** (`_d/7h-c6.md`): opening now first person instead of "We've all got…"; deleted the generic *3rd Alternative* closing blurb; swapped redirect URLs for permalinks (/7h → /7-habits, /gty → /negotiate — the /gty include was also missing from back-links.json, so the card was degraded); collapsed the three stacked includes after the Win/Win table to just the /negotiate one that has introducing text; promoted headers to h2 to match sibling chapter posts.
- **/sharpen-the-saw** (`_d/7h-c7.md`): closed the woodcutter's unclosed quote and moved "These are my insights…" to its own paragraph so the shipped excerpt is clean; defined PC in one clause with a link to the P/PC section of /7h-concepts; folded the abandoned "stop sharpening the saw, start cutting the shit" stub into the upward-spiral section as a kicker (no inbound links to the removed anchor); swapped /7h → /7-habits; added the amazon include for the source book in Books, matching /synergize.
- **/7-habits** (`_posts/2018-01-04-7-habits.md`): dropped the `inprogress: true` flag it's worn since 2018 (and the dead `collapsable` key no template reads, which the typos hook flags); merged the two duplicate Sharpen the Saw prompt sections; reordered the prompt sections into habit order 1→7 to mirror the dependent→independent→interdependent progression; gave Think Win/Win and Synergize two additional real prompts each; normalized the mixed `*`/`-` bullets; fixed "helped me be grow" → "helped me grow".

## Needs Igor

- **/7h-concepts — Map vs Terrain personal example**: the audit asks for "a real disagreement where two maps were both right." That needs a real memory, so I left the section's prose alone rather than invent one.
- **/end-in-mind — naming your actual center in False Centers**: I pulled the diagnostic forward with a linking line, but naming which center you actually drift to is yours to answer.
- **/be-proactive — the 5000-percent gap section**: still pure Covey retelling; grounding it needs a personal story (not in the audit's minutes-level fix list, noting for completeness).

Text-level cleanup only, no layout changes, so no screenshots; back-links.json regenerates via the update-backlinks workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxH3FCWWxKnrpn7PKL3fPY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined wording, punctuation, headings, and table formatting across the Seven Habits content.
  * Reorganized the refresher outline and updated the order and prompts for several habits.
  * Added or updated navigation entries, links, redirects, and the “Win/Win vs. the Third Alternative” section.
  * Streamlined illustrative stories, explanatory passages, and book-related content.
  * Removed outdated page summaries, video placeholders, and redundant explanatory text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->