### PR TITLE
Tier-3: fix 20 broken post openers (feed/social excerpts)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -97,6 +97,9 @@ catastrophize = "catastrophize"  # To view or present a situation as catastrophi
 catastrophizing = "catastrophizing"  # Present participle of catastrophize
 # Rust crate names
 ratatui = "ratatui"  # Rust TUI library (not ratatouille)
+# Fitness terms (shoulder-pain post)
+delt = "delt"  # Deltoid muscle abbreviation (rear delt, anterior delt)
+flyes = "flyes"  # Exercise name (reverse flyes)
 
 [files]
 # Files to ignore

--- a/_d/42.md
+++ b/_d/42.md
@@ -8,7 +8,7 @@ redirect_from:
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/racoon-health-struggle.png
 ---
 
-You survived young kids, marriage, house, some easy crises, and now it's time for remember, a healthy woman has a thousand wishes, a sick woman - just one: Things I wish I knew at 42
+You survived young kids, marriage, a house, and some easy crises. Now it's time to remember: a healthy woman has a thousand wishes, a sick woman just one. Here are the things I wish I knew at 42.
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
@@ -28,7 +28,7 @@ You survived young kids, marriage, house, some easy crises, and now it's time fo
   - [Hearing: Can you turn that up?](#hearing-can-you-turn-that-up)
   - [Other Health Stuff](#other-health-stuff)
 - [Themes](#themes)
-  - [Optimizing vs Satisfying](#optimizing-vs-satisfying)
+    - [Optimizing vs Satisfying](#optimizing-vs-satisfying)
 - [Some ideas from Ammon](#some-ideas-from-ammon)
 - [more ideas](#more-ideas)
 

--- a/_d/7h-c3.md
+++ b/_d/7h-c3.md
@@ -14,7 +14,7 @@ redirect_from:
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c3.webp
 ---
 
-The key to effective management, is allocating energy through the lens of importance rather than urgency. E.g, ask yourself what one thing could you do that if you did on a regular basis, would make a tremendous positive difference in your life? Lemme guess, it's important, but not urgent so you're not doing it. These are my insights based on the [7 habits](/7h) Chapter 3.
+The key to effective management is allocating energy through the lens of importance rather than urgency. E.g., ask yourself what one thing could you do that, if you did it on a regular basis, would make a tremendous positive difference in your life? Lemme guess, it's important, but not urgent so you're not doing it. These are my insights based on the [7 habits](/7h) Chapter 3.
 
 {% include ai-slop.html percent="50" %}
 

--- a/_d/7h-c4.md
+++ b/_d/7h-c4.md
@@ -14,11 +14,13 @@ redirect_from:
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c4.webp
 ---
 
-Win/Win is a constantly seeking mutual benefit in all interactions. Win/Win means that agreements or solutions are mutually beneficial, mutually satisfying. With a Win/Win solution, all parties feel good about the decision and feel committed to the action plan. Win/Win sees life as a cooperative, not a competitive arena. Most people tend to think in terms of dichotomies: strong or weak, hardball or softball, win or lose. But that kind of thinking is fundamentally flawed. It’s based on power and position rather than on principle. Win/Win is based on the paradigm that there is plenty for everybody, that one person’s success is not achieved at the expense or exclusion of the success of others.
+Win/Win sounds like soft idealism. It isn't — in any relationship that lasts past a single deal, it's the only paradigm that survives, because if we don't both win, we both eventually lose. These are my insights based on the [7 habits](/7h) Chapter 4.
 
 {% include ai-slop.html percent="50" %}
 
-These are my insights based on the [7 habits](/7h) Chapter 4.
+As Covey describes it:
+
+> Win/Win means that agreements or solutions are mutually beneficial, mutually satisfying. With a Win/Win solution, all parties feel good about the decision and feel committed to the action plan. Win/Win sees life as a cooperative, not a competitive arena. Most people tend to think in terms of dichotomies: strong or weak, hardball or softball, win or lose. But that kind of thinking is fundamentally flawed. It’s based on power and position rather than on principle. Win/Win is based on the paradigm that there is plenty for everybody, that one person’s success is not achieved at the expense or exclusion of the success of others.
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->

--- a/_d/7h-c5.md
+++ b/_d/7h-c5.md
@@ -13,12 +13,13 @@ redirect_from:
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-7h-c5.webp
 ---
 
-Imagine going to the eye doctor. After hearing your complaint he takes off his glasses and hands them to you.
-“Put these on,” he says. “I’ve worn this pair of glasses for ten years now and they’ve really helped me. I have an extra pair at home; you can wear these.” So you put them on, but it only makes the problem worse. “This is terrible!” you exclaim. “I can’t see a thing!” “Well, what’s wrong?” he asks. “They work great for me. Try harder.” “I am trying,” you insist. “Everything is a blur.” “Well, what’s the matter with you? Think positively.” “Okay. I positively can’t see a thing.” “Boy, are you ungrateful!” he chides. “And after all I’ve done to help you!”
+By default I listen with the intent to reply, not to understand — judging, probing, and advising from my own frame of reference instead of theirs. Covey's fix is the habit I need most: seek first to understand, then to be understood. These are my insights based on the [7 habits](/7h) Chapter 5.
 
 {% include ai-slop.html percent="50" %}
 
-These are my insights based on the [7 habits](/7h) Chapter 5.
+Covey opens the chapter with a parable — imagine going to the eye doctor. After hearing your complaint he takes off his glasses and hands them to you:
+
+> “Put these on,” he says. “I’ve worn this pair of glasses for ten years now and they’ve really helped me. I have an extra pair at home; you can wear these.” So you put them on, but it only makes the problem worse. “This is terrible!” you exclaim. “I can’t see a thing!” “Well, what’s wrong?” he asks. “They work great for me. Try harder.” “I am trying,” you insist. “Everything is a blur.” “Well, what’s the matter with you? Think positively.” “Okay. I positively can’t see a thing.” “Boy, are you ungrateful!” he chides. “And after all I’ve done to help you!”
 
 This has a lot of similarity to [compassion and being curious](/curious). From that post:
 

--- a/_d/ai-imagegen.md
+++ b/_d/ai-imagegen.md
@@ -7,7 +7,7 @@ redirect-from:
 ai_default_image: true
 ---
 
-Everyone talks about GPT, but you can also generate images. Lately, I've been playing with Flux, which is an image generator. You can generate images of me using the idvorkin with this lora on replicate.
+Everyone talks about GPT, but you can also generate images. Lately, I've been playing with Flux, which is an image generator. You can even generate images of me using my idvorkin LoRA on Replicate.
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
@@ -19,11 +19,11 @@ Everyone talks about GPT, but you can also generate images. Lately, I've been pl
 - [History Lessons](#history-lessons)
 - [Completion](#completion)
 - [How it works](#how-it-works)
-    - [Diffusion](#diffusion)
-    - [LoRAs](#loras)
-    - [Blending LoRAs](#blending-loras)
+  - [Diffusion](#diffusion)
+  - [LoRAs](#loras)
+  - [Blending LoRAs](#blending-loras)
 - [Providing Inputs](#providing-inputs)
-    - [Text 2 Image; Control Nets; In Painting](#text-2-image-control-nets-in-painting)
+  - [Text 2 Image; Control Nets; In Painting](#text-2-image-control-nets-in-painting)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->

--- a/_d/balance2.md
+++ b/_d/balance2.md
@@ -6,27 +6,30 @@ redirect_from:
   - /effectiveness
 ---
 
-I'm good at a lot of things, but balance is really hard for me. Hard for everyone I bet. I think this would be an area that can really benefit from [mortality software](/mortality-software). TODO: decide if this post should fork into energy and balance
+I'm good at a lot of things, but balance is really hard for me. Hard for everyone I bet. I think this would be an area that can really benefit from [mortality software](/mortality-software).
+
+<!-- TODO: decide if this post should fork into energy and balance -->
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
 - [On Balance](#on-balance)
-    - [Balance vs Productivity](#balance-vs-productivity)
-    - [Energy is finite, like really finite.](#energy-is-finite-like-really-finite)
-    - [You need to decide how you'll spend it](#you-need-to-decide-how-youll-spend-it)
-    - [Golden Geese: Balancing Production and Production Capacity](#golden-geese-balancing-production-and-production-capacity)
-    - [Juggling Elephants: Balancing the roles in your life](#juggling-elephants-balancing-the-roles-in-your-life)
-    - [Productivity vs addiction and resistance](#productivity-vs-addiction-and-resistance)
+  - [Balance vs Productivity](#balance-vs-productivity)
+  - [Energy is finite, like really finite.](#energy-is-finite-like-really-finite)
+  - [You need to decide how you'll spend it](#you-need-to-decide-how-youll-spend-it)
+  - [Golden Geese: Balancing Production and Production Capacity](#golden-geese-balancing-production-and-production-capacity)
+  - [Juggling Elephants: Balancing the roles in your life](#juggling-elephants-balancing-the-roles-in-your-life)
+  - [Productivity vs addiction and resistance](#productivity-vs-addiction-and-resistance)
 - [How to achieve](#how-to-achieve)
-    - [Realistic goals by role](#realistic-goals-by-role)
-    - [Monitoring the roles in your life vs your goals](#monitoring-the-roles-in-your-life-vs-your-goals)
-    - [Review adjustment](#review-adjustment)
-    - [Focus on Impact, not energy spent](#focus-on-impact-not-energy-spent)
-    - [Parkinson's law and the 80/20 rule](#parkinsons-law-and-the-8020-rule)
-    - [Peak end rule and moments](#peak-end-rule-and-moments)
-    - [Activation Energy](#activation-energy)
-    - [Recharging with Time off](#recharging-with-time-off)
+  - [Realistic goals by role](#realistic-goals-by-role)
+  - [Monitoring the roles in your life vs your goals](#monitoring-the-roles-in-your-life-vs-your-goals)
+  - [Review adjustment](#review-adjustment)
+  - [Focus on Impact, not energy spent](#focus-on-impact-not-energy-spent)
+  - [Parkinson's law and the 80/20 rule](#parkinsons-law-and-the-8020-rule)
+  - [Peak end rule and moments](#peak-end-rule-and-moments)
+  - [Activation Energy](#activation-energy)
+  - [Recharging with Time off](#recharging-with-time-off)
+  - [Learning to slow down](#learning-to-slow-down)
 - [More resources](#more-resources)
 
 <!-- vim-markdown-toc-end -->

--- a/_d/breath.md
+++ b/_d/breath.md
@@ -10,9 +10,9 @@ redirect_from:
   - breathing
 ---
 
-Breathing, an act so simple yet so crucial, harbors the potential to transform our health, mind, and life. This blog post is a deep dive into the world of breathing techniques, exploring a range of practices from Box Breathing and Victory Breath to Sitali Breath and the Breath Focus Technique. Each technique is detailed with its benefits and step-by-step instructions. In addition, the scientific perspective on breathing is explored. Whether you're seeking to reduce stress, improve focus, or simply understand the science of breathing, this post is your comprehensive guide. Join us as we explore the art of breathing, its techniques, and the science behind it.
+Change how you breathe and you change how you feel. Longer inhales rev me up, longer exhales calm me down, and holds build CO2 tolerance. These are my notes on the breathing patterns, the chemistry behind them, and a few techniques: box breathing, the psychological sigh, and alternate nostril breathing.
 
-For a deeper understanding of the science behind breathing and its profound impact on our health, I highly recommend James Nestor's groundbreaking book:
+For the science of breathing, I recommend James Nestor's book:
 
 {% include amazon.html asin="0735213615" %}
 

--- a/_d/facebook.md
+++ b/_d/facebook.md
@@ -7,7 +7,7 @@ redirect_from:
   - /fb
 ---
 
-Meta is a ‘social’ company; we value 1-1 time, fostering trust-driven relationships, and providing skip-level escalations and support. Here are my notes on Meta.
+Meta calls itself a ‘social’ company. As one of its managers put it: "we value 1-1 time, fostering trust-driven relationships, and providing skip-level escalations and support." Here are my notes on Meta.
 
 _(\* When I started this was still Facebook.)_
 

--- a/_d/frog.md
+++ b/_d/frog.md
@@ -14,7 +14,7 @@ tags:
   - how igor ticks
 ---
 
-Procrastination is the success killer, a powerful manifestations of the resistance. Eat that frog gives 21 antidotes to procrastination. These are my re-framing of the concepts into my favorite mental models. Chapter titles come from the book.
+Procrastination is the success killer, a powerful manifestation of the resistance. Eat that frog gives 21 antidotes to procrastination. This is my re-framing of the concepts into my favorite mental models. Chapter titles come from the book.
 
 {% include amazon.html asin="1583762027" %}
 

--- a/_d/gty.md
+++ b/_d/gty.md
@@ -8,22 +8,22 @@ redirect_from:
   - /negotiation
 ---
 
-Negotiation is the heart of collaboration. It is what makes conflict potentially meaningful and productive for all parties. Getting To Yes is the seminal book on negotiation. It's the deep dive into [win win or no deal](/win-win) and [seek first to understand](/first-understand). The formal, be hard on problems and soft on people, then focus on the desired outcomes not the positions, next get more options on the table, and make sure you measure by objective criteria - lastly know your BATNA.Several years later a new book came out by a hostage negotiator. Instead of being analytic focus, it's all about influencing the [elephant](/switch).
+Negotiation is the heart of collaboration. It is what makes conflict potentially meaningful and productive for all parties. Getting To Yes is the seminal book on negotiation. It's the deep dive into [win win or no deal](/win-win) and [seek first to understand](/first-understand). The formula: be hard on problems and soft on people, then focus on the desired outcomes not the positions, next get more options on the table, and make sure you measure by objective criteria - lastly, know your BATNA. Several years later a new book came out by a hostage negotiator. Instead of an analytic focus, it's all about influencing the [elephant](/switch).
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
 - [Getting To Yes](#getting-to-yes)
-    - [Hard on problems soft on people](#hard-on-problems-soft-on-people)
-    - [Focus on outcomes not positions](#focus-on-outcomes-not-positions)
-    - [Brainstorm options](#brainstorm-options)
-    - [Find objective criteria](#find-objective-criteria)
-    - [Know your BATNA](#know-your-batna)
+  - [Hard on problems soft on people](#hard-on-problems-soft-on-people)
+  - [Focus on outcomes not positions](#focus-on-outcomes-not-positions)
+  - [Brainstorm options](#brainstorm-options)
+  - [Find objective criteria](#find-objective-criteria)
+  - [Know your BATNA](#know-your-batna)
 - [Never Split the difference](#never-split-the-difference)
-    - [Mirroring and active listening](#mirroring-and-active-listening)
-    - [Tactical Empathy and Labeling](#tactical-empathy-and-labeling)
-    - [Mirroring](#mirroring)
-    - [Labeling](#labeling)
+  - [Mirroring and active listening](#mirroring-and-active-listening)
+  - [Tactical Empathy and Labeling](#tactical-empathy-and-labeling)
+  - [Mirroring](#mirroring)
+  - [Labeling](#labeling)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->

--- a/_d/lonely.md
+++ b/_d/lonely.md
@@ -32,8 +32,6 @@ Loneliness is like a warning signal. Just as hunger motivates you to eat, loneli
 
 ## The Scale of the Problem
 
-Loneliness is not just a personal feeling—it's a growing societal trend. In a study of 1,000 Americans, 36% of respondents reported feeling lonely "frequently", "almost all the time" or "all the time" in the prior four weeks. 61% of young people aged 18-25 and 51% of mothers with young children reported these miserable degrees of loneliness. The cost of loneliness is high: it is linked to early mortality and a wide array of serious physical and emotional problems, including depression, anxiety, heart disease, substance abuse, and domestic abuse.
-
 Recent data shows the problem is deepening. Since 1990, the percentage of U.S. adults with no close friends has quadrupled to 12%, while those with ten or more close friends has dropped nearly threefold. The average time Americans spend with friends has plummeted from 6.5 hours per week to just 4 hours (2014–2019). Nearly 40% of Americans now have online-only friendships, and among teenagers, daily in-person time with friends outside school has dropped from 140 minutes to just 40 minutes over the past two decades. These trends reflect a broader "Friendship Recession," where work, family, and digital life increasingly crowd out opportunities for real connection, making loneliness a default for many. ([source](https://www.happiness.hks.harvard.edu/february-2025-issue/the-friendship-recession-the-lost-art-of-connecting))
 
 ## The Science Behind Connection and Loneliness

--- a/_d/osx.md
+++ b/_d/osx.md
@@ -6,9 +6,9 @@ redirect_from:
   - /mac
 ---
 
-{% include alert.html style="info" content="Check out my [Mac install script](https://github.com/idvorkin/Settings/blob/master/mac/install.sh) for automated setup of my Mac environment." %}
-
 I pretty much use mac exclusively. I have 3 at work, and a mac mini at home, and I'm an automation nerd so I try to have everything auto install/synchronize across the machines. On the mac, I'm either in chrome/edge, Cursor (the new VS.code), the terminal (I use iterm), capcut (video editor), zoom, or the few super handy utilities I list below.
+
+{% include alert.html style="info" content="Check out my [Mac install script](https://github.com/idvorkin/Settings/blob/master/mac/install.sh) for automated setup of my Mac environment." %}
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc GFM -->

--- a/_d/planning.md
+++ b/_d/planning.md
@@ -39,7 +39,7 @@ All things are created twice - once in the design phase, and then again in the i
 
 {% include summarize-page.html src="/end-in-mind" %}
 
-**The plan trains the planner.** Planning isn't about predicting the future—it's about preparing your mind to meet it:
+Here's what planning actually buys you:
 
 - **Clarifies the goal** - Forces you to articulate what success actually looks like
 - **Surfaces unknowns** - Planning walks you toward the edges where risks hide; without it, you wander randomly and may never find them until they find you

--- a/_d/psychic-shadows.md
+++ b/_d/psychic-shadows.md
@@ -13,7 +13,7 @@ redirect_from:
   - /thought-spells
 ---
 
-It's 3am and your brain is replaying that conversation from six months ago, calculating worst-case financial scenarios, or imagining all the ways you'll fail at that thing you haven't even started yet. These aren't just ordinary worries - they're psychic shadows, specific thought patterns that loop endlessly in your mind like restless spirits. If you're tired of being held hostage by these ruminating thoughts, this post will teach you how to craft personalized spells that banish each shadow the moment it appears, giving you a mystical toolkit for transforming persistent mental loops into single-word circuit breakers that actually work.
+It's 3am and my brain is replaying a conversation from six months ago, calculating worst-case financial scenarios, or rehearsing all the ways I'll fail at something I haven't even started. These aren't ordinary worries - they're psychic shadows, specific thought patterns that loop endlessly like restless spirits. My way out is crafting spells: single words that name the shadow and break the loop the moment it appears. Here's how I craft them.
 
 {% include blob_image_float_right.html src="blog/racoon-power-word.webp" %}
 
@@ -22,19 +22,19 @@ It's 3am and your brain is replaying that conversation from six months ago, calc
 
 - [The Nature of Shadows](#the-nature-of-shadows)
 - [The Art of Spell-Crafting](#the-art-of-spell-crafting)
-    - [Step 1: Catch the Shadow](#step-1-catch-the-shadow)
-    - [Step 2: Analyze Deeply](#step-2-analyze-deeply)
-    - [Step 3: Bind to Word](#step-3-bind-to-word)
-    - [Step 4: Deploy the Spell](#step-4-deploy-the-spell)
+  - [Step 1: Catch the Shadow](#step-1-catch-the-shadow)
+  - [Step 2: Analyze Deeply](#step-2-analyze-deeply)
+  - [Step 3: Bind to Word](#step-3-bind-to-word)
+  - [Step 4: Deploy the Spell](#step-4-deploy-the-spell)
 - [Categories of Common Shadows](#categories-of-common-shadows)
-    - [Financial Shadows](#financial-shadows)
-    - [Health and Decay Shadows](#health-and-decay-shadows)
-    - [Relationship Shadows](#relationship-shadows)
-    - [Identity and Worth Shadows](#identity-and-worth-shadows)
+  - [Financial Shadows](#financial-shadows)
+  - [Health and Decay Shadows](#health-and-decay-shadows)
+  - [Relationship Shadows](#relationship-shadows)
+  - [Identity and Worth Shadows](#identity-and-worth-shadows)
 - [The Mystical Practice](#the-mystical-practice)
-    - [Daily Shadow Awareness](#daily-shadow-awareness)
-    - [Spell Maintenance and Evolution](#spell-maintenance-and-evolution)
-    - [When Shadows Transform](#when-shadows-transform)
+  - [Daily Shadow Awareness](#daily-shadow-awareness)
+  - [Spell Maintenance and Evolution](#spell-maintenance-and-evolution)
+  - [When Shadows Transform](#when-shadows-transform)
 - [Related Grimoire](#related-grimoire)
 
 <!-- vim-markdown-toc-end -->

--- a/_d/shoulder-pain.md
+++ b/_d/shoulder-pain.md
@@ -10,9 +10,9 @@ tags:
   - physical health
 ---
 
-{% include local_image_float_right.html src="raccoon-shoulder.webp" %}
-
 I developed shoulder impingement from Turkish Get-Ups - grinding through reps without the mobility or form to do them safely. Direct treatment didn't help. The fix requires an indirect approach: restore thoracic spine mobility, loosen pecs and lats, then rebuild rotator cuff strength. The shoulder is a symptom of upstream problems - fix those first, and it often resolves itself.
+
+{% include local_image_float_right.html src="raccoon-shoulder.webp" %}
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
@@ -67,42 +67,50 @@ My shoulder issue is impingement - the ball isn't staying centered in the socket
 Before diving into the fix, here's the vocabulary of shoulder movements. Understanding these directions helps you know what you're working on.
 
 **Flexion** (raising arm forward and overhead):
+
 - **What it looks like:** Arm moves from your side, forward, and up toward the ceiling (like raising your hand in class)
 - **Muscles:** Anterior deltoid (front of shoulder), upper pec, biceps (long head)
 - **Common exercises:** Front raises, overhead press
 
 **Extension** (moving arm backward):
+
 - **What it looks like:** Arm moves from your side backward behind you (like reaching for your back pocket)
 - **Muscles:** Lats, posterior deltoid (rear shoulder), teres major, triceps (long head)
 - **Common exercises:** Pull-ups, rows, straight-arm pulldowns
 
 **Abduction** (raising arm out to the side):
+
 - **What it looks like:** Arm moves from your side, out to the side, and up overhead (like making a snow angel)
 - **Muscles:** Supraspinatus (rotator cuff) initiates 0-15°, then middle deltoid takes over
 - **Common exercises:** Lateral raises, overhead press
 - **Critical:** Your shoulder blade MUST rotate upward or you get impingement
 
 **Adduction** (bringing arm down to your side or across body):
+
 - **What it looks like:** Arm moves from overhead or out to the side, down toward your body
 - **Muscles:** Lats, pecs, teres major
 - **Common exercises:** Pull-ups, lat pulldowns
 
 **External Rotation** (turning arm outward):
+
 - **What it looks like:** Elbow at your side, bent 90°, forearm rotates away from your body (like opening a door)
 - **Muscles:** Infraspinatus, teres minor (both rotator cuff muscles)
 - **WHY THIS MATTERS:** This is THE critical movement for fixing impingement. Most people are weak here.
 - **Common exercises:** Side-lying external rotation, face pulls
 
 **Internal Rotation** (turning arm inward):
+
 - **What it looks like:** Elbow at your side, bent 90°, forearm rotates toward your body (like closing a door)
 - **Muscles:** Subscapularis (rotator cuff), pecs, lats
 - **Note:** Usually overtrained from push-ups, bench press, desk work. Most people don't need MORE internal rotation.
 
 **Horizontal movements** (arm at shoulder height):
+
 - **Horizontal abduction (pulling back):** Rear delts, rhomboids, mid-traps - like reverse flyes
 - **Horizontal adduction (pulling across):** Pecs, anterior delt - like cable crossovers
 
 **What matters most for fixing impingement:**
+
 - **External rotation** - Weak in almost everyone, essential for centering the ball
 - **Scapular control** - Depression and retraction, the foundation for everything
 - **Avoid excessive internal rotation** - You're probably already too internally rotated
@@ -116,24 +124,28 @@ Now that you understand the movements, here are the muscles that make them happe
 These four small muscles wrap around the humeral head and are the only thing keeping the ball centered in the socket. If they're weak, the ball migrates and you get impingement.
 
 **Supraspinatus** (top of shoulder):
+
 - **Job:** Initiates abduction (first 0-15° of raising arm to side), pulls humeral head DOWN into socket
 - **Problem when weak:** Ball rides up, impingement starts immediately when raising arm
 - **Common issue:** First to get injured, prone to tears from overhead work
 - **Test:** Empty can test - arm straight out to side at 30° forward, thumb down (like emptying a can), raise 12-15 times with 2-5 lb weight. Pain or inability = weakness or injury.
 
 **Infraspinatus** (back of shoulder):
+
 - **Job:** External rotation, pulls humeral head DOWN and IN to center it
 - **Problem when weak:** Ball drifts forward and up, you lose external rotation range
 - **Critical:** This is THE muscle to strengthen for fixing impingement
 - **Test:** Elbow at side bent 90°, externally rotate against resistance (band or partner's hand). Can you do 15+ reps without shoulder hiking up toward ear? If shoulder elevates or you compensate = weak.
 
 **Teres Minor** (back of shoulder, below infraspinatus):
+
 - **Job:** External rotation, assists infraspinatus in pulling head down
 - **Problem when weak:** Same as infraspinatus - ball migrates forward/up
 - **Note:** Functionally very similar to infraspinatus - think of them as a team like biceps short head and long head. Anatomically distinct muscles, but in practice they fire together during external rotation. Almost impossible to isolate or test separately.
 - **Test:** Same as infraspinatus test - works together with it.
 
 **Subscapularis** (front of shoulder, against ribcage):
+
 - **Job:** Internal rotation, pulls humeral head forward INTO the socket (anteriorly)
 - **Problem when weak:** Ball can drift backward (rare)
 - **Problem when tight:** Restricts external rotation, contributes to forward shoulder posture
@@ -145,17 +157,20 @@ These four small muscles wrap around the humeral head and are the only thing kee
 The three deltoid heads are the big muscles that actually move your arm. They're strong, but if the rotator cuff is weak, they'll yank the ball out of position.
 
 **Anterior Deltoid** (front):
+
 - **Movements:** Flexion (raising arm forward), assists internal rotation
 - **Problem:** Often overdeveloped from pressing movements, contributes to forward shoulder posture
 - **Balance check:** Can you do as many overhead presses as bench presses?
 
 **Middle Deltoid** (side):
+
 - **Movements:** Abduction (raising arm to side)
 - **Critical coordination:** Works with supraspinatus - supraspinatus starts 0-15°, middle delt takes over
 - **Problem:** If supraspinatus is weak, middle delt takes over too early and yanks the ball upward
 - **Test:** Lateral raises with 5-10 lb dumbbells for 12-15 reps. Watch for shoulder hiking up - if it does, middle delt is compensating for weak supraspinatus.
 
 **Posterior Deltoid** (rear):
+
 - **Movements:** Extension (arm backward), external rotation, horizontal abduction
 - **Problem when weak:** Can't counteract forward pull from anterior delt and pecs
 - **Test:** Reverse flyes - bend forward 90°, arms hanging, raise arms out to sides. Can you do 15 reps with 5-10 lbs keeping shoulder blades squeezed? Weak = can't complete reps or upper traps take over.
@@ -165,6 +180,7 @@ The three deltoid heads are the big muscles that actually move your arm. They're
 The shoulder blade is the platform the ball-and-socket sits on. If the platform doesn't move correctly, the joint can't work properly.
 
 **Trapezius** (upper, middle, lower - three distinct sections):
+
 - **Upper trap:** Elevates shoulder (shrugging) - usually overactive, pulls shoulder up toward ear
 - **Middle trap:** Retracts scapula (pulls shoulder blade toward spine) - usually weak
 - **Lower trap:** Depresses and upwardly rotates scapula - CRITICAL for healthy overhead movement, usually very weak
@@ -173,11 +189,13 @@ The shoulder blade is the platform the ball-and-socket sits on. If the platform 
 - **Test for lower trap:** Stand, raise arms overhead in Y position. Can you hold 60 seconds without shoulders hiking toward ears? If shoulders elevate = weak lower trap, overactive upper trap.
 
 **Rhomboids** (between shoulder blades):
+
 - **Job:** Retract scapula, pull shoulder blades together
 - **Problem when weak:** Shoulder blades wing out, scapula sits too far forward
 - **Test:** Can you squeeze your shoulder blades together and hold for 10 seconds?
 
 **Serratus Anterior** (side of ribcage, wraps around):
+
 - **Job:** Protracts scapula (pushes it forward), upwardly rotates scapula
 - **Critical for:** Push-ups, punching, reaching forward, overhead movements
 - **Problem when weak:** Scapular winging (shoulder blade sticks out like a wing), can't push overhead properly
@@ -188,6 +206,7 @@ The shoulder blade is the platform the ball-and-socket sits on. If the platform 
 These large muscles get strong and tight from modern life and common exercises. When tight, they pull the shoulder into bad positions.
 
 **Pectorals** (chest - major and minor):
+
 - **Movements:** Internal rotation, adduction, horizontal adduction
 - **Problem:** Desk work, driving, bench press all shorten pecs. Tight pecs pull shoulder forward and internally rotated.
 - **Result:** Rounded shoulder posture, restricts external rotation, forces humeral head forward
@@ -195,6 +214,7 @@ These large muscles get strong and tight from modern life and common exercises. 
 - **Test for tightness:** Stand in doorway, arm on doorframe at 90°. Step through doorway - you should feel a stretch across chest. If no stretch or can't get arm back to doorframe = very tight pecs.
 
 **Latissimus Dorsi** (lats - broad back muscle):
+
 - **Movements:** Extension, adduction, internal rotation
 - **Problem:** Pull-ups, rows, and sitting all tighten lats. Tight lats restrict overhead range.
 - **Result:** Can't raise arms fully overhead without arching back, pulls shoulder down and forward
@@ -202,6 +222,7 @@ These large muscles get strong and tight from modern life and common exercises. 
 - **Test for tightness:** Lie on back, raise both arms overhead toward floor behind you, keep low back flat on ground. Can't touch floor with arms or back arches = tight lats restricting shoulder flexion.
 
 **Teres Major** (small muscle near lat):
+
 - **Movements:** Extension, internal rotation
 - **Problem:** Functions like a "mini lat" - often tight alongside lats
 - **Result:** Restricts overhead movement
@@ -210,6 +231,7 @@ These large muscles get strong and tight from modern life and common exercises. 
 **Key Principle - The Imbalance:**
 
 Modern life creates:
+
 - **Too much:** Internal rotation (pecs, lats, subscapularis), upper trap dominance, anterior delt work
 - **Too little:** External rotation (infraspinatus, teres minor), scapular retraction (mid/lower trap, rhomboids), scapular depression (lower trap)
 
@@ -278,6 +300,7 @@ This is THE critical step for fixing impingement. The rotator cuff's job is to p
 **Exercises:**
 
 **Side-lying external rotation** (fundamental movement):
+
 - Lie on your side, bottom arm tucked under head
 - Top arm bent 90°, elbow pinned to your side
 - Hold light dumbbell, rotate forearm up toward ceiling
@@ -285,12 +308,14 @@ This is THE critical step for fixing impingement. The rotator cuff's job is to p
 - 3 sets of 15-20 reps, multiple times per week
 
 **90/90 external rotation** (arm abducted position):
+
 - Lie on your side, upper arm out perpendicular to body, elbow bent 90°
 - Rotate forearm up toward ceiling
 - This trains external rotation with the arm in a more vulnerable position (mimics overhead movements)
 - 3 sets of 12-15 reps
 
 **Face pulls** (compound movement):
+
 - Cable or band at face height
 - Pull toward face, separating hands and rotating arms outward
 - Finish with hands by ears, thumbs pointing back
@@ -298,6 +323,7 @@ This is THE critical step for fixing impingement. The rotator cuff's job is to p
 - 3-4 sets of 15-20 reps
 
 **Banded external rotation at side** (warm-up/daily maintenance):
+
 - Band anchored at elbow height, stand sideways to anchor
 - Elbow bent 90°, pinned to side
 - Rotate arm outward against band resistance
@@ -305,6 +331,7 @@ This is THE critical step for fixing impingement. The rotator cuff's job is to p
 - 2-3 sets of 20 reps
 
 **Programming notes:**
+
 - Frequency matters more than intensity - 3-4x per week minimum
 - Always do BEFORE pressing movements (bench, overhead press) as prehab
 - Use tempo: 2 seconds up, pause, 2 seconds down
@@ -325,6 +352,7 @@ Exercises:
 Wall slides are both a diagnostic tool and the graduation test. They combine everything you've built in the previous steps into one integrated movement. If you can't do them smoothly, they show you exactly where your limitations are.
 
 **What wall slides require:**
+
 1. **T-spine extension** - to keep your back flat against the wall
 2. **Scapular upward rotation** - shoulder blades have to rotate smoothly as arms go up
 3. **External rotation** - to keep arms against the wall throughout the movement
@@ -332,6 +360,7 @@ Wall slides are both a diagnostic tool and the graduation test. They combine eve
 5. **Pec/lat length** - tight pecs or lats prevent arms from staying against the wall
 
 **How to do them:**
+
 - Stand with back against wall
 - Put arms against wall in "W" or "goal post" position (elbows bent 90°, upper arms out to sides)
 - Slide arms up overhead while keeping your back, head, and arms in contact with the wall
@@ -339,6 +368,7 @@ Wall slides are both a diagnostic tool and the graduation test. They combine eve
 - Repeat for 10-15 reps
 
 **What goes wrong if you have limitations:**
+
 - **Back arches off wall** → Stiff T-spine
 - **Arms pull forward off wall** → Tight pecs, weak external rotators
 - **Pain in shoulder** → Rotator cuff still weak, ball migrating up

--- a/_d/the-like-switch.md
+++ b/_d/the-like-switch.md
@@ -4,7 +4,7 @@ title: "How to build rapport and set people at ease"
 permalink: /like-switch
 ---
 
-The like switch, written by an ex-FBI agent, goes into detail on how to make friends and influence people in a much more modern form.
+The Like Switch, written by an ex-FBI agent, goes into detail on how to make friends and influence people in a much more modern form. It covers the friendship formula (proximity, frequency, duration, intensity), the nonverbal friend and foe signals we broadcast constantly, and the golden rule of friendship: make others feel good about themselves. These are my notes on the book.
 
 {% include amazon.html asin="1476754489" %}
 

--- a/_d/trusts.md
+++ b/_d/trusts.md
@@ -11,6 +11,8 @@ permalink: /trusts
 
 Most estate-planning advice on the web is either lawyer-jargon written for other lawyers, or generic "everyone needs a trust!" content that ignores where you actually live. This post is the trusts slice of my notes — what a plain revocable living trust actually does, what a credit shelter trust is, and why Washington's own estate tax (a low ~$3M exemption and, critically, **no spousal portability**) is the difference between your family keeping one exemption or two. It also covers the "qualified" trusts people half-remember (QTIP, and QDOT for a non-citizen / green-card spouse), the income-tax and step-up tradeoffs, and worked examples — including the break-even math on when a trust _isn't_ worth it.
 
+{% include ai-slop.html percent="90" %}
+
 For capital gains, step-up in basis, and retirement-account mechanics, see the companion [taxes post](/taxes). _Not legal or tax advice — see the disclaimer at the end. Figures are current as of June 2026, and Washington's rules just changed, so confirm specifics with a WA estate attorney + CPA._
 
 <!-- prettier-ignore-start -->

--- a/_posts/2017-11-16-understandingtechcompensation.md
+++ b/_posts/2017-11-16-understandingtechcompensation.md
@@ -11,27 +11,27 @@ redirect_from:
   - /pay
 ---
 
-Different companies use different compensation models. To compare models, use total compensation, not salary. The compensation models are arbitrary and complicated. For example, Amazon caps salary at 160K\$/yr and doesn't have bonuses. Google vests stocks monthly. Facebook bonuses have a company performance multiplier. At some companies, signing bonuses can be over 100% of salary!
+Different companies use different compensation models. To compare models, use total compensation, not salary. The compensation models are arbitrary and complicated. For example, in 2017, Amazon capped salary at 160K\$/yr and didn't have bonuses. Google vests stocks monthly. Facebook bonuses have a company performance multiplier. At some companies, signing bonuses can be over 100% of salary!
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->
 
 - [Total Compensation - It gets complicated](#total-compensation---it-gets-complicated)
-    - [Initial Grant Models - By Company](#initial-grant-models---by-company)
-    - [Steady State Comp Approaches - Independent vs Total Comp](#steady-state-comp-approaches---independent-vs-total-comp)
-    - [Assumptions](#assumptions)
+  - [Initial Grant Models - By Company](#initial-grant-models---by-company)
+  - [Steady State Comp Approaches - Independent vs Total Comp](#steady-state-comp-approaches---independent-vs-total-comp)
+  - [Assumptions](#assumptions)
 - [FAQ](#faq)
-    - [Why do I feel so bad?](#why-do-i-feel-so-bad)
-    - [I compared salaries and now I feel awful](#i-compared-salaries-and-now-i-feel-awful)
-    - [Wow, I had no idea, how do I get a new high-paying job?](#wow-i-had-no-idea-how-do-i-get-a-new-high-paying-job)
-    - [Should you include stock appreciation in total compensation?](#should-you-include-stock-appreciation-in-total-compensation)
-    - [How do I translate job levels between companies?](#how-do-i-translate-job-levels-between-companies)
-    - [I read on the internet company Foo pays Bar. Is that true?](#i-read-on-the-internet-company-foo-pays-bar-is-that-true)
-    - [Is it fair that promotions pay at the bottom of the pay scale, and new hires tend to be at the top?](#is-it-fair-that-promotions-pay-at-the-bottom-of-the-pay-scale-and-new-hires-tend-to-be-at-the-top)
-    - [What is the four-year cliff?](#what-is-the-four-year-cliff)
-    - [Example of Four-Year Cliff at Meta](#example-of-four-year-cliff-at-meta)
-    - [Explanation](#explanation)
-    - [Should I negotiate?](#should-i-negotiate)
+  - [Why do I feel so bad?](#why-do-i-feel-so-bad)
+  - [I compared salaries and now I feel awful](#i-compared-salaries-and-now-i-feel-awful)
+  - [Wow, I had no idea, how do I get a new high-paying job?](#wow-i-had-no-idea-how-do-i-get-a-new-high-paying-job)
+  - [Should you include stock appreciation in total compensation?](#should-you-include-stock-appreciation-in-total-compensation)
+  - [How do I translate job levels between companies?](#how-do-i-translate-job-levels-between-companies)
+  - [I read on the internet company Foo pays Bar. Is that true?](#i-read-on-the-internet-company-foo-pays-bar-is-that-true)
+  - [Is it fair that promotions pay at the bottom of the pay scale, and new hires tend to be at the top?](#is-it-fair-that-promotions-pay-at-the-bottom-of-the-pay-scale-and-new-hires-tend-to-be-at-the-top)
+  - [What is the four-year cliff?](#what-is-the-four-year-cliff)
+  - [Example of Four-Year Cliff at Meta](#example-of-four-year-cliff-at-meta)
+  - [Explanation](#explanation)
+  - [Should I negotiate?](#should-i-negotiate)
 
 <!-- vim-markdown-toc-end -->
 <!-- prettier-ignore-end -->

--- a/_td/screencast.md
+++ b/_td/screencast.md
@@ -4,7 +4,7 @@ permalink: /screencast
 layout: post
 ---
 
-Screencasting has become an essential tool for content creators, educators, and professionals alike. In this post, I'll share my experiences and insights on screencasting on macOS, covering various tools, techniques, and tips I've discovered along the way. From recording software to post-production enhancements, this guide aims to help you navigate the world of screencasting on your Mac.
+I record my screen with the built-in macOS recorder, capture my facecam as a separate track, and edit it all together in CapCut. I landed on this pipeline after Loom kept stalling on capture (while costing $20/month) and one-take OBS recordings ate my time. Here's the setup, plus the tips I picked up along the way.
 
 ### Screen Recording
 
@@ -34,14 +34,12 @@ Record facecam as a separate track for maximum flexibility:
    ```
 
 2. Benefits of separate recording:
-
    - Easier to reshoot just the facecam portion
    - Can record multiple takes without redoing screen capture
    - Better control over camera settings
    - No performance impact on screen recording
 
 3. Post-production in CapCut:
-
    - Import facecam as separate track
    - Use AI background removal
    - Easily position and resize

--- a/_td/smilebox.md
+++ b/_td/smilebox.md
@@ -4,7 +4,7 @@ permalink: /smilebox
 layout: post
 ---
 
-Way back in 2012 I had this idea to make a Smilebox. The tech wasn't good enough, but in 2023 tech is right ready. Here's quoting the original blog post ... Nothing makes me happier then seeing someone smile. In fact, seeing others smile makes me smile. As a result, I’m creating a box that captures smiles, which I'm calling a smile box. If you look at the smile box, you’ll see the smiles that are already captured . If you smile at the box, it’ll capture your smile and add it to the box.
+Way back in 2012 I had this idea to make a Smilebox. The tech wasn't good enough, but in 2023 tech is right ready. Here's quoting the original blog post ... Nothing makes me happier than seeing someone smile. In fact, seeing others smile makes me smile. As a result, I’m creating a box that captures smiles, which I'm calling a smile box. If you look at the smile box, you’ll see the smiles that are already captured . If you smile at the box, it’ll capture your smile and add it to the box.
 
 <script src="https://unpkg.com/@grammarly/editor-sdk?clientId=client_AMv8Ek2YNBrCaW2gfCXEa5"> </script>
 <script src="assets/js/face-api.js"></script>
@@ -224,8 +224,6 @@ $(document).ready(function() {
   // initFaceDetectionControls()
 })
 </script>
-
-Nothing makes me happier then seeing someone smile. In fact, seeing others smile makes me smile. As a result, I’m creating a box that captures smiles, which I'm calling a smile box. If you look at the smile box, you’ll see the smiles that are already captured . If you smile at the box, it’ll capture your smile and add it to the box.
 
 See the rest of the post (and what it turned into) here: <https://igsmilebox.blogspot.com/2012/12/what-is-smilebox.html>
 


### PR DESCRIPTION
Jekyll auto-generates an excerpt from the first paragraph of each post, and that excerpt is what shows up in blog indexes, RSS/Atom feeds, social-media link cards, and search snippets. The 2026-07-13 content audit found 20 posts whose excerpts were broken: includes/images sitting above the first paragraph (empty previews), garbled or typo'd first sentences, visible TODOs, AI-marketing openers with "we" violations, verbatim unattributed Covey passages, duplicated openers, a stale fact, and a missing ai-slop label.

This PR fixes the **opener layer only** — the first paragraph plus the specific defect the audit flagged in each excerpt. Many of these posts have deeper major-rework verdicts (empty sections, note-dump bodies, missing personal voice); that work is tracked separately (blog-g7b) and deliberately not attempted here. TOCs were regenerated via `toc.py` on every edited file that carries the `vim-markdown-toc-start` markers (indentation normalized to 2-space; `/balance` picked up its missing "Learning to slow down" entry).

## Per-post changes

- **/42** — repaired the garbled opening sentence; the healthy-woman proverb now parses.
- **/first-things-first** — fixed the opening comma splice ("The key to effective management, is...") and the `E.g,` typo.
- **/win-win** — new 2-sentence first-person opener; the pasted Covey definition (with its broken first sentence removed) now sits below as a blockquote attributed "As Covey describes it".
- **/first-understand** — new first-person opener (listening to reply vs. to understand); the eye-doctor parable kept below as a blockquote introduced as Covey's.
- **/ai-image** — repaired "You can generate images of me using the idvorkin with this lora on replicate."
- **/balance** — moved the visible "TODO: decide if this post should fork" out of the excerpt into an HTML comment.
- **/breath** — replaced the "Join us as we explore" AI opener with a first-person one that only promises techniques the post actually contains (the old intro advertised Victory Breath / Sitali / Breath Focus, none of which exist in the body); toned down the "groundbreaking" book plug.
- **/meta** — the opener no longer voices the FB manager's "we value 1-1 time..." line as Igor's own; it's now quoted and attributed.
- **/frog** — fixed "a powerful manifestations of the resistance" in the opener.
- **/negotiate** — fixed "The formal," → "The formula:", the fused "BATNA.Several", and "being analytic focus".
- **/lonely** — removed the 36%/61%/51% stats block that was duplicated word-for-word in "The Scale of the Problem"; the opener keeps the stats.
- **/osx** — moved the Mac-install-script alert below the opening paragraph so the excerpt is plain text.
- **/planning** — removed the "plan trains the planner / preparing your mind to meet it" passage that repeated the opener verbatim 30 lines later; the bullet list it introduced now has a plain lead-in.
- **/psychic-shadows** — rewrote the marketing-cadence opener ("mystical toolkit... that actually work") in first person, keeping the 3am hook.
- **/shoulder-pain** — moved the raccoon image include below the opening paragraph.
- **/like-switch** — the opener is now 3 sentences of plain text (friendship formula, friend/foe signals, golden rule — all from the post) before the Amazon include.
- **/trusts** — added `{% include ai-slop.html percent="90" %}` after the first paragraph.
- **/comp** — time-scoped the stale claim: "in 2017, Amazon capped salary at 160K$/yr" (was present-tense and wrong since 2022).
- **/screencast** — replaced the "essential tool for content creators" AI opener with a first-person pipeline summary (built-in recorder + separate facecam + CapCut, after Loom/OBS failed).
- **/smilebox** — fixed "happier then" → "than" in the opener and removed the identical paragraph duplicated at the bottom of the post.

Also: added `delt`/`flyes` (fitness jargon in /shoulder-pain) to `.typos.toml` so the typos hook passes on the touched file.

## Needs Igor

- **/ai-image frontmatter**: `redirect-from:` (hyphen) should be `redirect_from:` — the `/ai-imagegen` redirect silently doesn't exist. Left untouched since fixing it changes site URLs; one-word fix if you want it.
- **/comp company table**: the "Initial Grant Models - By Company" table still carries the un-scoped Amazon 160K cap and other stale numbers; needs your current numbers or a table-wide "as of" framing.
- **/breath**: the dangling SKY-breathing fragments right after the TOC ("Pretty cool... Hyperventilating / Good training available...") remain — turning them into real sentences needs your actual SKY practice details.
- **/osx TOC**: still uses the deprecated `vim-markdown-toc GFM` markers, so tooling won't regenerate it (headings unchanged in this PR, so it's not stale yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxH3FCWWxKnrpn7PKL3fPY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved wording, punctuation, spelling, and readability across numerous articles.
  * Reworked introductions and quotations for clearer context and presentation.
  * Improved table-of-contents formatting and nesting in several posts.
  * Added a planning benefits list and clarified breathing-technique guidance.
  * Corrected and reorganized instructional content, including shoulder-movement prerequisites.
  * Removed outdated or duplicated content from selected articles.
  * Added recognition for fitness terminology such as “delt” and “flyes.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->