### PR TITLE
Address post-merge CodeRabbit feedback (tiers 3-4)

### DIFF
--- a/_d/42.md
+++ b/_d/42.md
@@ -8,7 +8,7 @@ redirect_from:
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/racoon-health-struggle.png
 ---
 
-You survived young kids, marriage, a house, and some easy crises. Now it's time to remember: a healthy woman has a thousand wishes, a sick woman just one. Here are the things I wish I knew at 42.
+You survived young kids, marriage, a house, and some easy crises. Now it's time to remember the old saying — a healthy woman has a thousand wishes, a sick woman just one. Here are the things I wish I knew at 42.
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->

--- a/_d/7h-c7.md
+++ b/_d/7h-c7.md
@@ -148,4 +148,4 @@ The counterpoint keeps me honest: sometimes you need to stop sharpening the saw 
 - [Atomic Habits](/atomic-habits)
 - [Search Inside Yourself](/siy)
 
-{% include amazon.html asin="0743269519" %}
+{% include amazon.html asin="0743269519;B07D23CFGR;B0070XF474" %}

--- a/_d/gty.md
+++ b/_d/gty.md
@@ -8,7 +8,7 @@ redirect_from:
   - /negotiation
 ---
 
-Negotiation is the heart of collaboration. It is what makes conflict potentially meaningful and productive for all parties. Getting To Yes is the seminal book on negotiation. It's the deep dive into [win win or no deal](/win-win) and [seek first to understand](/first-understand). The formula: be hard on problems and soft on people, then focus on the desired outcomes not the positions, next get more options on the table, and make sure you measure by objective criteria - lastly, know your BATNA. Several years later a new book came out by a hostage negotiator. Instead of an analytic focus, it's all about influencing the [elephant](/switch).
+Negotiation is the heart of collaboration. It is what makes conflict potentially meaningful and productive for all parties. Getting To Yes is the seminal book on negotiation. It's the deep dive into [win-win or no deal](/win-win) and [seek first to understand](/first-understand). The formula: be hard on problems and soft on people, then focus on the desired outcomes not the positions, next get more options on the table, and make sure you measure by objective criteria - lastly, know your BATNA. Several years later a new book came out by a hostage negotiator. Instead of an analytic focus, it's all about influencing the [elephant](/switch).
 
 <!-- prettier-ignore-start -->
 <!-- vim-markdown-toc-start -->

--- a/_posts/2018-01-04-7-habits.md
+++ b/_posts/2018-01-04-7-habits.md
@@ -79,7 +79,7 @@ A little picture I drew when I'd just discovered the 7 habits ...
 
 ![igor_life_infographic](/images/igor-life-infographic.jpg)
 
-### Be Proactive
+## Be Proactive
 
 - Pause between stimulus and response
 - Who has helped me grow?
@@ -87,7 +87,7 @@ A little picture I drew when I'd just discovered the 7 habits ...
 - Use empowering language (I choose, I will)
 - Is this in my circle of influence, or circle of concern?
 
-### Begin with the end in mind
+## Begin with the end in mind
 
 - Re-read your [eulogy](/eulogy)
 - What does success look like
@@ -97,30 +97,30 @@ A little picture I drew when I'd just discovered the 7 habits ...
 - Who is most affected by my mission statement?
 - Am I over investing in one role at [the expense of another role](/balance)?
 
-### First things First
+## First things First
 
 - Stay in quadrant 2
 - What one thing can I do, that if invested regularly, would have a tremendous positive influence on my life?
 - What quadrant am I spending most of my time in? What is the consequence?
 - How many of my crisis could be avoided if I spent more time in quadrant 2?
 
-### Think Win/Win
+## Think Win/Win
 
 - If it's not WIN/WIN, it's LOSE/LOSE.
 - Where am I trying to win at someone else's expense this week?
 - Is there a deal here at all, or is [no deal](/win-win) the honest answer?
 
-### First Understand
+## First Understand
 
 - Imagine an eye doctor tried to make you use their glasses
 
-### Synergize
+## Synergize
 
 - How can I complement someone around me?
 - Whose difference am I treating as a deficit instead of a strength?
 - What [third alternative](/synergize) haven't we looked for yet?
 
-### Sharpen the Saw
+## Sharpen the Saw
 
 - Did you do your habits today?
 - Is technology helping me, or is it hurting me?

--- a/_td/smilebox.md
+++ b/_td/smilebox.md
@@ -4,7 +4,7 @@ permalink: /smilebox
 layout: post
 ---
 
-Way back in 2012 I had this idea to make a Smilebox. The tech wasn't good enough, but in 2023 tech is right ready. Here's quoting the original blog post ... Nothing makes me happier than seeing someone smile. In fact, seeing others smile makes me smile. As a result, I’m creating a box that captures smiles, which I'm calling a smile box. If you look at the smile box, you’ll see the smiles that are already captured . If you smile at the box, it’ll capture your smile and add it to the box.
+Way back in 2012 I had this idea to make a Smilebox. The tech wasn't good enough then, but by 2023 it was ready. Here's the original blog post: Nothing makes me happier than seeing someone smile. In fact, seeing others smile makes me smile. As a result, I’m creating a box that captures smiles, which I'm calling a smile box. If you look at the smile box, you’ll see the smiles that are already captured. If you smile at the box, it’ll capture your smile and add it to the box.
 
 <script src="https://unpkg.com/@grammarly/editor-sdk?clientId=client_AMv8Ek2YNBrCaW2gfCXEa5"> </script>
 <script src="assets/js/face-api.js"></script>


### PR DESCRIPTION
Follow-ups for CodeRabbit review threads left on already-merged PRs #749 (7 Habits) and #758 (excerpt fixes). Each is a small, verified fix against current `main`.

## Changes

- **`_d/7h-c7.md`** — the single-ASIN 7 Habits Amazon include is now a proper 3-book row, adding the **Atomic Habits** and **Search Inside Yourself** covers that were already listed as cross-links right above it. ASINs pulled from `_data/asins.json`, not guessed.
- **`_posts/2018-01-04-7-habits.md`** — promoted all seven habit headings from `###` to `##`. They were the post's only headings with no `##` parent (markdownlint MD001). Slugs are unchanged, so existing `#be-proactive`-style anchors still resolve.
- **`_d/42.md`** — framed the "a healthy woman has a thousand wishes" aphorism as a saying rather than a bare unattributed quote.
- **`_d/gty.md`** — hyphenated "win-win" in the visible link text.
- **`_td/smilebox.md`** — finished the opener copy edit #758 started: "tech is right ready" → "by 2023 it was ready", "Here's quoting the original blog post ..." → "Here's the original blog post:", removed the stray space before a period.

## Deliberately not changed

- **`_d/trusts.md`** — CodeRabbit flagged the `ai-slop` include as "immediately after front matter", but #758 already moved it below the opening paragraph. The comment is stale against current `main`; that thread is resolved with this note.

No permalinks changed and `back-links.json` is untouched (the update-backlinks workflow regenerates it after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxH3FCWWxKnrpn7PKL3fPY
