### PR TITLE
chore: normalize duplicate blog tags (fold variants into canonical form)

### DIFF
--- a/_d/act.md
+++ b/_d/act.md
@@ -6,7 +6,7 @@ permalink: /act
 tags:
   - book-notes
   - emotional-health
-  - mental-health
+  - mental health
   - psychology
 ---
 

--- a/_d/bc-vacation.md
+++ b/_d/bc-vacation.md
@@ -8,7 +8,7 @@ redirect_from:
 imagefeature: https://github.com/idvorkin/blob/raw/master/blog/raccoon-vacation.webp
 tags:
   - travel
-  - how-igor-ticks
+  - how igor ticks
 ---
 
 A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you're planning a quick weekend getaway or a longer adventure, here's what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my [summer 2024 adventures](/ig66/749), [Yellow Deli expedition](/ig66/718), and various time off adventures:

--- a/_d/chasing-daylight.md
+++ b/_d/chasing-daylight.md
@@ -3,7 +3,7 @@ layout: post
 title: "Chasing Daylight: Imagine you're gonna die in less than 100 days"
 tags:
   - death
-  - how-igor-ticks
+  - how igor ticks
   - book-notes
   - mindset
 permalink: /chasing-daylight

--- a/_d/emotional-lives.md
+++ b/_d/emotional-lives.md
@@ -4,7 +4,7 @@ title: "The Emotional Lives of Teenagers"
 tags:
   - parenting
   - book-notes
-  - emotional-intelligence
+  - emotional intelligence
   - dad
 permalink: /emotional-lives
 redirect_from:

--- a/_d/untangled.md
+++ b/_d/untangled.md
@@ -4,7 +4,7 @@ title: "Untangled: Guiding Teenage Girls Through the Seven Transitions into Adul
 tags:
   - parenting
   - book-notes
-  - emotional-intelligence
+  - emotional intelligence
   - dad
 permalink: /untangled
 redirect_from:

--- a/_d/upstream.md
+++ b/_d/upstream.md
@@ -5,7 +5,7 @@ comments: true
 inprogress: true
 tags:
   - manager
-  - heath
+  - health
   - book-notes
 permalink: /upstream
 redirect_from:

--- a/_ig66/636.md
+++ b/_ig66/636.md
@@ -6,7 +6,7 @@ week: 636
 fj: True
 tags:
   - family-journal
-  - accomplishemnt
+  - accomplishment
 ---
 
 This year for the fourth of July we got invited out to a 4th of July party. It was our first 4th of July party in a very, very long time and we had a blast. Conveniently, Ammon's family was out of town, and he wanted to make cake, so he made cakes and brought them to us.

--- a/_ig66/638.md
+++ b/_ig66/638.md
@@ -6,7 +6,7 @@ week: 638
 fj: True
 tags:
   - family-journal
-  - accomplishemnt
+  - accomplishment
 ---
 
 This week it's all about Zach, Zach has been kayaking and biking.

--- a/_ig66/685.md
+++ b/_ig66/685.md
@@ -6,7 +6,7 @@ week: 685
 fj: True
 tags:
   - family-journal
-  - accomplishemnt
+  - accomplishment
 ---
 
 "Igor, I was in Seattle the other day, and I saw a meditation bench with your name on it." And so began my 30-minute-a-day meditation practice! I'm on day 21, which means over 10 hours of meditation in the last month! For day 21, I woke up at 4:30 am (no free lunch, I go to bed at 8 pm), went to the beach and watched the sunrise as I meditated.


### PR DESCRIPTION
Normalize duplicate tags in post frontmatter by folding small variants into their dominant/canonical form ("Option B"). Only `tags:` values changed — no prose or other metadata touched. Every edited file changed exactly one line.

## Mappings applied

| Variant | Canonical | Files |
| --- | --- | --- |
| `accomplishemnt` (misspelling) | `accomplishment` | 3 |
| `heath` (misspelling) | `health` | 1 |
| `emotional-intelligence` (hyphen) | `emotional intelligence` | 2 |
| `how-igor-ticks` (hyphen) | `how igor ticks` | 2 |
| `mental-health` + `mental health` → unify | `mental health` (space form) | 1 |

**Total: 9 files, 9 lines changed.**

Verified after editing by re-deriving the full tag set from frontmatter:
- `accomplishment` 2 → 5, `accomplishemnt` gone
- `health` 13 → 14, `heath` gone
- `emotional intelligence` 58 → 60, `emotional-intelligence` gone
- `how igor ticks` 58 → 60, `how-igor-ticks` gone
- `mental health` 1 → 2, `mental-health` gone

The `mental health` space form was chosen to match sibling health sub-tags (`physical health`, `pain management`).

## Big two tags kept their spaced form (URLs unchanged)

`emotional intelligence` and `how igor ticks` were **not** renamed. Only the hyphen variants were folded *into* them, so their tag-page URLs are unchanged.

## `how` tag investigation → left untouched

The bare `how` tag (12 posts) was investigated. All 12 are legitimate standalone how-to / AI posts — `ai-cockpit`, `ai-operator`, `browsers-for-machines`, `chow`, `explainers`, `gas-city`, `gas-city-home`, `gas-city-rig`, `why-gas-city`, `hill-climbing`, `how-igor-chops`, `wally` — each tagged `ai` + `tools`/`manager`/`writing` + `how`. They are **not** mis-splits of "how igor ticks" (there are zero orphan `igor` or `ticks` tags anywhere in the corpus). Left untouched.

## Out of scope (intentionally untouched)

Achievement/Accomplishment synonym merge, Manager/Management, and Ai/Llm/Machine-learning — these change meaning and are being decided separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling errors in content tags, including “health” and “accomplishment.”
  * Standardized several tags by replacing hyphenated forms with space-separated labels, improving metadata consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->