### PR TITLE
Tier-4 quick fixes: Health & body

### DIFF
--- a/_d/2016-2-11-Insomnia.md
+++ b/_d/2016-2-11-Insomnia.md
@@ -10,7 +10,6 @@ redirect_from:
   - /sleepless
 
 comments: true
-inprogress: true
 imagefeature: https://github.com/idvorkin/blob/raw/master/problem-size.png
 ---
 
@@ -43,7 +42,7 @@ If the problem isn't a task I can work on, then I should clear my head, trying t
 After a few days of inadequate sleep, I'll often be trying to deal with sleep deprivation. When that happens it's about catching up.
 
 - The essential activity, is getting back on my natural sleep cycle. I do this best through sleep deprivation, not sleep catchup.
-- I take prescription sleeping pills (aka Ambien/Lunesta/Sonata).
+- I take prescription sleeping pills (aka Ambien/Lunesta/Sonata) - not to catch up on sleep, but to make sure I fall asleep at my normal bedtime.
 - I force myself out of bed at wake-up time - even if I didn't get enough sleep.
 - I do not drink caffeine or nap. The best path to fall asleep on time (or even early) is sleep exhaustion
 

--- a/_d/2016-2-14-Health-In-The-Head.md
+++ b/_d/2016-2-14-Health-In-The-Head.md
@@ -2,7 +2,9 @@
 layout: post
 title: "Emotional Health In My Head"
 comments: true
-inprogress: true
+permalink: /fit-in-my-head
+redirect_from:
+  - /d/2016-2-14-Health-In-The-Head
 tags:
   - emotional intelligence
   - health
@@ -15,4 +17,4 @@ In physical health, I used to be 230 pounds and refused to diet. In "my head" I 
 
 The same type of situation exists in my emotional health.
 
-In emotional health, I have solid self-awareness, and an ability to read others, but I refused to empathize, or be accepting. In "my head" I thought I was emotionally healthy because I could read people's motivations, including my own. BUT in reality, even though I have the building blocks of good emotional health, I'm still emotionally unhealthy. Recently, I realized empathy, and being accepting is critical to my emotional health. It'll take a while, but learning to empathize and be accepting sustainably, will be the ticket to my emotional health. I'm still able to see motivation clearly, but now I'm learning empathy and acceptance, so soon I'll not only look emotionally healthy, I'll actually be emotionally healthy.
+In emotional health, I have solid self-awareness and can read people's motivations, including my own - so in "my head" I was emotionally healthy. BUT I refused to empathize or be accepting, so in reality I had the building blocks and was still emotionally unhealthy. Like dieting, learning empathy and acceptance sustainably will take a while, but that's the path from looking emotionally healthy to being emotionally healthy.

--- a/_d/back-pain.md
+++ b/_d/back-pain.md
@@ -9,7 +9,7 @@ tags:
   - physical health
 ---
 
-Back pain is one of the most common and debilitating conditions. Stuart McGill's research changed how we think about it: the spine should stay stiff while motion comes from the hips and shoulders.
+For years my back was stiff every morning until I stretched it out, and kettlebell swings are what finally loosened it. Stuart McGill's research changed how I think about back pain: the spine should stay stiff while motion comes from the hips and shoulders.
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
@@ -51,6 +51,8 @@ If your hips or shoulders are stiff, your back will compensate by moving - and t
 {%include summarize-page.html src="/shoulder-pain"%}
 
 ### The 5 Whys Applied to Back Pain
+
+The 5 Whys is the root-cause tool from the Correction of Errors process I use at work - it applies surprisingly well to back pain:
 
 {%include summarize-page.html src="/coe"%}
 

--- a/_d/bells.md
+++ b/_d/bells.md
@@ -11,7 +11,7 @@ redirect_from:
   - /simple-and-sinister
 ---
 
