### PR TITLE
Tier-4 quick fixes: Tech notes

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -2,6 +2,9 @@
 # Language preferences
 locale = "en-us"
 
+# Ignore Amazon ASIN codes in amazon.html includes (random letter pairs get flagged)
+extend-ignore-re = ['asin="[A-Za-z0-9;]+"']
+
 [default.extend-words]
 # Common tech/domain-specific terms that might be flagged
 "iterm" = "iterm"  # iTerm is a terminal application for Mac

--- a/_d/2017-09-10-software-rot.md
+++ b/_d/2017-09-10-software-rot.md
@@ -10,6 +10,8 @@ After a year of not working on one of my hobby software projects, I decided it'd
 
 Much of the tool chain was now using "prehistoric" versions. Upgrading should have been simple, but of course each "current" version had its own backwards compatibility blockers, quirks, and incompatibilities with the other parts of the tool chain. Of course, when you look at the [change](https://github.com/idvorkin/onom/commit/b105f5079737806a88b970f1d5c8754e30409352) it seems easy, but it's expensive to find which changes to be made.
 
-Now that project was building, it was time to make my few lines of changes. When I went to implement the code something wasn't right. I was digging around and couldn't find quite the right way to implement the feature. After more code spelunking, I realized I'd already made the change I wanted a year ago.
+Now that the project was building, it was time to make my few lines of changes. When I went to implement the code something wasn't right. I was digging around and couldn't find quite the right way to implement the feature. After more code spelunking, I realized I'd already made the change I wanted a year ago.
 
 Oh well, at least I'll be ready to make the next change.
+
+**Update 2026**: AI coding agents have flipped the economics of this story. The rot still happens, but now an agent grinds through the toolchain upgrades while I do something else. The repair went from a lost weekend to nearly free.

--- a/_d/how-igor-chops.md
+++ b/_d/how-igor-chops.md
@@ -88,9 +88,9 @@ I mumble to Claude on my couch while my family wonders who I'm talking to. I vib
 
 ### The Most Expensive I Can Get
 
-Currently I'm using Claude Opus 4.5 on the $200/month plan.
+Currently I'm using Claude Opus 4.5 on the \$200/month plan.
 
-On one hand you might think I'm crazy spending $2,400 a year. On the other hand, imagine having brilliant collaborators who force multiply everything you do, train you up, and basically give you a PhD in whatever you're working on.
+On one hand you might think I'm crazy spending \$2,400 a year. On the other hand, imagine having brilliant collaborators who force multiply everything you do, train you up, and basically give you a PhD in whatever you're working on.
 
 ### Why Not Codex, Gemini, etc.?
 
@@ -164,7 +164,7 @@ This diagram perfectly captures the evolution I've lived through. Let me break d
 
 **Note to self: Review this section regularly. These principles are easy to forget when you're heads-down in a session.**
 
-- **Rent the most expensive brain you can**: Spend tokens liberally. Don't be cheap with AI usage - the $200/month is nothing compared to the force multiplication you get
+- **Rent the most expensive brain you can**: Spend tokens liberally. Don't be cheap with AI usage - the \$200/month is nothing compared to the force multiplication you get
 - **Maximize time between interventions**: Like Tesla's self-driving metrics, the goal is reducing how often you need to take over. Every friction point kills flow
   - **Don't be the intern doing grudge work**: If AI writes code and you manually test it, you've got the roles backwards. Make AI the tester too - be the architect, not the QA intern
   - **Tests as specification**: The clearer the tests, the less I need to intervene
@@ -172,6 +172,7 @@ This diagram perfectly captures the evolution I've lived through. Let me break d
   - **Conventions compound**: Time spent on CLAUDE.md pays off across every session
 - **Isolation is freedom**: YOLO containers let Claude run autonomously without risk to my real environment
 - **"Don't glaze me" changes everything**: Claude is far more useful when it pushes back on bad ideas
+- **Rot repair is nearly free**: Reviving a stale project used to mean a weekend of toolchain archaeology ([Software Rot](/d/2017-09-10-software-rot)); now an agent grinds through the upgrades for me
 
 ### What I'm Still Figuring Out
 

--- a/_d/snjb_.md
+++ b/_d/snjb_.md
@@ -5,7 +5,10 @@ permalink: /snjb
 notitle: true
 ---
 
-Zach built Steve's Night Jungle and Bar in twee, here's our [port to python](https://github.com/idvorkin/idvorkin.github.io/blob/master/pysrc/snjb.py)!
+My son Zach wrote Steve's Night Jungle and Bar, his own choose-your-own-adventure game, in [Twine](https://twinery.org)'s twee format. I loved it so much I [ported it to Python](https://github.com/idvorkin/idvorkin.github.io/blob/master/pysrc/snjb.py) so it could live here on the blog, running in your browser via [Brython](https://brython.info). Play it below.
+
+<script src="https://cdn.jsdelivr.net/npm/brython@3/brython.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/brython@3/brython_stdlib.js"></script>
 
 <script>
     window.addEventListener('load', (_) => brython() )

--- a/_d/vlc_player.md
+++ b/_d/vlc_player.md
@@ -11,9 +11,7 @@ redirect_from:
 
 # IINA Player Keyboard Shortcuts
 
-We watch a tonne of videos now, so it's good to be efficient with them. Go learn these keyboard shortcuts, you'll be happier. Not only will they save you time, but they'll make your viewing experience much more fluid and enjoyable.
-
-**Note: We have switched to IINA Player from VLC. This reference documents IINA's keyboard shortcuts.**
+I watch a tonne of videos, so it's worth being efficient with them. Learn these keyboard shortcuts, you'll be happier. I switched from VLC to IINA a while back, so this reference is for IINA.
 
 ## Key Notation Reference
 
@@ -25,134 +23,29 @@ We watch a tonne of videos now, so it's good to be efficient with them. Go learn
 | S        | Shift (⇧)            |
 | BS       | Backspace/Delete (⌫) |
 
-## Playback Controls
+## The Shortcuts I Actually Use
 
-- Space - Cycle Pause
-- ⌫ - Stop
-- → - Seek forward 5s
-- ← - Seek backward 5s
-- → - Next frame
-- ← - Previous frame
-- A-← - Seek to previous subtitle
-- A-→ - Seek to next subtitle
-
-## Playback Speed
-
-- M-[ - Multiply Speed by 0.5x
-- M-] - Multiply Speed by 2.0x
-- M-A-[ - Multiply Speed by 0.9091x
-- M-A-] - Multiply Speed by 1.1x
-- M-\ - Set Speed to 1.0
-
-## Chapter Navigation
-
-- A-S-C - Chapter panel
-- M-> - Chapter +1
-- M-< - Chapter -1
-
-## Media Controls
-
+- Space - Pause/Play
+- ← / → - Seek backward/forward 5s
+- A-← / A-→ - Seek to previous/next subtitle
+- , / . - Previous/next frame
+- M-[ / M-] - Halve/double playback speed
+- M-\ - Reset speed to 1.0
+- M-< / M-> - Previous/next chapter
+- M-← / M-→ - Previous/next media
+- ↑ / ↓ - Volume +5/-5
+- M-/ - Mute
+- C-S-F - Fullscreen
+- C-S-P - Picture-in-Picture
 - S-S - Screenshot
-- S-L - A-B loop
-- A-S-L - Cycle loop in ()
-- A-S-P - Playlist panel
-- M-→ - Next media
-- M-← - Previous media
-
-## Window Size
-
-- M-0 - Set Window scale to 0.5
-- M-1 - Set Window scale to 1
-- M-2 - Set Window scale to 2
-- M-3 - Fit to Screen
-- M-- - Smaller Window
-- M-= - Bigger Window
-
-## Display Controls
-
-- C-S-P - Toggle Picture-in-Picture
-- C-S-F - Cycle Fullscreen
-- C-S-T - Cycle Float on top
-- M-S-M - Toggle Music Mode
-
-## Volume Controls
-
-- ↑ - Volume +5
-- ↓ - Volume -5
-- A-↑ - Volume +1
-- A-↓ - Volume -1
-- M-/ - Cycle Mute
-
-## Audio Delay
-
-- ) - Audio delay +0.5
-- ( - Audio delay -0.5
-- } - Audio delay +0.1
-- { - Audio delay -0.1
-- : - Set Audio delay to 0
-
-## Subtitle Controls
-
 - A-S-D - Find online subtitles
-- A-Z - Subtitle delay -0.5
-- A-X - Subtitle delay +0.5
-- A-S-Z - Subtitle delay -0.1
-- A-S-X - Subtitle delay +0.1
-- A-C - Set Subtitle delay to 0
-- ↩ - Set Fullscreen to No
-- ⇥ - Set Fullscreen to Yes
-- Q - Quit
-
-## Additional Controls
-
-- P - Cycle Pause
-- . - Next frame
-- , - Previous frame
-- M - Cycle Mute
-- A-S-F - Seek forward 600s
-- A-S-B - Seek backward 600s
-- A-O - Subtitle scale +0.1
-- A-F - Subtitle scale -0.1
-- R - Subtitle position -1
-- A-R - Subtitle position +1
-- T - Subtitle position +1
-- F - Cycle Fullscreen
-- A-E - Cycle edition
-
-## Remote-Style Controls
-
-- POWER - Quit
-- PLAY - Cycle Pause
-- PAUSE - Cycle Pause
-- PLAYPAUSE - Cycle Pause
-- STOP - Quit
-- FORWARD - Seek forward 60s
-- REWIND - Seek backward 60s
-- NEXT - Next media
-- PREV - Previous media
-- VOLUME_UP - Volume +2
-- VOLUME_DOWN - Volume -2
-- MUTE - Cycle Mute
-- CLOSE_WIN - Quit
-
-## Panel Controls
-
-- A-S-V - Video panel
-- A-S-A - Audio panel
-- A-S-S - Subtitle panel
-- C-S-V - Cycle Video track
-- C-S-S - Cycle Subtitle track
-- C-S-A - Cycle Audio track
-
-_Note: These keybindings are for IINA Player. Key combinations may vary depending on your OS and IINA version._ 🎥
+- A-Z / A-X - Subtitle delay -0.5s/+0.5s
 
 # MPV
 
-mpv is a cli tool that lets you using cli with keybindings, i even added custom chapters commands
+mpv is a CLI player driven by keybindings, and I added custom chapter commands myself in my [mpv config](https://github.com/idvorkin/settings/blob/0fc587aa33e5a92bcbca409e71447bc831fa7e3d/config/mpv/input.conf?plain=1#l8):
 
-- c - show chapter list - i added myself [mpv config](https://github.com/idvorkin/settings/blob/0fc587aa33e5a92bcbca409e71447bc831fa7e3d/config/mpv/input.conf?plain=1#l8)
+- c - show chapter list
 - !/@ - next/prev chapter
 - [ / ] - decrease/increase playback speed
 - { / } - halve/double playback speed
-
-_[Copied from my GitHub techdiary](https://github.com/idvorkin/techdiary/blob/master/vlc_player.md)_

--- a/_d/where-have-all-the-bugs-gone.md
+++ b/_d/where-have-all-the-bugs-gone.md
@@ -15,3 +15,5 @@ There are two things:
 Back when working on Windows in the 2000s (yeah, I'm that old), the ship cycle was 6 months to 2 years, which meant you'd write code and it'd sit around with minimal use for a while. Unit tests didn't exist and code reviews were only done for complex parts of code, and at the time we treated testing as a separate function, and had testers. Those testers would "look for bugs" and then file bugs.
 
 Nowadays the ship cycle is much shorter, and we've converged on the idea that engineers own the quality of their product. As a result, we do code reviews and unit tests, this lets defects become a thing that's addressed during development, and not a bug. The first time your product is really used is once it hits production, which due to continuous integration, happens in low days, and when production has a defect, you don't get a bug, you get a ticket that the system isn't working.
+
+The hobby-project version of code sitting around unused: [Software Rot](/d/2017-09-10-software-rot).

--- a/_td/adblocker_trojan.md
+++ b/_td/adblocker_trojan.md
@@ -4,16 +4,16 @@ title: The Mystery of the google ads
 permalink: /adblocker-trojan
 ---
 
-Out of the blue I started seeing ads in my google search. They were especially prominent due to the fact they were white, and I use a back background. It was caused by a trojan running in my chrome extension, which I suspect was installed by a name-jacked NPM plugin.
+Out of the blue I started seeing ads in my google search. They were especially prominent due to the fact they were white, and I use a black background. It was caused by a trojan running in my chrome extension, which I suspect was installed by a name-jacked NPM plugin.
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
 - [Impact and blast radius](#impact-and-blast-radius)
-    - [Did happen when ...](#did-happen-when-)
-    - [Did not happen  when ...](#did-not-happen--when-)
+  - [Still happened even when ...](#still-happened-even-when-)
+  - [Went away when ...](#went-away-when-)
 - [Detection](#detection)
-    - [Debugging](#debugging)
+  - [Debugging](#debugging)
 - [Mitigation](#mitigation)
 - [Root Causing and hypothesis](#root-causing-and-hypothesis)
 
@@ -22,15 +22,13 @@ Out of the blue I started seeing ads in my google search. They were especially p
 
 ## Impact and blast radius
 
-Out of the blue I started seeing ads in my google search. They were especially prominent due to the fact they were white, and I use a back background
-
-### Did happen when ...
+### Still happened even when ...
 
 - In private mode
 - Disabling plugins
 - Close and reboot chrome
 
-### Did not happen when ...
+### Went away when ...
 
 - Using edge
 - Using another user profile in chrome
@@ -63,18 +61,8 @@ I'm not sure this happened, but my guess:
 - The package modified the extension on disk (I didn't verify, just guessing :( )
 - When my web page ran, the malicious extension ran, and loaded ads.
 
-More details from [Malware can edit the chrome binary, or extensions, with a loader](https://www.microsoft.com/security/blog/2020/12/10/widespread-malware-campaign-seeks-to-silently-inject-ads-into-search-results-affects-multiple-browsers/):
-
-_We call this family of browser modifiers Adrozek. If not detected and blocked, Adrozek adds browser extensions, modifies a specific DLL per target browser, and changes browser settings to insert additional, unauthorized ads into web pages, often on top of legitimate ads from search engines. The intended effect is for users, searching for certain keywords, to inadvertently click on these malware-inserted ads, which lead to affiliated pages. The attackers earn through affiliate advertising programs, which pay by amount of traffic referred to sponsored affiliated pages._
-
-_The malware makes changes to certain browser extensions. On Google Chrome, the malware typically modifies “Chrome Media Router”, one of the browser’s default extensions, but we have seen it use different extensions._
-
-_The malware also tampers with certain browser DLLs. For instance, on Microsoft Edge, it modifies MsEdge.dll to turn off security controls that are crucial for detecting any changes in the Secure Preferences file._
+More details from Microsoft: [Adrozek](https://www.microsoft.com/security/blog/2020/12/10/widespread-malware-campaign-seeks-to-silently-inject-ads-into-search-results-affects-multiple-browsers/) is a malware family that adds browser extensions, tampers with browser DLLs, and injects unauthorized ads into search results to earn affiliate ad revenue.
 
 While web searches mentioned [ad blockers were compromised](https://www.imperva.com/blog/the-ad-blocker-that-injects-ads/), there was no evidence that [uBlock](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm?hl=en) was.
 
-I wondered if something edited the uBlock extension on disk. Turns out NPM packages are "brand jacked" by making [NPM extension](https://blog.sonatype.com/open-source-attacks-on-the-rise-top-8-malicious-packages-found-in-npm) with a similar name.
-
-_These mimicked the legitimate NodeJS-based database libraries, including jdb and db-json, but downloaded the malicious njRAT aka Bladabindi onto the user’s system._
-
-Here's a deep dive into how sophisticated the [attack can be](https://blog.sonatype.com/bladabindi-njrat-rat-in-jdb.js-npm-malware).
+I wondered if something edited the uBlock extension on disk. Turns out NPM packages get "brand jacked" — [Sonatype found malicious NPM packages](https://blog.sonatype.com/open-source-attacks-on-the-rise-top-8-malicious-packages-found-in-npm) mimicking legitimate libraries (jdb, db-json) that install the njRAT trojan. Here's a deep dive into how sophisticated the [attack can be](https://blog.sonatype.com/bladabindi-njrat-rat-in-jdb.js-npm-malware).

--- a/_td/ast-grep.md
+++ b/_td/ast-grep.md
@@ -4,7 +4,7 @@ title: AST Grep
 permalink: /ast-grep
 ---
 
-Sometimes you need to search/replace but on code, so let's use ASTs for that. The tool is called [ast-grep](https://github.com/ast-grep/ast-grep) (which you invoke with sg).
+Sometimes you need to search/replace but on code, so let's use ASTs for that. The tool is called [ast-grep](https://github.com/ast-grep/ast-grep) (which you invoke with sg — though on many Linux systems `sg` collides with the setgroups binary, so use the `ast-grep` binary name there).
 
 ### Pet Project: Extracting all documentation from hyper-div
 
@@ -55,6 +55,16 @@ This has human-readable output, which we can make computer-readable with
 
 ```bash
 ❮ sg scan --rule doc_puller.yaml --json  |  jq -r '.[] | {file: .file, lines: .lines} | "\(.file)\n\(.lines)"'
+```
+
+Each match comes out as the file, then the matched source — for the loops example above:
+
+```text
+hyperdiv_docs/pages/guide/loops.py
+docs_markdown(
+    """
+    When rendering components in loops, we have to take a bit
+    of extra precaution. ...
 ```
 
 ### Notes

--- a/_td/dump_imessage_history.md
+++ b/_td/dump_imessage_history.md
@@ -8,24 +8,24 @@ _[Copied from my GitHub techdiary](https://github.com/idvorkin/techdiary/blob/ma
 
 # Accessing iMessage history
 
-You'll need to start by taking full disk access for you terminal
+You'll need to start by granting full disk access to your terminal
 
-Open System Preferences, find the “Security & Privacy” pane, click on the “Privacy” tab, and find the “Full Disk Access” item. Make sure your SQL client and/or terminal are selected.
+Open System Settings (System Preferences pre-Ventura), find the “Privacy & Security” pane, and find the “Full Disk Access” item. Make sure your SQL client and/or terminal are selected.
 
 You'll also need to make sure you've enabled full cloud syncing if your message history is truncated
 
-iMessage -> Preferences -> Imessage -> settings (Apple Id -> Enable Messages is iCloud) , grayed out sync now button.
+Messages -> Settings -> iMessage (Apple ID -> Enable Messages in iCloud), grayed out sync now button.
 <https://www.mackungfu.org/HowtomakesureyourMacisusingMessagesiniCloud>
 
-iMessage is just a sqllite file located @
+iMessage is just a SQLite file located @
 
     ~/Library/Messages/chat.db
 
-A nice sqllite cli is litecli (pip install litecli)
+A nice SQLite cli is litecli (pip install litecli)
 
     litecli  -e'select  text, date, is_from_me , destination_caller_id, h.id from message m, handle h where m.handle_id = h.ROWID  limit 200 ' chat.db
 
-Dates are in a goofy formab, handle them
+Dates are in a goofy format, handle them
 
     litecli  -e'select  text, datetime(date/1000000000 + strftime("%s", "2001-01-01") ,"unixepoch","localtime")  as date_uct , is_from_me , destination_caller_id, h.id from message m, handle h where m.handle_id = h.ROWID  limit 10 ' chat.db | tee o1
 
@@ -36,6 +36,8 @@ A decent query (reverse engineering the table formats)
 Same query, dump the whole thing.
 
     litecli  -e'select  datetime(date/1000000000 + strftime("%s", "2001-01-01") ,"unixepoch","localtime")  as date,text,  is_from_me ,  h.id as to_phone  from message m,  chat_message_join cmj, chat_handle_join chj,  handle h where cmj.message_id = m.ROWID  and cmj.chat_id = chj.chat_id  and h.ROWID = chj.handle_id order by date ' ~/imessage/chat.db > ~/tmp/big_dump.txt
+
+Heads up for modern macOS: many messages store their text in the `attributedBody` blob instead of the `text` column, so the queries above silently return NULL for those. If you're doing this today, use [imessage-exporter](https://github.com/ReagentX/imessage-exporter), which handles that.
 
 References:
 

--- a/_td/irl.md
+++ b/_td/irl.md
@@ -16,45 +16,41 @@ _[Copied from my GitHub techdiary](https://github.com/idvorkin/techdiary/blob/ma
 <!-- vim-markdown-toc-start -->
 
 - [Physical Health](#physical-health)
-    - [Personal Trainer](#personal-trainer)
-    - [Calf Health](#calf-health)
-    - [Knee Health](#knee-health)
-    - [Booger Health](#booger-health)
-    - [Skin Health](#skin-health)
-    - [Wrist Health](#wrist-health)
-    - [Books on injury prevention](#books-on-injury-prevention)
-    - [Standing Desks](#standing-desks)
-    - [Gym Stuff](#gym-stuff)
-    - [Under Desk Exercise Equipment](#under-desk-exercise-equipment)
-- [Emotional Health](#emotional-health)
-    - [Meditation](#meditation)
-    - [Therapist](#therapist)
-- [Cognitive Health](#cognitive-health)
-    - [Blogging](#blogging)
-    - [Weekly goals](#weekly-goals)
+  - [Personal Trainer](#personal-trainer)
+  - [Calf Health](#calf-health)
+  - [Knee Health](#knee-health)
+  - [Booger Health](#booger-health)
+  - [Skin Health](#skin-health)
+  - [Wrist Health](#wrist-health)
+  - [Books on injury prevention](#books-on-injury-prevention)
+  - [Gym Stuff](#gym-stuff)
+  - [Under Desk Exercise Equipment](#under-desk-exercise-equipment)
+- [[Emotional Health](/emotional-health)](#emotional-health)
+  - [Meditation](#meditation)
+  - [Therapist](#therapist)
 - [Identity Health](#identity-health)
-    - [Eulogy Writing](#eulogy-writing)
+  - [Eulogy Writing](#eulogy-writing)
 - [Personal Carry](#personal-carry)
-    - [Fanny Pack](#fanny-pack)
-    - [Gym Bag](#gym-bag)
-    - [Work Bag](#work-bag)
-    - [Selfie Sticks](#selfie-sticks)
-    - [Portable Espresso](#portable-espresso)
-- [Biking](#biking)
+  - [Fanny Pack](#fanny-pack)
+  - [Gym Bag](#gym-bag)
+  - [Work Bag](#work-bag)
+  - [Selfie Sticks](#selfie-sticks)
+  - [Portable Espresso](#portable-espresso)
+- [[Biking](/bike)](#biking)
 - [Car Tech](#car-tech)
-    - [Tony](#tony)
-    - [Tech (Old)](#tech-old)
+  - [Tony](#tony)
+  - [Tech (Old)](#tech-old)
 - [Tech](#tech)
-    - [How to add a poison pill to the addictive iPhone](#how-to-add-a-poison-pill-to-the-addictive-iphone)
-    - [Computers](#computers)
-    - [Monitors](#monitors)
-    - [Keyboards](#keyboards)
+  - [How to add a poison pill to the addictive iPhone](#how-to-add-a-poison-pill-to-the-addictive-iphone)
+  - [Computers](#computers)
+  - [Monitors](#monitors)
+  - [Keyboards](#keyboards)
 - [Camera](#camera)
 - [Virtual Reality - Oculus](#virtual-reality---oculus)
 - [Backyard](#backyard)
-    - [Inflatable Hot tub](#inflatable-hot-tub)
-    - [Propane Fire Pit](#propane-fire-pit)
-    - [Canopies](#canopies)
+  - [Inflatable Hot tub](#inflatable-hot-tub)
+  - [Propane Fire Pit](#propane-fire-pit)
+  - [Canopies](#canopies)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
@@ -116,8 +112,6 @@ Get 'em both
 
 {%include amazon.html asin="1628604220;1735728500" %}
 
-### Standing Desks
-
 ### Gym Stuff
 
 With age comes the need for more accouterments
@@ -138,11 +132,13 @@ I don't use this, but it's under my desk. The day I got it and used it, I decide
 
 ### Meditation
 
+I used to have a complex meditation routine, which was very "focused", but had too much complexity. I skipped it and now use headspace, and do it slouching in a chair. Huge improvement.
+
+If you're interested in why to start meditating, read Search Inside Yourself:
+
 {%include summarize-page.html src="/siy" %}
 
 **OLD**
-
-I used to have a complex meditation routine, which was very "focused", but had too much complexity. I skipped it and now use headspace, and do it slouching in a chair. Huge improvement.
 
 I meditate kneeling (Seiza) and have two benches. Meditation benches are overpriced, but if it improves my emotional health (and it's supposed to) it's worth it.
 
@@ -167,12 +163,6 @@ I've been seeing a therapist weekly since my early 30's. It provides me several 
 - A constant reminder of the importance of my emotional health
 - A historical reminder of previous states
 
-## Cognitive Health
-
-### Blogging
-
-### Weekly goals
-
 ## Identity Health
 
 ### Eulogy Writing
@@ -195,9 +185,7 @@ I often stuff the gym bag in a larger bag so small matters - I use:
 
 ### Work Bag
 
-It's taken me several tries, but I've concluded I like the smallest bag possible. I use a 13" MacBook Pro laptop and an iPad Pro 10" and this is the perfect bag for me:
-
-There's also the horizontal version - which is slightly bigger but also nice:
+It's taken me several tries, but I've concluded I like the smallest bag possible. I use a 13" MacBook Pro laptop and an iPad Pro 10", and the vertical bag below is perfect for me. There's also the horizontal version - slightly bigger but also nice:
 
 {%include amazon.html asin="B07WNPPF72;B07H4QYC2D" %}
 
@@ -219,7 +207,7 @@ I take the OutIn Mino on walks — portable espresso on the go. It's battery-pow
 
 ## [Biking](/bike)
 
-I **love** not driving. Biking is an awesome form of transit. It took a while but I concluded I have several use cases so need several bikes. In fact,
+I **love** not driving. Biking is an awesome form of transit. It took a while but I concluded I have several use cases so need several bikes - the full story is at [/bike](/bike).
 
 ## Car Tech
 

--- a/_td/minecraft.md
+++ b/_td/minecraft.md
@@ -10,29 +10,20 @@ _[Copied from my GitHub techdiary](https://github.com/idvorkin/techdiary/blob/ma
 
 ## Why?
 
-Kids love Minecraft, dad loves tech. Here's my experiences in the world of Minecraft
+Kids love Minecraft, dad loves tech. Here's my experiences in the world of Minecraft. These notes are from 2020, when I ran a Bedrock server for the kids - a diary entry from that era.
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
+- [Why?](#why)
 - [Bedrock not Java](#bedrock-not-java)
   - [Bedrock Server](#bedrock-server)
   - [The X-Box Proxy Hack](#the-x-box-proxy-hack)
   - [Run bedrock server on lightsail/AWS](#run-bedrock-server-on-lightsailaws)
-- [Scripting](#scripting)
-  - [Command Blocks](#command-blocks)
-  - [Functions](#functions)
-  - [Resource Packs](#resource-packs)
-  - [Behavior Packs](#behavior-packs)
-  - [Connecting to a JavaScript 'script'](#connecting-to-a-javascript-script)
 - [Meta Stuff](#meta-stuff)
   - [Copying worlds between servers and stand alone](#copying-worlds-between-servers-and-stand-alone)
-  - [World Editors](#world-editors)
 - [Minecraft Education Edition](#minecraft-education-edition)
 - [Making resource packs](#making-resource-packs)
-- [Cool Stuff](#cool-stuff)
-  - [Fancy worlds](#fancy-worlds)
-- [Other Resources](#other-resources)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
@@ -77,31 +68,11 @@ https://github.com/jhead/phantom
 - Multiple servers same box
 - Backup worlds
 
-## Scripting
-
-### Command Blocks
-
-### Functions
-
-### Resource Packs
-
-### Behavior Packs
-
-### Connecting to a JavaScript 'script'
-
 ## Meta Stuff
 
 ### Copying worlds between servers and stand alone
 
 https://www.reddit.com/r/MCPE/comments/aqlld1/using_a_saved_realm_world_on_a_bedrock_dedicated/
-
-### World Editors
-
-Minecraft tool chest (for Java - https://mcctoolchest.weebly.com/blockeditor.html)
-
-Minecraft tool chest for PE:
-
-http://www.mcctoolchest.com/Download
 
 ## Minecraft Education Edition
 
@@ -111,9 +82,3 @@ Not sure what this is as you need an education account. Looks like you have an '
 
 [Bridge](https://github.com/bridge-core/bridge)
 [Resource Pack Tutorial](https://minecraft.gamepedia.com/Tutorials/Creating_resource_pack_add-ons)
-
-## Cool Stuff
-
-### Fancy worlds
-
-## Other Resources

--- a/_td/roblox2.md
+++ b/_td/roblox2.md
@@ -4,36 +4,28 @@ title: Developing on roblox
 permalink: /roblox-dev
 ---
 
-Zach and Amelia are roblox fans, so it's fun to be able to create things in there playgrounds. With Zach (and maybe Amelia in a while) it's even more fun to get to program. Here's some stuff I've learned about programming robolox.
+Zach and Amelia are roblox fans, so it's fun to be able to create things in their playgrounds. With Zach (and maybe Amelia in a while) it's even more fun to get to program. Here's some stuff I've learned about programming Roblox.
 
 <!-- prettier-ignore-start -->
 
 
 <!-- vim-markdown-toc-start -->
 
-- [Roblox Environment](#roblox-environment)
 - [Tool Chain](#tool-chain)
-    - [The language - Lua (you get used to it)](#the-language---lua-you-get-used-to-it)
-    - [The editor and tools - VS Code and plugins](#the-editor-and-tools---vs-code-and-plugins)
-    - [Package managers](#package-managers)
-        - [Foreman - Install Tools](#foreman---install-tools)
-        - [Wally - Install Packages](#wally---install-packages)
-- [Libraries](#libraries)
-    - [Roblox](#roblox)
-- [Testing](#testing)
-- [My games](#my-games)
-- [Philosophy](#philosophy)
+  - [The language - Lua (you get used to it)](#the-language---lua-you-get-used-to-it)
+  - [The editor and tools - VS Code and plugins](#the-editor-and-tools---vs-code-and-plugins)
+  - [Package managers](#package-managers)
+    - [Foreman - Install Tools](#foreman---install-tools)
+    - [Wally - Install Packages](#wally---install-packages)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->
-
-## Roblox Environment
 
 ## Tool Chain
 
 ### The language - Lua (you get used to it)
 
-Oddly, Roblox scripting is done via Lua. Lua is verbose in syntax and has oddites (indexing starts at 1 - blashemy). At first this was overwhelming to me, but thanks to a very strong tool chain, you stop worrying about it.
+Oddly, Roblox scripting is done via Lua. Lua is verbose in syntax and has oddities (indexing starts at 1 - blasphemy). At first this was overwhelming to me, but thanks to a very strong tool chain, you stop worrying about it.
 
 ### The editor and tools - VS Code and plugins
 
@@ -51,26 +43,16 @@ See [them in my project](https://github.com/idvorkin/cat-lady-2/blob/main/.vscod
 
 Not Sure I use this:
 
-- Robolox Lua Autocomplete
+- Roblox Lua Autocomplete
 
 ### Package managers
 
-1. crates install foreman
-2. ~/.cargo/bin/foreman install
-
 #### Foreman - Install Tools
 
-3. ~/.foreman/bin/wally install
-4. [https://wally.run/](https://wally.run/)
+1. cargo install foreman
+2. ~/.cargo/bin/foreman install
 
 #### Wally - Install Packages
 
-## Libraries
-
-### Roblox
-
-## Testing
-
-## My games
-
-## Philosophy
+1. ~/.foreman/bin/wally install
+2. [https://wally.run/](https://wally.run/)

--- a/_td/tool.md
+++ b/_td/tool.md
@@ -24,19 +24,19 @@ A collection of tips, tricks and pointers of the various tools i use
 - [Apple](#apple)
 - [Home Automation](#home-automation)
 - [Text manipulation tools](#text-manipulation-tools)
-    - [jq](#jq)
-    - [Pup - regexp For HTML](#pup---regexp-for-html)
+  - [jq](#jq)
+  - [Pup - regexp For HTML](#pup---regexp-for-html)
 - [Cool shell tools](#cool-shell-tools)
 - [Process Monitoring](#process-monitoring)
 - [Natural Language Processing](#natural-language-processing)
 - [Azure One Liners](#azure-one-liners)
-    - [Deploy webapp via git checkin](#deploy-webapp-via-git-checkin)
+  - [Deploy webapp via git checkin](#deploy-webapp-via-git-checkin)
 - [git](#git)
-    - [Colorized Diff - delta](#colorized-diff---delta)
-    - [TUI Client - lazygit/tig](#tui-client---lazygittig)
-    - [Git Stats](#git-stats)
-    - [TUI merge - fac](#tui-merge---fac)
-    - [Re-write history](#re-write-history)
+  - [Colorized Diff - delta](#colorized-diff---delta)
+  - [TUI Client - lazygit/tig](#tui-client---lazygittig)
+  - [Git Stats](#git-stats)
+  - [TUI merge - fac](#tui-merge---fac)
+  - [Re-write history](#re-write-history)
 - [GitHub](#github)
 - [SSH](#ssh)
 - [TMUX](#tmux)
@@ -44,13 +44,13 @@ A collection of tips, tricks and pointers of the various tools i use
 - [App Launchers](#app-launchers)
 - [Chrome extensions](#chrome-extensions)
 - [Web tools (http)](#web-tools-http)
-    - [wuzz](#wuzz)
-    - [httplab](#httplab)
-    - [httpie](#httpie)
-    - [httpprompt](#httpprompt)
-    - [Link Checkers](#link-checkers)
-    - [brow.sh - Text based web browser](#browsh---text-based-web-browser)
-    - [w3m - Text based web browser](#w3m---text-based-web-browser)
+  - [wuzz](#wuzz)
+  - [httplab](#httplab)
+  - [httpie](#httpie)
+  - [httpprompt](#httpprompt)
+  - [Link Checkers](#link-checkers)
+  - [brow.sh - Text based web browser](#browsh---text-based-web-browser)
+  - [w3m - Text based web browser](#w3m---text-based-web-browser)
 - [Video Manipulation Tools](#video-manipulation-tools)
 - [Linters and formatters](#linters-and-formatters)
 - [Switching between Unix and DOS file ending](#switching-between-unix-and-dos-file-ending)
@@ -58,19 +58,19 @@ A collection of tips, tricks and pointers of the various tools i use
 - [Web scripting](#web-scripting)
 - [Document conversion - Pandoc](#document-conversion---pandoc)
 - [Programming Helpers](#programming-helpers)
-    - [howdoi](#howdoi)
+  - [howdoi](#howdoi)
 - [Excalidraw](#excalidraw)
 - [PlantUML alternatives](#plantuml-alternatives)
 - [D2](#d2)
 - [PlantUML](#plantuml)
-    - [PlantUML Tools](#plantuml-tools)
-    - [PlantUML in Markdown](#plantuml-in-markdown)
-    - [Inline plantuml via Gravizo](#inline-plantuml-via-gravizo)
-    - [Quirks](#quirks)
+  - [PlantUML Tools](#plantuml-tools)
+  - [PlantUML in Markdown](#plantuml-in-markdown)
+  - [Inline plantuml via Gravizo](#inline-plantuml-via-gravizo)
+  - [Quirks](#quirks)
 - [Windows Managers](#windows-managers)
 - [ClI Fun](#cli-fun)
 - [CLI Screen Recoding](#cli-screen-recoding)
-    - [Show pressed keys](#show-pressed-keys)
+  - [Show pressed keys](#show-pressed-keys)
 - [Docker](#docker)
 - [Terminal Info](#terminal-info)
 - [OBS](#obs)
@@ -183,6 +183,7 @@ Profiling:
 - XPath and HtmlAgilityPack
 - Regexp + VIM
 - Beautiful soup
+- [ast-grep](/ast-grep) - search/replace on code structure via ASTs, my notes on using it to extract docs
 
 #### jq
 
@@ -709,7 +710,7 @@ _If on iOS then you need to click to open the image in a new tag_
 
 ![inamged image](https://raw.githubusercontent.com/idvorkin/techdiary/master/images/demo-cli-screen-recording.svg?sanitize=true)
 
-_(Note, to include an svg from raw.githubusercontent.com/blah.svg you'll need to add blah.svg?sanatize=true)_
+_(Note, to include an svg from raw.githubusercontent.com/blah.svg you'll need to add blah.svg?sanitize=true)_
 
 #### Show pressed keys
 

--- a/_td/visual-vocabulary.md
+++ b/_td/visual-vocabulary.md
@@ -16,9 +16,7 @@ I'm a visual thinker and here are some notes that help me with drawing/visualizi
 - [The noun project](http://thenounproject.com) - open source icons for everything.
 - [Google Quick Draw](https://quickdraw.withgoogle.com/data) Random people drawing [345 things](https://github.com/googlecreativelab/quickdraw-dataset/blob/master/categories.txt)
 - [Drawing Cartoons to Explain stuff ](https://jvns.ca/zines/) - Some very simple rules to make cool stuff.
-- [Facial Expressions](http://danidraws.com/blog/2007/12/06/50-facial-expressions-and-how-to-draw-them/) - Tips on facial expression.
 - [Sketch Books](http://sachachua.com/blog/category/visual-book-notes/) - A nice visual summary.
-- [Draw with me ](https://worlddraw.withgoogle.com/draw) - Googles draw a world together.
 - [Flat Icons](https://www.flaticon.com/) - A good library of vectors
 - [Vector Stock](https://www.vectorstock.com/) - Another library of images
 
@@ -26,9 +24,3 @@ I'm a visual thinker and here are some notes that help me with drawing/visualizi
 
 - InkScape
 - Affinity Designer
-
-### Pen Cast Software
-
-Video Scribe
-
-### Igor's first pencasts

--- a/pysrc/brython_runner_passage.py
+++ b/pysrc/brython_runner_passage.py
@@ -1,8 +1,11 @@
-from collections import defaultdict
-from typing import Dict, Callable, List
+from typing import List
 from dataclasses import dataclass
-import copy
-from pysrc.passages import *
+
+try:
+    from pysrc.passages import GetHeader, Passage, PassageFactory, TP
+except ModuleNotFoundError:
+    # Brython resolves imports relative to this script's directory (pysrc/)
+    from passages import GetHeader, Passage, PassageFactory, TP
 from browser import document, window, html, markdown  # type:ignore
 
 
@@ -88,12 +91,11 @@ class HtmlRenderer:
                 output <= html.SPAN(md_to_html(element))
                 continue
             if isinstance(element, TP):
-                alink = html.A(f" {element.Text} ")
                 output <= self.makeLink(element.Text, element.PassageFactory)
                 continue
             if callable(element):
                 function_name = element.__name__
-                text_link = f"{function_name.replace('_',' ')}"
+                text_link = f"{function_name.replace('_', ' ')}"
                 if text_link.startswith(" "):
                     text_link = text_link[1:]
                 output <= self.makeLink(text_link, element)

--- a/pysrc/html_snjb.py
+++ b/pysrc/html_snjb.py
@@ -1,15 +1,18 @@
-from browser import document, window, markdown, html
-from browser.widgets.dialog import InfoDialog
-from pysrc import snjb
+from browser import document, html
+
+# Brython resolves imports relative to this script's directory (pysrc/),
+# so import siblings directly instead of via the pysrc package.
+import brython_runner_passage as runner
+import snjb
+
 
 def startgame(_=0):
     runner.HtmlRenderer("gamediv", snjb.header).run(snjb.start_game)
 
-from pysrc import snjb
-import pysrc.brython_runner_passage as runner
-document['reset-game'].innerHTML=""
+
+document["reset-game"].innerHTML = ""
 reset_link = html.A("Restart SNJB")
 reset_link.href = "#"
-reset_link.bind('click',startgame)
-document['reset-game'] <= reset_link
+reset_link.bind("click", startgame)
+document["reset-game"] <= reset_link
 startgame()


### PR DESCRIPTION
Minutes-effort fixes from the 2026-07-13 full-blog quality audit for the Tech notes set. Tracked: blog-2xh.

## Per-post changes

- **/d/2017-09-10-software-rot** — Fixed the dropped word ("Now that the project was building"), added a two-sentence 2026 update (AI agents flip the economics of dependency-rot repair), and de-orphaned it with cross-links from [where-have-all-the-bugs-gone](/d/where-have-all-the-bugs-gone) and the "What Works Well" list in [/how-igor-chops](/how-igor-chops).
- **/snjb** — Added the 2-3 sentence father-son story intro (Zach's Twine game, ported to in-browser Python). While verifying the audit's bitrot worry, found the game has been **broken since 2022-12-31**: commit 4229658 moved Brython CDN loading from shared scripts.html onto individual pages but missed snjb — the page called `brython()` with no library loaded, leaving eternal spinners. Restored the script tags (properly closed, npm CDN; the old gh-hosted widgets script is 404 and unneeded) and updated `pysrc/html_snjb.py` / `pysrc/brython_runner_passage.py` imports for modern Brython's script-relative resolution. Verified locally with Playwright: game renders, restart link appears.
- **/vlc** — Switched "we" voice to "I", cut the config dump to the ~15 shortcuts under "The Shortcuts I Actually Use", deleted the Remote-Style Controls section and the duplicate/conflicting bindings (arrow-key seek vs frame conflict resolved: arrows seek, `,`/`.` step frames), kept the MPV custom-chapters section, dropped the now-inaccurate techdiary-copy attribution.
- **/adblocker-trojan** — Fixed "back background" → "black background", deleted the verbatim-duplicated opening paragraph, renamed the confusing headers to "Still happened even when ..." / "Went away when ...", and trimmed the Microsoft/Sonatype block quotes to one-line summaries with links.
- **/ast-grep** — Added the `sg`/`ast-grep` binary-name collision caveat, added a sample of the extracted output so the pipeline's result is visible, and de-orphaned it with a bullet in [/tools](/tools) § Text manipulation tools.
- **/td/dump_imessage_history** — Fixed typos (you→your, formab→format, sqllite→SQLite), updated System Preferences → System Settings / Privacy & Security and the Messages settings path, and added the `attributedBody` caveat plus a pointer to imessage-exporter.
- **/irl** — Finished the years-dangling "In fact," biking sentence with a /bike link, deleted the empty Standing Desks / Cognitive Health / Blogging / Weekly goals headings, restored the Meditation section to its original 2020 current-first/OLD-second order (a later edit had scrambled it, per git history), and tidied the Work Bag text so the "perfect bag" sentence points at the include below it.
- **/td/minecraft** — Deleted the seven empty scaffold headings (Scripting × 5, Fancy worlds, Other Resources), dropped the dead mcctoolchest World Editors links, and framed the notes as a dated 2020 diary entry.
- **/roblox-dev** — Deleted the five empty sections (Roblox Environment, Libraries/Roblox, Testing, My games, Philosophy), untangled the foreman/wally install steps so each lands under its own header (and fixed `crates` → `cargo`), and fixed the typos (there→their, oddites, blashemy, robolox).
- **/td/visual-vocabulary** — Deleted the empty "Igor's first pencasts" header and the two-word Pen Cast Software section; checked all links and removed the two dead ones (danidraws 500, worlddraw 404). The rest respond fine.
- **/tools** — Besides the ast-grep bullet: fixed `sanatize` → `sanitize` (the GitHub raw-SVG param is genuinely `?sanitize=true`), and the TOC regen now preserves its level-4 entries.
- **.typos.toml** — Ignore ASIN strings in amazon includes (the typos hook false-positived on `B00CWXU9FO`).

## Needs Igor

- **/td/visual-vocabulary** — the audit also wanted "one sentence per link on how you actually used it"; that's your memory, not mine to invent.
- **/roblox-dev** — "My games" was deleted as empty, but the audit notes it's the section that would make the post worth reading if Zach and Amelia's games exist.
- **/vlc** — the ~15 kept shortcuts are the objectively-core set (seek/speed/chapters/volume/subtitles/fullscreen); adjust if your actual muscle memory differs.

Text-level cleanup only, no layout changes, so no screenshots; back-links.json regenerates via the update-backlinks workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxH3FCWWxKnrpn7PKL3fPY
