### PR TITLE
Tier-4 quick fixes: Work & productivity

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -11,6 +11,7 @@ locale = "en-us"
 "BA" = "BA"  # Part of Asciinema ID
 "NAEuBAJhe9qdU" = "NAEuBAJhe9qdU"  # Asciinema ID  
 "mis-hire" = "mis-hire"  # Common term in hiring
+mis = "mis"  # Token of "mis-hire" (typos splits on the hyphen)
 "MoFo" = "MoFo"  # Slang term used intentionally
 "oter" = "oter"  # Part of YouTube ID 002oterS2Wg
 "vizualization" = "vizualization"  # In JS library

--- a/_d/2015-11-18-Outsourcing.md
+++ b/_d/2015-11-18-Outsourcing.md
@@ -2,7 +2,6 @@
 layout: post
 title: "On outsourcing"
 author: "Igor Dvorkin"
-inprogress: true
 comments: true
 permalink: /outsourcing
 redirect_from:
@@ -28,14 +27,12 @@ Time is my precious resource - I have a limited number of hours in my life, and 
 
 Thanks to the many outsourcing crowd sourcing tools, getting contractors is easier than ever. Below are the tools I use and the tasks I've outsourced.
 
-- [ODesk](http://www.ODesk.com) - Get a professional for a more elaborate project, often someone to build relationships with
-
-  - Editor for my featured [posts](http://localhost:4000/software%20as%20a%20service/the-recruiter-does-not-think-you-are-hot/)
+- [Upwork](https://www.upwork.com) (was ODesk when I wrote this) - Get a professional for a more elaborate project, often someone to build relationships with
+  - Editor for my featured [posts](/the-recruiter-does-not-think-you-are-hot)
   - Musician, to help me produce a [song](https://soundcloud.com/igor-dvorkin/two-wheels-full-of-grace).
   - Audio transcriber for my upcoming interview series.
 
 - [Task Rabbit](http://www.taskrabbit.com) - Get help for an in person task.
-
   - Gutter Cleaning
 
 - [Fiverr](http://www.Fiverr.com) - Get a person for a simple, cheap, often weird task.
@@ -49,11 +46,4 @@ Thanks to the many outsourcing crowd sourcing tools, getting contractors is easi
 
 - Accountant - to do taxes
 - Trades - Plumbing/Heating/Major Home Repair/Car Mechanic/Medical Professionals.
-
-### Things I want to start outsourcing.
-
-- Personal Trainer - Done- incredible idea!
-
-#### TBD - When to build relationships with contractors
-
-#### TBD - How to get better at outsourcing
+- Personal Trainer - this one sat on my "want to outsource" list for a while. Done, and an incredible idea!

--- a/_d/2016-2-15-Seth-Godin-Notes.md
+++ b/_d/2016-2-15-Seth-Godin-Notes.md
@@ -58,7 +58,7 @@ Sources:
 
 - People prefer selfies to signed books
 - Make experiences people want to tell their friends/families about.
-- Give people a story they can tell others [TBD:Link - why is noone referring my project]
+- Give people a story they can tell others - and remove the credibility risk, or they won't tell it ([why is no one referring my project](/why-is-no-one-referring))
 - Story/Context is how people connect.
 - Perfection blocks connection, as not accessible. Rough feels good, and accessible.
 - Enjoyment of amateur vs pro - there is tension that can be failure.

--- a/_d/ai-coder.md
+++ b/_d/ai-coder.md
@@ -691,7 +691,7 @@ Most of this is picked up from others (there are no unique thoughts), but here's
 
 - With coding so easy, might as well make a tool just for your use case.
   - [Explainers](/explainers) — interactive visualizations that let you _play_ with a concept instead of reading about it. AI makes them trivially easy to build
-  - [Hand writing daily journal workflow](/process-journal#journalling-workflow-in-2025)
+  - [Hand writing daily journal workflow](/process-journal#current-workflow)
   - A grab bag of randomness called y.py [upload clipboard to git, start a flow session, move windows around](https://github.com/idvorkin/settings/blob/db1ca0310d79c9db8b3cc7092cb14904a560eb6d/py/y.py?plain=1#L744)
 - Probably a pendulum swings from:
   - in the 90's every company needing own IT department

--- a/_d/ai-second-brain.md
+++ b/_d/ai-second-brain.md
@@ -26,6 +26,9 @@ Your brain is for thinking, not storage. That was the promise of the "second bra
   - [Debrief — Capture Insight While It's Fresh](#debrief--capture-insight-while-its-fresh)
   - [The Flywheel](#the-flywheel)
 - [Example Workflows](#example-workflows)
+  - [Reading an article](#reading-an-article)
+  - [Preparing for a meeting](#preparing-for-a-meeting)
+  - [Capturing daily notes](#capturing-daily-notes)
 - [I've Been Building This Without Calling It That](#ive-been-building-this-without-calling-it-that)
 - [The Organizational Second Brain](#the-organizational-second-brain)
 - [FAQ](#faq)
@@ -141,7 +144,7 @@ Traditional second brains failed because "organize" was a separate chore disconn
 I've been doing [stream of consciousness journaling](/process-journal) since 2011 — over a million words. The old problem: handwritten journals are great for thinking but impossible to search. Typed journals are searchable but less personal.
 
 1. **Available context:** I brain-dump thoughts on a Kindle Scribe every morning, primed by yesterday's TODOs and habit tracker
-2. **Automated capture:** The handwriting gets [transcribed to text](/process-journal#journalling-workflow-in-2025), TODOs get extracted to OmniFocus — all automated
+2. **Automated capture:** The handwriting gets [transcribed to text](/process-journal#current-workflow), TODOs get extracted to OmniFocus — all automated
 3. **Debrief (weekly):** [Larry](/larry) reads the week's journals, drafts a weekly report, scores 11 life domains with evidence from my own words, and catches patterns — "You've committed to restart meditation 5 times since November. What's different this time?"
 4. **Pre-brief (daily):** Next morning, AI has yesterday's journal as context. "You said you were avoiding the hard conversation with your manager. Did you have it?"
 

--- a/_d/blueprint.md
+++ b/_d/blueprint.md
@@ -12,24 +12,22 @@ So there's this guy who measures his nightly erections, doesn't go out into the 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
-- [Stuff i love](#stuff-i-love)
+- [Stuff I love](#stuff-i-love)
 - [Goofy stuff](#goofy-stuff)
-- [Sleep](#sleep)
 - [Don't Die - Voices in his head](#dont-die---voices-in-his-head)
 - [Who holds the reins, morning or evening Igor](#who-holds-the-reins-morning-or-evening-igor)
 - [Why not defer control to an algorithm?](#why-not-defer-control-to-an-algorithm)
 - [Attitude to others](#attitude-to-others)
-- [Changes he's made me consider](#changes-hes-made-me-consider)
 - [Changes he's made me implement](#changes-hes-made-me-implement)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
 
-## Stuff i love
+## Stuff I love
 
-- Sleep is sacred (note he was depressed for 10 years)
+- Sleep is sacred (note he was depressed for 10 years). How good a night's sleep you have sets the difficulty level of the next day - how could you not go all in on this?
 - Doesn't drink, because it messes with sleep. Mitigated by having wine for breakfast, but even that messed with his sleep so he stopped
-- "The you in the moment", can make terrible decisions and has no accountability. This begs the question, who gave them permission to run the ship and screw over others (note, this scales up to
+- "The you in the moment", can make terrible decisions and has no accountability. This begs the question, who gave them permission to run the ship and screw over others?
 - Move everything from the rider to shaping the path (What he calls blue prints)
 
 ## Goofy stuff
@@ -37,10 +35,6 @@ So there's this guy who measures his nightly erections, doesn't go out into the 
 - Doesn't go out in the sun during the day, bad for the skin
 - Measures everything he can including evening erections
 - (I can relate) Hates seeing grey hair, but also hates dying his hair (I took some stabs at [dying my beard](/ig66/663))
-
-## Sleep
-
-How good a night's sleep you have is really sets the difficulty level of the next day. How could you not go all in on this.
 
 ## Don't Die - Voices in his head
 
@@ -60,8 +54,6 @@ I also try to do this for my finances using zero index funds vs lottery tickets.
 
 He is like, I want to be an inspiration, don't feel you need to do what I do, just realize it can be done, and let it be an inspiration
 
-## Changes he's made me consider
-
 ## Changes he's made me implement
 
-- Re-enforce my importance of sleep.
+- Re-enforce the importance of sleep.

--- a/_d/bmu.md
+++ b/_d/bmu.md
@@ -14,29 +14,26 @@ tags:
 
 The business model canvas is a tool for understanding how a company makes money. This same model can be applied to a person's career. While [job hunting](/job-hunt-stress) this was helpful figuring out my [dream job](/dream-job). I suppose it should also prioritize my [work energy](/boss), and probably how to prioritize my [life energy](/eulogy). But that's to come.
 
+The filled-in canvas below is a snapshot from a past role (I last touched it in 2021). Read the specifics as a worked example of the method, not my current situation.
+
 {%include blob_image.html src="business-model-you-canvas.jpeg" %}
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
 - [The "you" global boxes:](#the-you-global-boxes)
-    - [Key Activities - What you do](#key-activities---what-you-do)
-    - [Key Resources - Who you are/What you have](#key-resources---who-you-arewhat-you-have)
-    - [Key Partners - Who helps you?](#key-partners---who-helps-you)
+  - [Key Activities - What you do](#key-activities---what-you-do)
+  - [Key Resources - Who you are/What you have](#key-resources---who-you-arewhat-you-have)
+  - [Key Partners - Who helps you?](#key-partners---who-helps-you)
 - [Per customer boxes:](#per-customer-boxes)
-    - [Value Provided - How you help:](#value-provided---how-you-help)
-    - [Channels - How they know you, how you deliver](#channels---how-they-know-you-how-you-deliver)
-    - [Customer Relationships - How do you interact?](#customer-relationships---how-do-you-interact)
+  - [Channels - How they know you, how you deliver](#channels---how-they-know-you-how-you-deliver)
+  - [Customer Relationships - How do you interact?](#customer-relationships---how-do-you-interact)
 - [Customer Segment Specific](#customer-segment-specific)
-- [The engineering team I support](#the-engineering-team-i-support)
-- [Product Manager](#product-manager)
-- [Boss](#boss)
-- [Grand Boss](#grand-boss)
-    - [Mentees](#mentees)
-- [Feeling Meetings Members](#feeling-meetings-members)
+  - [The engineering team I support](#the-engineering-team-i-support)
+  - [Product Manager](#product-manager)
 - [The balance sheet](#the-balance-sheet)
-    - [Revenue - What you get?](#revenue---what-you-get)
-    - [Costs - What you give up](#costs---what-you-give-up)
+  - [Revenue - What you get?](#revenue---what-you-get)
+  - [Costs - What you give up](#costs---what-you-give-up)
 - [More resources](#more-resources)
 
 <!-- vim-markdown-toc-end -->
@@ -108,8 +105,6 @@ See my [dream job](/dream-job)
 
 ## Per customer boxes:
 
-### Value Provided - How you help:
-
 ### Channels - How they know you, how you deliver
 
 More complex than it sounds, need to do this per customer segment:
@@ -128,7 +123,7 @@ More complex than it sounds, need to do this per customer segment:
 
 ## Customer Segment Specific
 
-## The engineering team I support
+### The engineering team I support
 
 **Value Provided**
 
@@ -140,15 +135,13 @@ More complex than it sounds, need to do this per customer segment:
 - Ensuring sufficient resources
 - Resolving critical issues
 
-**Channel** - tbd
-
 **Relationship**
 
 - Goal retention
 - Weekly 1:1s
 - Weekly group meeting
 
-## Product Manager
+### Product Manager
 
 **Value Provided**
 
@@ -160,21 +153,11 @@ More complex than it sounds, need to do this per customer segment:
   - Architecture and Process trade offs
 - Divide and conquer on influence through technical channels
 
-**Channel** - tbd
-
 **Relationship**
 
 - Goal retention
 - Weekly 1:1s
 - Weekly group meeting
-
-## Boss
-
-## Grand Boss
-
-### Mentees
-
-## Feeling Meetings Members
 
 ## The balance sheet
 

--- a/_d/hobby.md
+++ b/_d/hobby.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Why a Engineering Manager masquerades as a magician on the weekends"
+title: "Why an Engineering Manager masquerades as a magician on the weekends"
 permalink: /hobby
 redirect_from:
   - /hobbies
@@ -51,7 +51,7 @@ Performing music reinforces identity. You are a musician. If you're in a band yo
 
 You know why you need a hobby, and what makes a great one, now get out there and start looking for your ideal hobby. As you hunt for your hobbies a few ideas to help you out:
 
-- Chase you curiosity. That's where you'll find the motivation to elevate your talent, turning interest into competency.
+- Chase your curiosity. That's where you'll find the motivation to elevate your talent, turning interest into competency.
 - Remember the laws of new skills
 
 {%include summarize-page.html src="/new-skills"%}
@@ -66,7 +66,9 @@ For those unfamiliar with the terms, Autonomy, Mastery, Purpose (AMP) is Daniel 
 
 This gets into nomenclature. In my model, hobbies are things that make you happy while [habits](/habits) (the positive ones) make you healthy. Practicing your hobby can become a habit.
 
-**Should I have my hobby be my work?** I'd recommend strongly against it for two reasons. First, it's work so you'll need to prioritize what makes your customers happy over what makes you happy and second, because if works goes badly, you'll also lose your hobby, which defeats the purpose of having a hobby.
+#### Should I have my hobby be my work?
+
+I'd recommend strongly against it for two reasons. First, it's work so you'll need to prioritize what makes your customers happy over what makes you happy and second, because if work goes badly, you'll also lose your hobby, which defeats the purpose of having a hobby.
 
 #### What is your hobby?
 
@@ -74,6 +76,6 @@ My current hobby is [magic](/magic). All I need is a coin or a deck of cards and
 
 #### Did you find your hobby on the first try?
 
-No. One of my early hobbies was scuba diving. Going scuba diving takes a lot of gear and preparation. Even worse you need a dive buddy who has the matching gear, will, and schedule. Needless to say, my scuba gear has been gathering dust for a long while, and my wife keeps threatening to sell it. After scuba diving, I loved squash and fencing, both fantastic hobbies, but as I crossed into my late thirties, repetitive motion caused tendentious in my forearm, and I had to give them up.
+No. One of my early hobbies was scuba diving. Going scuba diving takes a lot of gear and preparation. Even worse you need a dive buddy who has the matching gear, will, and schedule. Needless to say, my scuba gear has been gathering dust for a long while, and my wife keeps threatening to sell it. After scuba diving, I loved squash and fencing, both fantastic hobbies, but as I crossed into my late thirties, repetitive motion caused tendinitis in my forearm, and I had to give them up.
 
 Next up was juggling, which for me is a fantastic hobby. Even though it meets all my criteria, it's not as accessible as magic and it's harder to form a connection juggling. For example, juggling clubs don't fit in my back pocket, and I get strange looks juggling at the bar, and don't get me started on security guards reaction to [flaming torches](https://ig66.blogspot.com/2014/08/accomplishment-unlocked-juggling-file.html). While juggling let me connect with folks, it's not an intimate connection and it's rarely remembered. By contrast with magic I can strike up a conversation, personalize the magic for the audience, and often give a souvenir which when I've formed my best connection, the audience will take home and cherish for years.

--- a/_d/how-igor-chops.md
+++ b/_d/how-igor-chops.md
@@ -406,7 +406,7 @@ I think there's a pendulum here:
 - 2000s: SaaS - rent the same software as everyone else
 - 2030s: Single dev does all the required tooling, personalized to their exact needs
 
-See more in my [hyper-personalization](/hyper-personal) post. Examples from my own life: [handwriting journal workflow](/process-journal#journalling-workflow-in-2025), [mortality software](/mortality-software), [all my pet projects](/pet-projects).
+See more in my [hyper-personalization](/hyper-personal) post. Examples from my own life: [handwriting journal workflow](/process-journal#current-workflow), [mortality software](/mortality-software), [all my pet projects](/pet-projects).
 
 ### The Joy Question
 

--- a/_d/pet-projects.md
+++ b/_d/pet-projects.md
@@ -6,7 +6,7 @@ redirect_from:
   - /tinkering
 ---
 
-As an engineer, I love to build bespoke tools that solve my unique problems exactly the way I want them solved. The bonus? This is lets me learn new technologies (did you know my blog has multiplayer support?). Sometimes I even make a tool so I have something to learn from. And with AI, this list of projects and explorations has exploded! Note to self, when I want to veg out and just feed my social media addiction I should do some vibe coding on all of these.
+As an engineer, I love to build bespoke tools that solve my unique problems exactly the way I want them solved. The bonus? This lets me learn new technologies (did you know my blog has multiplayer support?). Sometimes I even make a tool so I have something to learn from. And with AI, this list of projects and explorations has exploded! Note to self, when I want to veg out and just feed my social media addiction I should do some vibe coding on all of these.
 
 <!-- MAINTENANCE INSTRUCTIONS FOR CLAUDE
 
@@ -41,6 +41,21 @@ GitHub orgs to check:
 
 {% include alert.html content='[Here is a beautiful landing page for my pet projects](/static/pet-projects.html)' style="info" %}
 
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [Self Reflection](#self-reflection)
+- [Personal Productivity Tools](#personal-productivity-tools)
+- [CLI Tools](#cli-tools)
+- [Computer Vision & Motion](#computer-vision--motion)
+- [Dev Tools & Infrastructure](#dev-tools--infrastructure)
+- [VIM & Editor Tools](#vim--editor-tools)
+- [Explainers](#explainers)
+- [Fun & Experiments](#fun--experiments)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
 ## Self Reflection
 
 | Project                                                                        | Description                                                                                                                                      |
@@ -57,13 +72,13 @@ GitHub orgs to check:
 | [Breathing Shapes](https://igor-breathe.surge.sh/)                             | Visual breathing exercise guide with animated shapes. [<i class="fa fa-github"></i>](https://github.com/idvorkin/igor-breathe)                                                                             |
 | [Context Grabber](https://github.com/idvorkin/context-grabber)                 | iOS app that grabs HealthKit & location data as JSON for [Larry](/larry). Expo/React Native, 7-day charts, share sheet export. [<i class="fa fa-github"></i>](https://github.com/idvorkin/context-grabber) |
 | [Humane Tracker](https://humane-tracker.surge.sh/)                             | Habit tracking across 5 wellness categories. Firebase-based with weekly views. [<i class="fa fa-github"></i>](https://github.com/idvorkin/humane-tracker-1)                                                |
-| [Gym Timer](https://idvorkin.github.io/igor-timer/)                            | Interval training timer PWA with presets, work/rest phases, and wake lock. [<i class="fa fa-github"></i>](https://github.com/idvorkin/igor-timer)                                                          |
-| [Tax Calculator](https://idvorkin.github.io/tax-calculator/)                   | Interactive tax bracket visualizer. [<i class="fa fa-github"></i>](https://github.com/idvorkin/tax-calculator)                                                                                             |
+| [Gym Timer](https://github.com/idvorkin/igor-timer)                            | Interval training timer PWA with presets, work/rest phases, and wake lock.                                                                                                                                 |
+| [Tax Calculator](https://github.com/idvorkin/tax-calculator)                   | Interactive tax bracket visualizer.                                                                                                                                                                        |
 | [Weight Analysis](https://weight-analysis.surge.sh/)                           | Jupyter notebook analyzing Apple Health weight data. Box plots, time series, interactive visualizations. [<i class="fa fa-github"></i>](https://github.com/idvorkin/jupyter)                               |
 | [OmniFocus CLI](https://github.com/idvorkin/omnifocus_cli)                     | Command-line interface for OmniFocus task management                                                                                                                                                       |
-| [MathFlash](https://idvorkin.github.io/mathflash/)                             | Math flashcard trainer for kids. [<i class="fa fa-github"></i>](https://github.com/idvorkin/mathflash)                                                                                                     |
-| [World Happiness Report](https://idvorkin.github.io/world-happiness-report/)   | Interactive data visualization of global happiness data. [<i class="fa fa-github"></i>](https://github.com/idvorkin/world-happiness-report)                                                                |
-| [Donut Profit Calculator](https://idvorkin.github.io/donut-profit-calculator/) | Calculate donut shop profitability. [<i class="fa fa-github"></i>](https://github.com/idvorkin/donut-profit-calculator)                                                                                    |
+| [MathFlash](https://github.com/idvorkin/mathflash)                             | Math flashcard trainer for kids.                                                                                                                                                                           |
+| [World Happiness Report](https://github.com/idvorkin/world-happiness-report)   | Interactive data visualization of global happiness data.                                                                                                                                                   |
+| [Donut Profit Calculator](https://github.com/idvorkin/donut-profit-calculator) | Calculate donut shop profitability.                                                                                                                                                                        |
 
 ## CLI Tools
 
@@ -107,7 +122,7 @@ GitHub orgs to check:
 | [Dotfiles](https://github.com/idvorkin/settings)                                       | VIM, TMUX, and shell configuration                      |
 | [Tech Diary](https://github.com/idvorkin/techdiary)                                    | Technical notes and learnings                           |
 
-## [Explainers](/explainers)
+## Explainers
 
 Interactive experiences that let you _do_ the thing, not just read about it — an antidote to [cognitive debt](/ai-native-vocab#cognitive-debt). See the [full explainers page](/explainers) for great examples, the AI workflow, and why this matters.
 

--- a/_d/process-journal.md
+++ b/_d/process-journal.md
@@ -16,7 +16,7 @@ I've been doing [daily stream of consciousness journaling](/emotional-health#dai
 <!-- vim-markdown-toc-start -->
 
 - [Handwriting vs Typing](#handwriting-vs-typing)
-- [Journalling Workflow in 2025](#journalling-workflow-in-2025)
+- [Current Workflow](#current-workflow)
 - [Journal Structure](#journal-structure)
 - [The Prompts at the Bottom](#the-prompts-at-the-bottom)
 - [Appendix: The Evolution of How I Journal](#appendix-the-evolution-of-how-i-journal)
@@ -32,7 +32,7 @@ AI transcription ended the tradeoff. I write by hand on a Kindle Scribe, then le
 
 ![Me writing in my journal](https://raw.githubusercontent.com/idvorkin/ipaste/main/20250302_191054.webp)
 
-## Journalling Workflow in 2025
+## Current Workflow
 
 The old version of this was fiddly. Every morning I created a fresh notebook on the Scribe, named it with the date, wrote, then emailed it to myself so a script could grab the PDF. A new notebook a day meant a long scroll of loose files with no easy way to flip back to last Tuesday.
 
@@ -106,4 +106,4 @@ The current setup is the third act. I'm keeping the earlier ones here for the re
 
 It worked, but a fresh notebook every day meant a long scroll of loose files and no easy way to flip back to last Tuesday. That's the itch the template scratched.
 
-**The hyperlinked template (2026-now).** One navigable PDF per quarter, synced through Google Drive - the [current workflow](#journalling-workflow-in-2025) above.
+**The hyperlinked template (2026-now).** One navigable PDF per quarter, synced through Google Drive - the [current workflow](#current-workflow) above.

--- a/_d/productive2.md
+++ b/_d/productive2.md
@@ -6,27 +6,24 @@ redirect_from:
   - /productivity
 ---
 
-At the core of balance, energy, wlb, habits is being productive.
+At the core of balance, energy, work-life balance, and habits is being productive. This page is my hub for productivity - the concepts that fuel it, and the kryptonite that kills it. Most of the ideas are big enough to get their own posts, so treat this as a map with links.
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
 - [Concepts](#concepts)
-    - [The fuel of productivity, is energy.](#the-fuel-of-productivity-is-energy)
-    - [Match task to energy](#match-task-to-energy)
-    - [Stay balanced](#stay-balanced)
-    - [Shape the path, leverage habits](#shape-the-path-leverage-habits)
-    - [Drip, Drip, Drip - it adds up](#drip-drip-drip---it-adds-up)
-    - [Motivation](#motivation)
-    - [Realistic Expectations](#realistic-expectations)
-    - [Flow](#flow)
+  - [The fuel of productivity, is energy.](#the-fuel-of-productivity-is-energy)
+  - [Match task to energy](#match-task-to-energy)
+  - [Stay balanced](#stay-balanced)
+  - [Shape the path, leverage habits](#shape-the-path-leverage-habits)
+  - [Motivation](#motivation)
 - [Related Positive notes](#related-positive-notes)
 - [Productivity's Kryptonite](#productivitys-kryptonite)
-    - [The Resistance](#the-resistance)
-    - [Anxiety/Fear](#anxietyfear)
-    - [Addictions](#addictions)
-    - [Procrastination](#procrastination)
-    - [Sayings](#sayings)
+  - [The Resistance](#the-resistance)
+  - [Anxiety/Fear](#anxietyfear)
+  - [Addictions](#addictions)
+  - [Procrastination](#procrastination)
+  - [Sayings](#sayings)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
@@ -49,19 +46,13 @@ No point spending "my high energy/willpower time" on a low energy activity. It's
 
 {%include summarize-page.html src="/switch" %}
 
-### Drip, Drip, Drip - it adds up
-
 ### Motivation
 
 [Momentum is emotional gravity](/energy#momentum-is-emotional-gravity). The feeling of shipping, completing, moving forward—it compounds. When you're making progress, everything feels lighter. When you're stuck, everything feels heavier than it is. Forward motion creates its own fuel.
 
-### Realistic Expectations
-
-### Flow
-
 ## Related Positive notes
 
-- [Getting things done](/gty) - A system for productivity
+- [Getting things done](/gtd) - A system for productivity
 - [First things first](/7h-c2)
 - [Habits](/habits)
 

--- a/_posts/2015-3-13-why-is-no-one-referring.md
+++ b/_posts/2015-3-13-why-is-no-one-referring.md
@@ -22,4 +22,8 @@ A. The work of doing the referral
 B. The message to give to the person to be referred
 C. The risk to the credibility of the person providing the referral.
 
-And in case you're confused, the order in which to tackle these problems is C, B, A. Future posts will talk about how to minimize credibility risk.
+And in case you're confused, the order in which to tackle these problems is C, B, A. So how do you reduce the credibility risk?
+
+- Let the customer see results first - they should be vouching for something they've watched work.
+- Make the referral revocable - a low-stakes "take a look" beats a "you should buy this".
+- Guarantee the experience - if the referral goes badly, make it your name on the line, not theirs.

--- a/_posts/2016-11-26-interviewsarehard.markdown
+++ b/_posts/2016-11-26-interviewsarehard.markdown
@@ -45,4 +45,4 @@ Interviews are especially expensive as you need:
 - 8 hours for the actual interview.
 - Emotional processing after the interview
 
-Once you have a few offers rolling in, then there's the energy required to make one of the biggest decisions in your life.
+Once you have a few offers rolling in, then there's the energy required to make one of the biggest decisions in your life. Just don't make it because [the recruiter is hot](/the-recruiter-does-not-think-you-are-hot).

--- a/_posts/2017-02-17-job-hunt-stress.md
+++ b/_posts/2017-02-17-job-hunt-stress.md
@@ -133,6 +133,7 @@ After your have all your offers:
 - Think deeply about your [dream job](/dream-job). You won't be able to check all the boxes, but know your criteria to make great decisions.
 - For apples to apples compensation comparisons, look at [Total compensation](/comp)
 - Use the [decisive](/decide) to help you decide.
+- Whatever you do, don't pick a job because [the recruiter is hot](/the-recruiter-does-not-think-you-are-hot). I learned that one the hard way.
 
 During your day job - your lowest priority
 

--- a/_posts/2020-01-01-the-recruiter-does-not-think-you-are-hot.md
+++ b/_posts/2020-01-01-the-recruiter-does-not-think-you-are-hot.md
@@ -18,7 +18,7 @@ My EbolaSoft interview was at 9am and it started off on the wrong foot. The inte
 That night, with a job offers from EbolaSoft and HappySoft in my left hand, an IPA in my right hand, and Biff, my college roommate, sitting across from me, I worked through the details. “Sure the job might suck, but Rene is hot, and man her smile... Look if the job sucks, I’ll work less and spend all my time seeing the city with my favorite recruiter”. Biff, knowing better than to argue after I’d made up my mind, just paid for our beers and left.
 The next morning, I signed the job offer with Rene’s company.
 
-I started work for EbolaSoft in September, in the middle of a long death march. Too busy trying to get his feature out the door, my new boss hadn't spent any time thinking about what I’d be working, and he certainly didn't have the time to talk to me about what I should be working on. Worst of all, even though I was always hanging around recruiting I never saw Rene’s smile again.
+I started work for EbolaSoft in September, in the middle of a long death march. Too busy trying to get his feature out the door, my new boss hadn't spent any time thinking about what I’d be working on, and he certainly didn't have the time to talk to me about what I should be working on. Worst of all, even though I was always hanging around recruiting I never saw Rene’s smile again.
 
 Moral of the story 1: Do not take a job because your recruiter is hot, I don’t care how much she smiles at you.
 

--- a/_posts/2020-01-04-sustainable-work.md
+++ b/_posts/2020-01-04-sustainable-work.md
@@ -18,6 +18,8 @@ I don't want to die knowing I spent too much time at work and I bet you don't ei
 
 _This is a re-post of my talk on [LinkedIn](http://bit.ly/igor-wlb-manifesto)_
 
+_I wrote this in early 2020, before remote work went mainstream. Read the mechanics (Chime, video rooms, monthly remote days) as a snapshot of that era - the principles still hold._
+
 ### How do I model work-life balance?
 
 Organizations reflect their leaders, and I strive to model work-life balance.
@@ -36,7 +38,7 @@ Organizations reflect their leaders, and I strive to model work-life balance.
 
 Work-life balance requires organizational mechanisms and care, here are some of ours.
 
-**Off the books paid time off** To encourage people to take care of themselves, we do payed time off, off the books. Some people take advantage of this naturally, but others require encouragement. For example, this year July 4th was a Wednesday, so I removed two days of capacity from everyone's sprint and told them to be 'sick' either Monday/Tuesday or Thursday/Friday. As another example, when folks do an internal transfer into my team, I encourage them to take a few weeks off to refresh and reset.
+**Off the books paid time off** To encourage people to take care of themselves, we do paid time off, off the books. Some people take advantage of this naturally, but others require encouragement. For example, this year July 4th was a Wednesday, so I removed two days of capacity from everyone's sprint and told them to be 'sick' either Monday/Tuesday or Thursday/Friday. As another example, when folks do an internal transfer into my team, I encourage them to take a few weeks off to refresh and reset.
 
 **Realistic expectations for work deliverables** To enjoy your time off work, you need to be free of anxiety. Because anxiety is the difference between expectations and reality my top priority is making sure everyone is thinking realistically. This is a huge topic, so I'd only skim the surface in a single dimension - unrealistic thoughts people have in their mind.
 
@@ -50,7 +52,7 @@ When I spot this happening, I jump in to remind the person that I know they're g
 
 **Flexible hours from wherever we want to be** Everyone achieves work-life balance differently. So, the team does everything we can think of to make it easier to watch your daughter's soccer game, get your car to the mechanic or go for an afternoon jog. For example, all our meetings are between 10 and 4, we use group messenger (Slack/Chime) heavily, we have meetings in rooms with video conferencing, and we have high-quality microphones for ad-hoc conversations like stand up. I work remotely at least once a month, so if the experience sucks, I prod the team to fix it.
 
-**Making work like having a blast with your friends** Having you look forward to coming to work is a top priority for me, and I'll have several posts on the topic. The first post, making memorable moments at work is in progress.
+**Making work like having a blast with your friends** Having you look forward to coming to work is a top priority for me. I wrote about one way to do this in [moments at work](/moments-at-work).
 
 **Treating you like the human you are** I'm deeply offended when managers think developers are fungible resources assessed as the sum of their deliverables. I fundamentally believe developers are people first and need to be treated as such.
 
@@ -82,11 +84,7 @@ While we had a great short-term solution, my son wasn't becoming any less demand
 
 ### Tell me more
 
-In future posts, I'll describe how leaders can build a culture of work-life balance into organizations that haven't embraced it yet.
-
-I'm always looking for folks passionate about software engineering leadership and management, so reach out for virtual coffee if you share my passion!
-
-I'm hiring, so if you're a principal developer, senior developer or SDE-II reach out.
+I'm always looking for folks passionate about software engineering leadership and management, so reach out for a virtual coffee if you share my passion!
 
 ### FAQ
 
@@ -100,7 +98,7 @@ I'm hiring, so if you're a principal developer, senior developer or SDE-II reach
 
 **Sounds like I'm working less, how will this impact my career/bonus?** If someone works as effectively as you for 60 hours a week, when you're working 40 hours a week, they'll get ahead. However, what I often see is the folks working 60 hours, are less effective with their time, and often burn out.
 
-**What happens when the larger organization doesn't value work-life balance?** I'll go into this in detail in my blog post on bringing work life balance into an organizational. In short, in some organizations, a significant fraction of people have no life, and it's literally going to cost you to have one yourself. If that's not your cup of tea, then that's not the organization for you.
+**What happens when the larger organization doesn't value work-life balance?** I'll go into this in detail in my blog post on bringing work-life balance into an organization. In short, in some organizations, a significant fraction of people have no life, and it's literally going to cost you to have one yourself. If that's not your cup of tea, then that's not the organization for you.
 
 **Did you always do this?** No, when I was young and single, I wanted to build my tech muscles as fast as I could and often worked 50-60 hours a week. When I was employee number 50 in Azure, the entire team worked 60+ hours a week, and it was one of the most fun times of my career.
 


### PR DESCRIPTION
Minutes-effort fixes from the 2026-07-13 full-blog quality audit, Work & productivity set. Tracked: blog-2ls.

## Per-post changes

- **/outsourcing** — fixed the localhost URL shipped in production (now `/the-recruiter-does-not-think-you-are-hot`), updated ODesk to Upwork, deleted both empty "TBD" headers, moved the done Personal Trainer line from "want to start outsourcing" into the outsourced list, and dropped the decade-old `inprogress: true` flag.
- **/bmy** — stripped every empty heading (Boss, Grand Boss, Mentees, Feeling Meetings Members, the empty Value Provided box) and both "Channel - tbd" lines, nested the engineering-team and PM segments under "Customer Segment Specific" as H3s, and added a framing line that the filled-in canvas is a snapshot from a past role (last touched 2021, per git history) so the Orca-Pass-era specifics read as a worked example.
- **/productive** — fixed the wrong `/gty` (Getting to Yes) link to `/gtd` (Getting Things Done), deleted the three empty heading stubs (Drip Drip Drip, Realistic Expectations, Flow), and expanded the clipped one-line opener (with unexplained "wlb") into a real 3-sentence paragraph explaining the hub.
- **/why-is-no-one-referring** — replaced the 11-year-old "future posts will talk about how to minimize credibility risk" promise with the three concrete bullets the audit prescribed (results first, revocable referral, guarantee the experience). De-orphaned it by resolving an existing `[TBD:Link]` placeholder in the Seth Godin notes that already pointed at this exact post.
- **/the-recruiter-does-not-think-you-are-hot** — fixed the missing "on" ("what I'd be working on"), and cross-linked it from /job-hunt-stress (offers section) and /interviewsarehard (closing line) so the featured post is no longer an orphan.
- **/sustainable-work** — deleted the 2020 hiring CTA, linked the "in progress" moments-at-work promise to the post that actually exists (`/moments-at-work`), removed the never-delivered "future posts" culture promise, fixed the payed/organizational/virtual-coffee typos, and added a one-line pre-remote-era note so the Chime/video-room mechanics read as a dated snapshot.
- **/blueprint** — resolved the sentence abandoned mid-parenthetical ("(note, this scales up to"), capitalized "Stuff i love", merged the redundant Sleep section into the sleep bullet it restated (also fixing "is really sets"), deleted the completely empty "Changes he's made me consider" section, and unawkwarded the implement bullet.
- **/hobby** — title grammar fix ("Why a" → "Why an" Engineering Manager), fixed "Chase you curiosity", "tendentious" → "tendinitis", "if works goes badly" → "if work goes badly", and promoted the bolded FAQ question to an H4 like its siblings.
- **/process-journal** — renamed "Journalling Workflow in 2025" (which the appendix itself dated to 2026) to "Current Workflow" so it stops aging, killing the Journalling/journaling spelling inconsistency with it; updated the in-page anchor plus the three inbound deep links (ai-coder, ai-second-brain, how-igor-chops).
- **/pet-projects** — fixed the "This is lets me" typo in the excerpt-bearing opener, added the TOC the eight-section catalog was missing, and ran the link-check pass the maintenance comment asks for: 5 of the live URLs are dead (GitHub Pages disabled on igor-timer, tax-calculator, mathflash, world-happiness-report, donut-profit-calculator — verified via `gh api ... has_pages: false`), so those project names now point at their repos instead of 404s. All other live links returned 200.
- **.typos.toml** — the existing `mis-hire` exception never worked because typos tokenizes on the hyphen; allowed the `mis` token so the pre-existing "mis-hire" prose in /job-hunt-stress passes the hook.

## Needs Igor

- **/outsourcing** — the audit wanted a sentence on *why* the personal trainer was "incredible". That's your memory, not mine to invent — the line moved mechanically, add the why if you want it.
- **/blueprint** — the audit asked for 3-4 real bullets under "Changes he's made me consider/implement". Those are your actual life changes; I deleted the empty consider section (audit-sanctioned) and kept the single implement bullet. Also, the broken parenthetical originally trailed off with "this scales up to" — I ended the sentence cleanly rather than guess what it scaled up to; restore the thought if you remember it.
- **/pet-projects** — if you'd rather the five delisted projects be live again, re-enable GitHub Pages on those repos and the live links can come back.

Text-level cleanup only, no layout changes, so no screenshots; back-links.json regenerates via the update-backlinks workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxH3FCWWxKnrpn7PKL3fPY