-There's no way I'm swinging that thing between my legs; I'm going to kill my back. When I started working out with a trainer in 2020, they tried to get me to do a kettlebell swing, and I was like, no way. Then they spent 3 weeks teaching me Turkish Get-Ups (TGUs), which I absolutely loved. Then I read _Simple and Sinister_, and now I've achieved _Timeless Simple_ and do heavy clubs instead of halos.
+There's no way I'm swinging that thing between my legs; I'm going to kill my back. When I started working out with a trainer in 2020, they tried to get me to do a kettlebell swing, and I was like, no way. Then they spent 3 weeks teaching me Turkish Get-Ups (TGUs), which I absolutely loved. Then I read _Simple and Sinister_, and now I've achieved _Timeless Simple_ and do heavy clubs instead of halos. (Timeless Simple is hitting Pavel's Simple standard - 100 swings and 10 get-ups with a 32 kg bell - without the time limits.)
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
@@ -19,8 +19,8 @@ There's no way I'm swinging that thing between my legs; I'm going to kill my bac
 - [Swings](#swings)
 - [TGUs](#tgus)
 - [Goals](#goals)
-- [KB Squats](#kb-squats)
 - [Heavy Clubs](#heavy-clubs)
+- [Swing Analyzer App](#swing-analyzer-app)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
@@ -56,8 +56,6 @@ I'm applying a goal from a book called _Kettlebell Simple and Sinister_.
 - 10x10 @ 32 KG Two-Arm Swings (100!) (Achieved November '23), but then regressed due to injury.
 - 10x10 @ 32 KG (50 per arm) One-Arm Swings
 - 5x1 @ 32 KG (5 per arm) Achieved January '24, but then regressed due to not doing them for a long holiday.
-
-### KB Squats
 
 Now I'm picking up one-handed front rack squats.
 

--- a/_d/emotional-health-hold.md
+++ b/_d/emotional-health-hold.md
@@ -18,20 +18,22 @@ Emotionally healthy folks can let it go, empathize with others, and most importa
 
 I picked up, and also execute, these habits semi-randomly today. However, as I do with physical health, I'll try to build up a more deliberate system. If you're interested in building up your emotional intelligence, my "bible" for emotional health practices is currently [SIY](/search-inside-yourself). This is also a key [saw to be sharpened](/sharpen-the-saw).
 
+A warning before the practices: health in my head isn't health in reality. I learned that with physical health first, and I'm relearning it emotionally - see [Emotional Health In My Head](/fit-in-my-head).
+
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
 - [Active Practices](#active-practices)
-    - [Daily Stream of Consciousness Journaling](#daily-stream-of-consciousness-journaling)
-    - [Daily Gratefulness Journal](#daily-gratefulness-journal)
-    - [4:30 am wake up (psst - it's really physical health)](#430-am-wake-up-psst---its-really-physical-health)
-    - [Formal 20 minute breathing meditation](#formal-20-minute-breathing-meditation)
-    - [Box breathing](#box-breathing)
+  - [Daily Stream of Consciousness Journaling](#daily-stream-of-consciousness-journaling)
+  - [Daily Gratefulness Journal](#daily-gratefulness-journal)
+  - [4:30 am wake up (psst - it's really physical health)](#430-am-wake-up-psst---its-really-physical-health)
+  - [Formal 20 minute breathing meditation](#formal-20-minute-breathing-meditation)
+  - [Box breathing](#box-breathing)
 - [Future Practices](#future-practices)
-    - [Sublime States Training](#sublime-states-training)
-    - [Daily Reflective Journal](#daily-reflective-journal)
+  - [Sublime States Training](#sublime-states-training)
+  - [Daily Reflective Journal](#daily-reflective-journal)
 - [Inconsistent/Future practices](#inconsistentfuture-practices)
-    - [Discontinued Practices](#discontinued-practices)
+  - [Discontinued Practices](#discontinued-practices)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->

--- a/_d/physical-pain.md
+++ b/_d/physical-pain.md
@@ -24,15 +24,14 @@ Physical pain has been a recurring teacher in my life. Each injury forced me to 
   - [Flexibility vs Mobility](#flexibility-vs-mobility)
   - [The Tendon Problem: No Pain Until It's Too Late](#the-tendon-problem-no-pain-until-its-too-late)
   - [Isometrics: How to Load a Tendon Without Moving the Joint](#isometrics-how-to-load-a-tendon-without-moving-the-joint)
+  - [Using the 5 whys to understand pain](#using-the-5-whys-to-understand-pain)
+  - [Rotation for stiffness](#rotation-for-stiffness)
   - [So why do we do massage, and stretch](#so-why-do-we-do-massage-and-stretch)
 - [Approaches to Managing Pain](#approaches-to-managing-pain)
   - [Physio Therapy](#physio-therapy)
   - [Massage, Stretch, Strengthen](#massage-stretch-strengthen)
   - [Self Release: Massage and Foam Roller, Tennis Ball](#self-release-massage-and-foam-roller-tennis-ball)
 - [Great Books For Across the Board Improvements](#great-books-for-across-the-board-improvements)
-- [Other Ideas to Classify](#other-ideas-to-classify)
-  - [Using the 5 whys to understand pain](#using-the-5-whys-to-understand-pain)
-  - [Rotation for stiffness](#rotation-for-stiffness)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
@@ -163,39 +162,6 @@ Roughly:
 
 Honesty check: the analgesia and the core principle (load drives tendon adaptation) are solid. The exact numbers — 30s vs 45s holds, the 6-8 hour spacing, the precise gelatin dose and timing — are emerging science, built partly on blood markers rather than long-term tendon outcomes. I treat the protocol as a reasonable default, not gospel.
 
-### So why do we do massage, and stretch
-
-Because while that tightness is a symptom, it's also limiting range of motion, and by loosening (even temporarily), we can be more effective at strengthening (again exactly the same as anxiety in mental pain).
-
-## Approaches to Managing Pain
-
-### Physio Therapy
-
-Physio therapy is a great model for improvement. You go, they coach you, and then you have to do the work.
-
-Critical because Practice makes permanent. See
-
-{%include summarize-page.html src="/new-skills"%}
-
-### Massage, Stretch, Strengthen
-
-Massage (aka Release) feels amazing, stretching good, and Strengthening Does Nothing.
-Inconveniently, massage only lasts 20 minutes, stretching a day or 2, but strengthening lasts forever.
-
-### Self Release: Massage and Foam Roller, Tennis Ball
-
-- Foam roller and Tennis ball are mostly self massage, which is mostly less effective than an expert nailing it.
-- Remember this is not fixing the problem, it's giving you a window to maximize your efficiency in fixing the problem.
-
-## Great Books For Across the Board Improvements
-
-- **Rebuilding Milo** - From the Squat University guy (Aaron Horschig). Focuses on diagnosing and fixing common lifting injuries (hip, knee, shoulder, back). Very practical with specific rehab protocols and movement assessments.
-- **Built from Broken** - Scott Hogan's science-based approach to joint health and injury recovery. Covers the "why" behind pain and provides structured programs for rebuilding strength after injury. Good on nutrition's role in tissue healing.
-
-{% include amazon.html asin="1628604220;1735728500" %}
-
-## Other Ideas to Classify
-
 ### Using the 5 whys to understand pain
 
 From our favorite COE process - the 5 whys:
@@ -228,3 +194,34 @@ Shoulder external rotation was really hard for me, and also interesting since th
 Lack of shoulder external rotation meant I had really weak wrists and put extra strain on my wrists.
 
 To have strength, you need stability or your body shuts off strength to avoid injury (hopefully). You have a few ways to get stiffness: one is stiffening random muscles, the other is external rotation.
+
+### So why do we do massage, and stretch
+
+Because while that tightness is a symptom, it's also limiting range of motion, and by loosening (even temporarily), we can be more effective at strengthening (again exactly the same as anxiety in mental pain).
+
+## Approaches to Managing Pain
+
+### Physio Therapy
+
+Physio therapy is a great model for improvement. You go, they coach you, and then you have to do the work.
+
+Critical because Practice makes permanent. See
+
+{%include summarize-page.html src="/new-skills"%}
+
+### Massage, Stretch, Strengthen
+
+Massage (aka Release) feels amazing, stretching feels good, and strengthening feels like it does nothing.
+Inconveniently, massage only lasts 20 minutes, stretching a day or 2, but strengthening lasts forever.
+
+### Self Release: Massage and Foam Roller, Tennis Ball
+
+- Foam roller and Tennis ball are mostly self massage, which is mostly less effective than an expert nailing it.
+- Remember this is not fixing the problem, it's giving you a window to maximize your efficiency in fixing the problem.
+
+## Great Books For Across the Board Improvements
+
+- **Rebuilding Milo** - From the Squat University guy (Aaron Horschig). Focuses on diagnosing and fixing common lifting injuries (hip, knee, shoulder, back). Very practical with specific rehab protocols and movement assessments.
+- **Built from Broken** - Scott Hogan's science-based approach to joint health and injury recovery. Covers the "why" behind pain and provides structured programs for rebuilding strength after injury. Good on nutrition's role in tissue healing.
+
+{% include amazon.html asin="1628604220;1735728500" %}

--- a/_d/terzepatide.md
+++ b/_d/terzepatide.md
@@ -1,14 +1,16 @@
 ---
 layout: post
-title: "Terzepatide: The magic weight loss shot"
+title: "Tirzepatide: The magic weight loss shot"
 tags:
   - health
   - weight-loss
 
 permalink: /terzepatide
+redirect_from:
+  - /tirzepatide
 ---
 
-"You know Igor, weight loss is a solved problem" - my bestie, texted me when I complained about my pants no longer fitting. Remember - Diet dominates weight, as weight is simple arithmetic -"calories in" minus "calories out". For me, will power dominates diet, and terzepatide dominates will power when stuffing things in my mouth. I started Terzepatide in February 2024, and so far it's been great.
+"You know Igor, weight loss is a solved problem" - my bestie, texted me when I complained about my pants no longer fitting. Remember - Diet dominates weight, as weight is simple arithmetic -"calories in" minus "calories out". For me, will power dominates diet, and tirzepatide dominates will power when stuffing things in my mouth. I started tirzepatide in February 2024, and so far it's been great.
 
 <!-- prettier-ignore-start -->
 
@@ -44,13 +46,13 @@ Interesting it's volume based, so if you wolf down calorie dense foods, you can 
 
 ## Differences from calorie restriction
 
-I've done a ton of dieting - the core approach is to get my calories down, get used to an empty stomach, and frequently eat small meals like popcorn or protein shakes - which satiates me. This **does not** work well with terzepatide.
+I've done a ton of dieting - the core approach is to get my calories down, get used to an empty stomach, and frequently eat small meals like popcorn or protein shakes - which satiates me. This **does not** work well with tirzepatide.
 
 I think the reason is that on the above dieting strategy you get used to a mostly empty belly, and even a bit full having some calories feels satiated.
 
-On terzepatide, you digest food more slowly. So you're better off eating a large meal of meat, and then your digestion is slowed down so you feel full for way longer.
+On tirzepatide, you digest food more slowly. So you're better off eating a large meal of meat, and then your digestion is slowed down so you feel full for way longer.
 
-I'll convert this to a graph, and all these numbers are made up:
+These numbers are made up, but they show the shape of it:
 
 - Fullness- How full you need to feel full
 - Normal meal - How full you need to feel full on a normal meal
@@ -60,7 +62,7 @@ I'll convert this to a graph, and all these numbers are made up:
 | ------------- | -------- | ----------- | -------------- |
 | Normal Eating | 100      | 70          | 30             |
 | Local Dieting | 50       | 20          | 30             |
-| Terzepatide   | 100      | 70          | 10             |
+| Tirzepatide   | 100      | 70          | 10             |
 
 ## Side effects
 
@@ -79,7 +81,7 @@ I'll convert this to a graph, and all these numbers are made up:
 
 ### Muscle loss
 
-This is a bit of a misnomer, as the same can happen when dieting hard. I think the mitigations are lots of protein, I"m probably doing 1g\*lbs/day, and exercise, I"m currently doing 6 days/week.
+This is a bit of a misnomer, as the same can happen when dieting hard. I think the mitigations are lots of protein (I'm probably doing 1g per lb of bodyweight per day) and exercise (I'm currently doing 6 days/week).
 
 ### Bryan Johnson's Tirzepatide Experiment Failure
 
@@ -89,7 +91,7 @@ For Johnson, this was an unacceptable trade-off. While GLP-1 drugs showed promis
 
 ## Traveling with it (or any med that needs a fridge)
 
-Terzepatide — like plenty of other meds — wants to stay cold. Three things make travel painless for me:
+Tirzepatide — like plenty of other meds — wants to stay cold. Three things make travel painless for me:
 
 1. **A TSA-approved travel cooler.** Holds cold for a full travel day, so the airport-to-Airbnb gap is covered:
 
@@ -105,9 +107,6 @@ Terzepatide — like plenty of other meds — wants to stay cold. Three things m
 
 I use [lifemd](http://www.lifemd.com), they give you a Dr to help you decide and check in on side effects, and then co-ordinate with a compounding pharmacy. Ends up about 500\$/month, which probably I save half of that on food.
 
-I think there is some shenanigans with compounding pharmacies and copyright and emergency use when shortages. So I'm not getting the brand name Zepbound (get the pun on the name), I'm getting a blend of Terzepatide and something else (some places did Vitamin D). I don't get the fancy dispenser, but need to inject myself (which Tori originally did, but decided I'm a grown up and can do it myself).
+I think there is some shenanigans with compounding pharmacies and copyright and emergency use when shortages. So I'm not getting the brand name Zepbound (get the pun on the name), I'm getting a blend of tirzepatide and something else (some places did Vitamin D). I don't get the fancy dispenser, but need to inject myself (which Tori originally did, but decided I'm a grown up and can do it myself).
 
 More details on [how it's done and the risks](https://www.drugs.com/medical-answers/you-tirzepatide-compounding-pharmacy-3575862/).
-
-- Ammon Stories of weight loss
-  - Fake pills

--- a/_posts/2017-10-07-physical-health.md
+++ b/_posts/2017-10-07-physical-health.md
@@ -83,19 +83,9 @@ For me, it's long enough to work up a sweat, but short enough to not eat up my d
 
 "Tony the trainer" taught me a great protocol I swear by it, and think I came close to it accidentally before.
 
-TL;DR: All that matters is training at 90% of your max HR. 15 minutes a day 3x a week and you're set. But good luck doing 15 minutes at 90% max HR. Break it down as follows. 5 min on, 5 off, 4 on, 4 off, ... 1 on, 1 off. You should get a curve as follows
+TL;DR: All that matters is training at 90% of your max HR. 15 minutes a day 3x a week and you're set. But good luck doing 15 minutes at 90% max HR. Break it down as follows: 5 min on, 5 off, 4 on, 4 off, ... 1 on, 1 off.
 
-TODO: Add heart graphs
-
-What's great about this protocol is it works at any fitness level. If all you can do is walk to get winded, walk till you hit the goal. If you can run, run. BUT, don't look at speed, look at heart rate.
-
-Other stuff:
-
-- How I got lucky to re-start it as started by running, but calf injury made this happen
-- Used to do infinite elliptical
-- Show impact on HRV and Resting Heart Rate
-- How quickly you need to scale up the intensity.
-- The goal is not "muscle strength", it's cardio strength, so back down when you hit your HR max, regardless of how tired you are.
+What's great about this protocol is it works at any fitness level. If all you can do is walk to get winded, walk till you hit the goal. If you can run, run. BUT, don't look at speed, look at heart rate. And remember the goal is cardio strength, not muscle strength - back down when you hit your max HR, regardless of how tired you are.
 
 #### My body part really hurts, what should I do?
 
@@ -125,9 +115,9 @@ In summary, trainers are worth it.
 
 {%include summarize-page.html src="/kettlebell" %}
 
-#### Where's my strength at in 2024
+#### Where's my strength at?
 
-My current strength routine includes:
+As of early 2024, my strength routine includes:
 
 - Kettlebell swings: 10x10 @ 32kg two-handed (achieved Nov '23, regressed after injury)
 - Turkish Get-Ups: 5x1 @ 32kg per side (achieved Jan '24, regressed after holiday break)
@@ -158,4 +148,5 @@ But a few points to add after you read the article:
 3. The "productivity advantage" for me is motivation starts strong when I get up and declines through the day, gone by 9 pm when I'm on the couch, binging YouTube with my beer and chips. By contrast, at 5 am I'm ready to do something useful, and no one is awake, and nothing is open to distract me.
 4. Sometimes my body goes a bit batty and I wake up early, that has me waking up at 3:30 am which is annoying, as by noon I'm pretty toast and have to fight to stay awake till 8 pm.
 5. Not gonna lie, I love the feeling of pride when I tell folks I get up crazy early.
-   ps. Being a nerd I use a bunch of [toys]({% post_url 2017-10-06-tech-health-toys %}) to help with my health.
+
+ps. Being a nerd I use a bunch of [toys]({% post_url 2017-10-06-tech-health-toys %}) to help with my health.


### PR DESCRIPTION
Minutes-effort fixes from the 2026-07-13 full-blog quality audit for the Health & body set. Tracked: blog-mpb.

## Per-post changes

- **/insomnia** — removed the stale `inprogress: true` flag (the playbook has been complete for years) and resolved the internal tension the audit flagged: the sleeping-pills bullet now says the pills are for falling asleep at my normal bedtime, not catching up, so it no longer contradicts the no-catchup rule.
- **/fit-in-my-head** (was `/d/2016-2-14-Health-In-The-Head`) — gave the orphan a real permalink with a redirect from the old date URL, removed the `inprogress` flag, and tightened the third paragraph by ~40% so it keeps the physical/emotional symmetry without the clause-for-clause echo.
- **/emotional-health** — added one line cross-linking to /fit-in-my-head so the post stops being invisible.
- **/back-pain** — replaced the generic "we"-voice health-site opener with a first-person one (stiff-back mornings, grounded in the /kettlebell post), and added a bridge sentence explaining why the /coe include belongs in the 5 Whys section.
- **/kettlebell** — added one sentence defining Timeless Simple (Pavel's Simple standard, untimed), folded the one-line KB Squats section into Goals, and regenerated the stale TOC (now includes Swing Analyzer App).
- **/physical-pain** — fixed the inverted aphorism to "strengthening feels like it does nothing" (the missing "feels like" was reversing the post's central point), promoted the 5-whys and external-rotation sections into Key Concepts, and deleted the "Other Ideas to Classify" inbox header. TOC regenerated.
- **/terzepatide** — fixed the drug-name spelling (Tirzepatide) in the title and everywhere in the body; the permalink is unchanged per the never-change-permalinks rule, with `/tirzepatide` added as a redirect so the correct spelling resolves. Also reworded the unfulfilled "I'll convert this to a graph" promise to own the table, fixed the smart-quote and `1g*lbs/day` typos, and deleted the trailing "Ammon Stories / Fake pills" scratch notes.
- **/physical-health** — deleted the "Other stuff" notes dump and the "TODO: Add heart graphs" line in the HIIT section (the one substantive bullet — cardio strength, back down at max HR — was folded into the surrounding prose), retitled "Where's my strength at in 2024" to the evergreen "Where's my strength at?" with the date moved into the body ("As of early 2024..."), and fixed the `ps.` line so it's no longer an indented continuation of list item 5.

## Needs Igor

- **/terzepatide** — the deleted scratch notes ("Ammon Stories of weight loss / Fake pills") hinted at a story only Igor knows; if it's worth telling, it needs his memory.
- **/physical-health** — the promised heart-rate graphs for the HIIT protocol were cut rather than added; adding real graphs needs Igor's data. The circular sleep-advice line the audit flagged ("get as much sleep as you need") was left alone since the audit recommendation didn't include it.

Text-level cleanup only, no layout changes, so no screenshots; back-links.json regenerates via the update-backlinks workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxH3FCWWxKnrpn7PKL3fPY
