### PR TITLE
Evals: smevals deep-dive in /ai-testing + /ai-eval-tools survey page

### DIFF
--- a/_d/ai-eval-tools.md
+++ b/_d/ai-eval-tools.md
@@ -21,6 +21,7 @@ Every time I want to compare models, prompts, or agent harnesses I trip over the
   - [Inspect AI (0.3.x)](#inspect-ai-03x)
   - [DeepEval (4.x)](#deepeval-4x)
   - [Giskard (2.x)](#giskard-2x)
+  - [Container-native agentic: Terminal-Bench, SWE-bench, Vivaria](#container-native-agentic-terminal-bench-swe-bench-vivaria)
   - [The SaaS tier: Braintrust, LangSmith, Langfuse](#the-saas-tier-braintrust-langsmith-langfuse)
 - [Repo naming convention](#repo-naming-convention)
 
@@ -76,9 +77,9 @@ Example: none yet — when I try it, the repo will be named `pydantic-evals-some
 
 ### Inspect AI (0.3.x)
 
-The UK AI Safety Institute's framework, used for serious public benchmarks. Research-grade: tasks, solvers, and scorers in Python, sandboxed tool use, big parallelism, a good log viewer.
+The UK AI Safety Institute's framework, used for serious public benchmarks. Research-grade: tasks, solvers, and scorers in Python, big parallelism, a good log viewer — and the standout feature for agentic work: `sandbox="docker"` runs each sample's tool calls inside its own container, which is how the serious agentic benchmarks (SWE-bench via inspect_evals, Cybench, GAIA) isolate the agent.
 
-Limitations: heavyweight authoring for weekend-sized evals, and the solver abstraction doesn't map cleanly onto driving an external CLI harness like Claude Code. Academic flavor throughout.
+Limitations: heavyweight authoring for weekend-sized evals, and the agent is Inspect's own Python solver loop — driving an external CLI harness like Claude Code or Codex isn't its native shape. Academic flavor throughout.
 
 Example: none yet.
 
@@ -95,6 +96,16 @@ Example: none yet.
 More scanner than eval harness: probes an LLM app for injection, leakage, and bias, red-team style.
 
 Limitations: that focus is the limitation — it answers "is this app vulnerable," not "did the agent do the task right." Different tool for a different question.
+
+### Container-native agentic: Terminal-Bench, SWE-bench, Vivaria
+
+Most of the tools above are prompt-shaped. A separate tier evaluates agents inside containers, which buys the three things agentic evals actually need: isolation (the agent can be given full permissions safely — exactly the sandbox fight I lost on my [codex runs](/ai-testing#grading-the-agent-with-smevals)), reproducibility (pinned task images), and parallelism.
+
+- **Terminal-Bench** — the closest cousin to my blog-edit eval, professionalized: each task is a Docker container with setup plus a verifier script, and it benchmarks the actual CLI harnesses — Claude Code, Codex, and friends — on terminal tasks.
+- **SWE-bench harness** — per-issue Docker images; grading is "do the repo's tests pass in the container." The agent layer (SWE-agent and descendants) attaches on top.
+- **METR Vivaria** — the platform METR runs dangerous-capability evals on; agents in containers against their Task Standard.
+
+Limitations: these are benchmark-first, not write-your-own-weekend-eval-first — standing up custom tasks means adopting their image conventions. And containers themselves are a dependency my dev VM can't meet: OrbStack machines block namespace creation outright, so anything container-native runs on the Mac host or a real Linux box, not here. smevals sits out this fight by being agnostic — its Runner is any executable, so it can `docker run` when a container runtime exists, but manages none of it for you.
 
 ### The SaaS tier: Braintrust, LangSmith, Langfuse
 

--- a/_d/ai-eval-tools.md
+++ b/_d/ai-eval-tools.md
@@ -105,7 +105,15 @@ Most of the tools above are prompt-shaped. A separate tier evaluates agents insi
 - **SWE-bench harness** — per-issue Docker images; grading is "do the repo's tests pass in the container." The agent layer (SWE-agent and descendants) attaches on top.
 - **METR Vivaria** — the platform METR runs dangerous-capability evals on; agents in containers against their Task Standard.
 
-Limitations: these are benchmark-first, not write-your-own-weekend-eval-first — standing up custom tasks means adopting their image conventions. And containers themselves are a dependency my dev VM can't meet: OrbStack machines block namespace creation outright, so anything container-native runs on the Mac host or a real Linux box, not here. smevals sits out this fight by being agnostic — its Runner is any executable, so it can `docker run` when a container runtime exists, but manages none of it for you.
+Limitations: these are benchmark-first, not write-your-own-weekend-eval-first — standing up custom tasks means adopting their image conventions. smevals sits out this fight by being agnostic — its Runner is any executable, so it can `docker run` when a container runtime exists, but manages none of it for you.
+
+#### Getting a container-capable VM on a Mac
+
+The catch on macOS, learned the hard way: OrbStack machines are shared-kernel containers, not full VMs — their runtime has no user-namespace support ([orbstack#2312](https://github.com/orbstack/orbstack/issues/2312)), so Docker, bubblewrap, and agent sandboxes all fail inside them by architecture, not configuration. What actually works:
+
+- **A real Linux VM** via [Lima](https://lima-vm.io) (`vmType: vz`) or UTM brings its own kernel — containers and sandboxes just work, on any Apple Silicon chip, no nested virtualization needed. That's the box for Terminal-Bench or a full-permission containerized harness.
+- **True VM-in-VM** (KVM inside the Linux VM) needs nested virtualization: M3 or later, macOS 15+, Linux guests only. UTM supports it; Lima behind a `nestedVirtualization: true` flag ([lima#2824](https://github.com/lima-vm/lima/issues/2824)); OrbStack [doesn't](https://github.com/orgs/orbstack/discussions/2074).
+- **Keep OrbStack** for what it's best at — the Docker engine itself and fast shared-kernel dev machines. Just don't expect a container runtime *inside* one.
 
 ### The SaaS tier: Braintrust, LangSmith, Langfuse
 

--- a/_d/ai-eval-tools.md
+++ b/_d/ai-eval-tools.md
@@ -23,6 +23,7 @@ Every time I want to compare models, prompts, or agent harnesses I trip over the
   - [Giskard (2.x)](#giskard-2x)
   - [Container-native agentic: Terminal-Bench, SWE-bench, Vivaria](#container-native-agentic-terminal-bench-swe-bench-vivaria)
   - [The SaaS tier: Braintrust, LangSmith, Langfuse](#the-saas-tier-braintrust-langsmith-langfuse)
+- [The shared anatomy: same concepts, different names](#the-shared-anatomy-same-concepts-different-names)
 - [Repo naming convention](#repo-naming-convention)
 
 <!-- vim-markdown-toc-end -->
@@ -120,6 +121,52 @@ The catch on macOS, learned the hard way: OrbStack machines are shared-kernel co
 Hosted eval-plus-observability platforms — datasets, judges, traces, dashboards, team features, CI history. If you want a team UI and longitudinal tracking, this tier is where it lives.
 
 Limitations for me: account-first, your data lives off-repo, and my evals are weekend-sized. A directory of runs I can grep beats a dashboard I have to log into.
+
+## The shared anatomy: same concepts, different names
+
+Strip the branding and every tool here is the same handful of concepts. Learning them once makes any tool's docs readable in minutes:
+
+1. **Case** — one exercise: an input plus expectations
+2. **Collection** — cases grouped into a runnable set
+3. **Target config** — the thing under test: model, prompt, or agent-plus-harness, with its parameters
+4. **Execution environment** — where the target actually runs: an in-process function call, a subprocess in a workdir, or a container
+5. **Run record** — the persisted attempt: output, artifacts, timing
+6. **Grader** — turns a run into a score: deterministic checks and/or LLM judges
+7. **Report** — aggregation across runs: leaderboards, rates, variance
+8. **Trace viewer** — per-run inspection when a number looks wrong
+
+The rosetta stone:
+
+| Concept     | smevals                 | PromptFoo         | Pydantic Evals    | Inspect AI              | DeepEval          | Terminal-Bench  |
+| ----------- | ----------------------- | ----------------- | ----------------- | ----------------------- | ----------------- | --------------- |
+| Collection  | Eval / Suite            | config `tests`    | Dataset           | Task                    | EvaluationDataset | dataset         |
+| Case        | Task                    | test              | Case              | Sample                  | LLMTestCase       | task            |
+| Target      | Config + Runner         | provider + prompt | your function     | solver + model          | your app code     | agent adapter   |
+| Execution   | any executable, workdir | in-process call   | Python call       | solver loop, opt docker | Python call       | Docker per task |
+| Run record  | `runs/` dir, immutable  | results cache     | report + OTel     | `.eval` log             | test results      | run logs        |
+| Grader      | Grader → Checkers       | assertions        | Evaluators, judge | Scorers                 | metrics (G-Eval)  | verifier script |
+| Report      | leaderboard CLI         | matrix viewer     | summary table     | log stats               | SaaS dashboard    | leaderboard     |
+| Trace view  | files + `serve`         | web UI            | Logfire           | `inspect view`          | Confident AI      | logs            |
+
+The first three concepts are commodity — every tool has cases, collections, and target configs, and choosing between tools on those is a wash. The separation happens on two axes:
+
+**Execution environment** is the agentic divide. Tools whose execution model is "call a function and look at the return value" (PromptFoo, DeepEval, Pydantic Evals) cannot naturally test an agent whose real output is filesystem side effects. Tools whose execution model is "spawn something in an environment and inspect what it did" (smevals, Terminal-Bench, Inspect-with-docker) can.
+
+**Run records + decoupled grading** is the iteration divide. If runs are immutable records and graders apply separately (smevals; Inspect can re-score logs), you improve graders for free against history. If assertions run inline with execution (PromptFoo, DeepEval), every grader idea re-bills you for every run.
+
+Capability grid against my [criteria](#what-i-want-from-an-eval-tool) — ✓ yes, ◐ partial/BYO, ✗ no:
+
+| Required feature       | smevals | PromptFoo | Pydantic | Inspect | DeepEval | T-Bench |
+| ---------------------- | ------- | --------- | -------- | ------- | -------- | ------- |
+| Agent-in-workdir       | ✓       | ✗         | ✗        | ◐       | ✗        | ✓       |
+| Container isolation    | ◐ BYO   | ✗         | ✗        | ✓       | ✗        | ✓       |
+| Deterministic graders  | ✓       | ✓         | ✓        | ✓       | ◐        | ✓       |
+| LLM judge              | ◐ BYO   | ✓         | ✓        | ✓       | ✓        | ◐       |
+| Decoupled re-grading   | ✓       | ✗         | ✗        | ✓       | ✗        | ◐       |
+| Trace viewer           | ◐       | ✓         | ◐ SaaS   | ✓       | ◐ SaaS   | ◐       |
+| Local-first            | ✓       | ✓         | ✓        | ✓       | ◐        | ✓       |
+
+Read column-wise and the survey's conclusions fall out: smevals and Terminal-Bench are the agentic pair (smevals for weekend-sized custom evals, Terminal-Bench for standardized harness benchmarks), Inspect is the heavyweight that covers the most boxes, and the prompt-shaped tools trade the two divides above for richer judge libraries and viewers.
 
 ## Repo naming convention
 

--- a/_d/ai-eval-tools.md
+++ b/_d/ai-eval-tools.md
@@ -1,0 +1,107 @@
+---
+layout: post
+title: AI Eval Tools
+permalink: /ai-eval-tools
+ai_default_image: true
+---
+
+Every time I want to compare models, prompts, or agent harnesses I trip over the same question: which eval tool? This page is a quick survey of the field to get a feel for what exists — not a considered review. I've only used two of these in anger, the versions move fast, and most of what follows will be stale by the time you read it.
+
+{% include ai-slop.html percent="95" %}
+
+<!-- prettier-ignore-start -->
+<!-- vim-markdown-toc-start -->
+
+- [What I want from an eval tool](#what-i-want-from-an-eval-tool)
+- [Our benchmark evals](#our-benchmark-evals)
+- [The tools](#the-tools)
+  - [smevals (0.2.0)](#smevals-020)
+  - [PromptFoo (0.121.x)](#promptfoo-0121x)
+  - [Pydantic Evals (2.x)](#pydantic-evals-2x)
+  - [Inspect AI (0.3.x)](#inspect-ai-03x)
+  - [DeepEval (4.x)](#deepeval-4x)
+  - [Giskard (2.x)](#giskard-2x)
+  - [The SaaS tier: Braintrust, LangSmith, Langfuse](#the-saas-tier-braintrust-langsmith-langfuse)
+- [Repo naming convention](#repo-naming-convention)
+
+<!-- vim-markdown-toc-end -->
+<!-- prettier-ignore-end -->
+
+## What I want from an eval tool
+
+Criteria, learned the hard way while building [my first real eval](/ai-testing#grading-the-agent-with-smevals):
+
+1. **Agent-in-a-workdir** — the unit under test is an agent mutating files through a harness (Claude Code, Codex), not prompt-in/completion-out
+2. **Deterministic checkers first** — string matches, git diffs, running my own tools as oracles. LLM judges are opt-in for quality, never the default gate
+3. **Decoupled grading** — runs are immutable records on disk; re-grade with a new grader without re-paying for the runs
+4. **Local-first** — plain files in a repo, no SaaS account before hello world
+5. **Cheap authoring** — YAML plus small scripts, not an SDK ceremony
+6. **Useful reports** — leaderboard by config × model, metric rates, per-task splits
+
+## Our benchmark evals
+
+The honest way to feel out a tool is to implement the same evals in each:
+
+**Blog page edit** — can an agent make a scoped edit to a page, keep the generated TOC byte-identical to toc.py's output, and touch nothing else? Built with smevals in [smevals-blog-edit-evals](https://github.com/idvorkin-ai-tools/smevals-blog-edit-evals); results and design in [Testing AI](/ai-testing#grading-the-agent-with-smevals).
+
+**Raccoon generator** — my recurring real need: generate a raccoon illustration in the blog's house style. Deterministic checks first (file exists, right format, transparent background, sane dimensions), then a vision judge for the parts only a judge can see: is it actually a raccoon, and does it match the style. Not built yet — it's next, and it forces the multimodal-judge question the blog-edit eval deliberately dodges.
+
+## The tools
+
+Versions as of 2026-08 — one quick signal of how alive each project is.
+
+### smevals (0.2.0)
+
+[smevals](https://github.com/prime-radiant-inc/smevals) is Simon Willison's framework, and the only one here designed for agent-harness evals out of the box. Filesystem-first: an eval is a directory of YAML, the Runner and Checkers are any executables, Runs are immutable, and grading is decoupled so new graders re-score old runs for free.
+
+Limitations: young. The released version lags its own README (`-n` isn't shipped, harness-failed runs still get graded), there are no built-in judge helpers (you write your own checker), and it's single-machine with no history service.
+
+Example: [smevals-blog-edit-evals](https://github.com/idvorkin-ai-tools/smevals-blog-edit-evals) — three tasks, three deterministic checkers, mock runners that validate the graders, plus an LLM-judge grader layered on after the fact.
+
+### PromptFoo (0.121.x)
+
+Config-driven prompt × provider × assertion matrix with a strong web viewer and a red-team mode. This is what I used before smevals — see the [funnier-LLM and git-summarizer examples](/ai-testing#examples).
+
+Limitations: the unit under test is prompt→completion. Testing an agent that edits a repo means custom-provider contortions, and assertions run coupled to the eval run — re-judging means re-running. Node ecosystem, if that matters to you.
+
+Example: my [PromptFoo test cases in the nlp repo](https://github.com/idvorkin/nlp/blob/1ca6b3f85895b2684596c8957f0a0bd5a7a5d4f1/eval/commit/diff_commit.json).
+
+### Pydantic Evals (2.x)
+
+From the Pydantic AI team. Python and typed: Datasets of Cases run through Evaluators, with an LLMJudge built in, OpenTelemetry tracing underneath, and a natural pairing with their Logfire service.
+
+Limitations: code-first — an eval is a Python program, not a directory of data, so non-Python harnesses feel bolted on. Running and grading are coupled, and the local reporting is basic unless you adopt Logfire. Gravity pulls you toward the Pydantic AI ecosystem.
+
+Example: none yet — when I try it, the repo will be named `pydantic-evals-something` per the convention below.
+
+### Inspect AI (0.3.x)
+
+The UK AI Safety Institute's framework, used for serious public benchmarks. Research-grade: tasks, solvers, and scorers in Python, sandboxed tool use, big parallelism, a good log viewer.
+
+Limitations: heavyweight authoring for weekend-sized evals, and the solver abstraction doesn't map cleanly onto driving an external CLI harness like Claude Code. Academic flavor throughout.
+
+Example: none yet.
+
+### DeepEval (4.x)
+
+Pytest-style evals with a large library of judge-based metrics — G-Eval, hallucination, RAG relevance, and friends.
+
+Limitations: judge-heavy by default (most metrics are an LLM call), the dashboards push you to their Confident AI SaaS, and like PromptFoo the unit is a completion, not an agent's side effects.
+
+Example: none yet.
+
+### Giskard (2.x)
+
+More scanner than eval harness: probes an LLM app for injection, leakage, and bias, red-team style.
+
+Limitations: that focus is the limitation — it answers "is this app vulnerable," not "did the agent do the task right." Different tool for a different question.
+
+### The SaaS tier: Braintrust, LangSmith, Langfuse
+
+Hosted eval-plus-observability platforms — datasets, judges, traces, dashboards, team features, CI history. If you want a team UI and longitudinal tracking, this tier is where it lives.
+
+Limitations for me: account-first, your data lives off-repo, and my evals are weekend-sized. A directory of runs I can grep beats a dashboard I have to log into.
+
+## Repo naming convention
+
+Every tool I actually try gets its example checked into a repo named after the tool — `smevals-blog-edit-evals` today, `pydantic-evals-raccoon-gen` when it happens — so the examples don't get lost behind generic repo names.

--- a/_d/ai-testing.md
+++ b/_d/ai-testing.md
@@ -157,15 +157,16 @@ My first one: [blog-edit-evals](https://github.com/idvorkin-ai-tools/blog-edit-e
 
 Three tasks: add a section, rename a heading, and fix a body typo — the last one is a trap, since the TOC must NOT change. Each runs against headless Claude Code as the harness.
 
-First results (2026-08, Claude Code as the harness):
+First results (2026-08):
 
-| Config                 | Runs | Edit landed | TOC correct | No collateral | Avg diff lines |
-| ---------------------- | ---- | ----------- | ----------- | ------------- | -------------- |
-| sonnet                 | 9    | 100%        | 100%        | 100%          | 4.6            |
-| haiku                  | 10   | 100%        | 100%        | 100%          | 3.7            |
-| mock-bad (grader test) | 3    | 100%        | 33%         | 0%            | -              |
+| Config                                   | Runs | Edit landed | TOC correct | No collateral | Avg diff lines |
+| ---------------------------------------- | ---- | ----------- | ----------- | ------------- | -------------- |
+| sonnet · Claude Code                     | 9    | 100%        | 100%        | 100%          | 4.6            |
+| haiku · Claude Code                      | 11   | 100%        | 100%        | 100%          | 3.7            |
+| gpt-5.4-mini · Codex CLI, zero reasoning | 10   | 70%         | 100%        | 100%          | 3.0            |
+| mock-bad (grader test)                   | 3    | 100%        | 33%         | 0%            | -              |
 
-Both models pass everything, including zero TOC churn on the trap task. So today this eval is saturated - its job is to catch the regression when I swap the harness, the model, or the conventions file. The harder variants are where I expect separation: drop the CLAUDE.md hints, use full-size pages, make edits that span files.
+Both Claude configs pass everything, including zero TOC churn on the trap task. The deliberately dumb Codex config (mini model, reasoning effort none, sandbox replaced by a pre-approved command allowlist since its bwrap sandbox can't spawn in my VM) broke the saturation: 3 of its 10 runs fail, and every failure is a give-up after the first blocked edit attempt - never a wrong edit. When it does act, the TOC and collateral checks stay clean. Which surfaces the real lesson: the permission envelope is part of the harness under test, not just the model. Next variants: drop the CLAUDE.md hints, use full-size pages, make edits that span files.
 
 The graders themselves get tested with a pair of mock runners — a known-good one that must always pass, and a sloppy one (skips the TOC regen, leaves a scratch file behind) that must always fail. If your checkers have never failed a bad run on purpose, you don't know that they work.
 

--- a/_d/ai-testing.md
+++ b/_d/ai-testing.md
@@ -22,6 +22,7 @@ Testing math is easy, it's right or wrong. Testing spelling is easy too, but tes
 - [Eval Systems](#eval-systems)
   - [Human-based blind taste tests Chatbot arena](#human-based-blind-taste-tests-chatbot-arena)
   - [Eval Data Sets](#eval-data-sets)
+  - [Grading the agent with smevals](#grading-the-agent-with-smevals)
 - [Testing Theory](#testing-theory)
   - [Good books](#good-books)
   - [Simplest form of testing](#simplest-form-of-testing)
@@ -120,6 +121,8 @@ Testing this is normally a PITA with me doing manual testing, let's see if I can
 
 Let's start with promptfoo
 
+Update 2026-08: this itch finally became a real eval — see [Grading the agent with smevals](#grading-the-agent-with-smevals).
+
 ## Eval Systems
 
 A good eval isn't the finish line — it's the scoring function that drives a search loop. Once you have one that's cheap, unambiguous, and aligned with what you actually want, the agent can run [eval-driven hill climbing](/hill-climbing) while you look at the final result. The systems below are what make that scoring cheap and repeatable.
@@ -141,6 +144,30 @@ _The Elo system, however, adjusts a player’s rating based on the expected outc
 Building good "generic" eval data sets is hard, here are some:
 
 - [Big Bench](https://github.com/suzgunmirac/BIG-Bench-Hard/tree/main) - a bunch of hard question prompts
+
+### Grading the agent with smevals
+
+Most eval tools, PromptFoo included, treat the unit under test as prompt in, completion out. That stops working once the thing I'm testing is an agent mutating a repo. [smevals](https://github.com/prime-radiant-inc/smevals) — Simon Willison's eval framework — handles this case: the Runner is any executable (so it can drive Claude Code or Codex in a working directory), and grading is decoupled from running (Runs are immutable records on disk, so I can re-grade old runs with a new Grader without paying for the runs again). Checkers are also just executables that share a workspace, so a check can run git diff or the project's own tooling instead of asking an LLM judge.
+
+My first one: [blog-edit-evals](https://github.com/idvorkin-ai-tools/blog-edit-evals). Every post on this blog keeps a generated table of contents, and what I actually care about when an agent edits a page is: did it make the change, did it regenerate the TOC, and did it leave everything else alone. Three deterministic checkers, no judge required:
+
+- **expected-content** — the requested change landed in the file, not just in the chat reply
+- **toc-correct** — regenerating the TOC with my own toc.py must be a byte-level no-op (the repo's tool is the oracle)
+- **no-collateral** — git status against a baseline commit shows only the target file changed, frontmatter untouched, plus a diff-line count that catches agents rewriting the whole file to fix one word
+
+Three tasks: add a section, rename a heading, and fix a body typo — the last one is a trap, since the TOC must NOT change. Each runs against headless Claude Code as the harness.
+
+First results (2026-08, Claude Code as the harness):
+
+| Config                 | Runs | Edit landed | TOC correct | No collateral | Avg diff lines |
+| ---------------------- | ---- | ----------- | ----------- | ------------- | -------------- |
+| sonnet                 | 9    | 100%        | 100%        | 100%          | 4.6            |
+| haiku                  | 10   | 100%        | 100%        | 100%          | 3.7            |
+| mock-bad (grader test) | 3    | 100%        | 33%         | 0%            | -              |
+
+Both models pass everything, including zero TOC churn on the trap task. So today this eval is saturated - its job is to catch the regression when I swap the harness, the model, or the conventions file. The harder variants are where I expect separation: drop the CLAUDE.md hints, use full-size pages, make edits that span files.
+
+The graders themselves get tested with a pair of mock runners — a known-good one that must always pass, and a sloppy one (skips the TOC regen, leaves a scratch file behind) that must always fail. If your checkers have never failed a bad run on purpose, you don't know that they work.
 
 ## Testing Theory
 

--- a/_d/ai-testing.md
+++ b/_d/ai-testing.md
@@ -155,7 +155,7 @@ My first one: [blog-edit-evals](https://github.com/idvorkin-ai-tools/blog-edit-e
 - **toc-correct** — regenerating the TOC with my own toc.py must be a byte-level no-op (the repo's tool is the oracle)
 - **no-collateral** — git status against a baseline commit shows only the target file changed, frontmatter untouched, plus a diff-line count that catches agents rewriting the whole file to fix one word
 
-Three tasks: add a section, rename a heading, and fix a body typo — the last one is a trap, since the TOC must NOT change. Each runs against headless Claude Code as the harness.
+Three tasks: add a section, rename a heading, and fix a body typo — the last one is a trap, since the TOC must NOT change. Each runs headless against the harness under test — Claude Code and Codex CLI so far.
 
 First results (2026-08):
 

--- a/_d/ai-testing.md
+++ b/_d/ai-testing.md
@@ -159,14 +159,16 @@ Three tasks: add a section, rename a heading, and fix a body typo — the last o
 
 First results (2026-08):
 
-| Config                                   | Runs | Edit landed | TOC correct | No collateral | Avg diff lines |
-| ---------------------------------------- | ---- | ----------- | ----------- | ------------- | -------------- |
-| sonnet · Claude Code                     | 9    | 100%        | 100%        | 100%          | 4.6            |
-| haiku · Claude Code                      | 11   | 100%        | 100%        | 100%          | 3.7            |
-| gpt-5.4-mini · Codex CLI, zero reasoning | 10   | 70%         | 100%        | 100%          | 3.0            |
-| mock-bad (grader test)                   | 3    | 100%        | 33%         | 0%            | -              |
+| Config                                   | Runs | Edit landed | TOC correct | No collateral | Judge score |
+| ---------------------------------------- | ---- | ----------- | ----------- | ------------- | ----------- |
+| sonnet · Claude Code                     | 9    | 100%        | 100%        | 100%          | 0.99        |
+| haiku · Claude Code                      | 11   | 100%        | 100%        | 100%          | 0.96        |
+| gpt-5.4-mini · Codex CLI, zero reasoning | 10   | 70%         | 100%        | 100%          | 0.70        |
+| mock-bad (grader test)                   | 3    | 100%        | 33%         | 0%            | 0.61        |
 
-Both Claude configs pass everything, including zero TOC churn on the trap task. The deliberately dumb Codex config (mini model, reasoning effort none, sandbox replaced by a pre-approved command allowlist since its bwrap sandbox can't spawn in my VM) broke the saturation: 3 of its 10 runs fail, and every failure is a give-up after the first blocked edit attempt - never a wrong edit. When it does act, the TOC and collateral checks stay clean. Which surfaces the real lesson: the permission envelope is part of the harness under test, not just the model. Next variants: drop the CLAUDE.md hints, use full-size pages, make edits that span files.
+Both Claude configs pass everything, including zero TOC churn on the trap task. The deliberately dumb Codex config (mini model, reasoning effort none, sandbox replaced by a pre-approved command allowlist since its bwrap sandbox can't spawn in my VM) broke the saturation: 3 of its 10 runs fail, and every failure is a give-up after the first blocked edit attempt - never a wrong edit. When it does act, the TOC and collateral checks stay clean. Which surfaces the real lesson: the permission envelope is part of the harness under test, not just the model.
+
+The judge column is a second grader — an LLM judge scoring correctness, voice match, and scope from the diff — layered on after the fact, since decoupled grading re-scores old runs for free. It found the daylight the deterministic checks can't see: sonnet 0.99 vs haiku 0.96 (haiku gets docked for details like unspaced em-dashes on a page that uses spaced hyphens), while an empty diff short-circuits to 0 with no LLM call. Deterministic graders stay the gate; the judge adds the quality axis. Next variants: drop the CLAUDE.md hints, use full-size pages, make edits that span files.
 
 The graders themselves get tested with a pair of mock runners — a known-good one that must always pass, and a sloppy one (skips the TOC regen, leaves a scratch file behind) that must always fail. If your checkers have never failed a bad run on purpose, you don't know that they work.
 

--- a/_d/ai-testing.md
+++ b/_d/ai-testing.md
@@ -149,7 +149,7 @@ Building good "generic" eval data sets is hard, here are some:
 
 Most eval tools, PromptFoo included, treat the unit under test as prompt in, completion out. That stops working once the thing I'm testing is an agent mutating a repo. [smevals](https://github.com/prime-radiant-inc/smevals) — Simon Willison's eval framework — handles this case: the Runner is any executable (so it can drive Claude Code or Codex in a working directory), and grading is decoupled from running (Runs are immutable records on disk, so I can re-grade old runs with a new Grader without paying for the runs again). Checkers are also just executables that share a workspace, so a check can run git diff or the project's own tooling instead of asking an LLM judge.
 
-My first one: [blog-edit-evals](https://github.com/idvorkin-ai-tools/blog-edit-evals). Every post on this blog keeps a generated table of contents, and what I actually care about when an agent edits a page is: did it make the change, did it regenerate the TOC, and did it leave everything else alone. Three deterministic checkers, no judge required:
+My first one: [smevals-blog-edit-evals](https://github.com/idvorkin-ai-tools/smevals-blog-edit-evals). Every post on this blog keeps a generated table of contents, and what I actually care about when an agent edits a page is: did it make the change, did it regenerate the TOC, and did it leave everything else alone. Three deterministic checkers, no judge required:
 
 - **expected-content** — the requested change landed in the file, not just in the chat reply
 - **toc-correct** — regenerating the TOC with my own toc.py must be a byte-level no-op (the repo's tool is the oracle)
@@ -169,6 +169,8 @@ First results (2026-08):
 Both Claude configs pass everything, including zero TOC churn on the trap task. The deliberately dumb Codex config (mini model, reasoning effort none, sandbox replaced by a pre-approved command allowlist since its bwrap sandbox can't spawn in my VM) broke the saturation: 3 of its 10 runs fail, and every failure is a give-up after the first blocked edit attempt - never a wrong edit. When it does act, the TOC and collateral checks stay clean. Which surfaces the real lesson: the permission envelope is part of the harness under test, not just the model. Next variants: drop the CLAUDE.md hints, use full-size pages, make edits that span files.
 
 The graders themselves get tested with a pair of mock runners — a known-good one that must always pass, and a sloppy one (skips the TOC regen, leaves a scratch file behind) that must always fail. If your checkers have never failed a bad run on purpose, you don't know that they work.
+
+For a survey of the wider tool field — PromptFoo, Pydantic Evals, Inspect AI, and the SaaS tier — see [AI Eval Tools](/ai-eval-tools).
 
 ## Testing Theory
 

--- a/back-links.json
+++ b/back-links.json
@@ -423,7 +423,7 @@
                 "/y25",
                 "/y26"
             ],
-            "last_modified": "2026-06-07T11:08:11-07:00",
+            "last_modified": "2026-07-14T13:40:07+02:00",
             "markdown_path": "_d/42.md",
             "outgoing_links": [
                 "/chapters",
@@ -485,7 +485,7 @@
                 "/timeoff-2020-12",
                 "/win-win"
             ],
-            "last_modified": "2025-07-20T19:26:41-07:00",
+            "last_modified": "2026-07-14T04:50:44+00:00",
             "markdown_path": "_posts/2018-01-04-7-habits.md",
             "outgoing_links": [
                 "/7h-concepts",
@@ -516,7 +516,7 @@
                 "/sharpen-the-saw",
                 "/writing"
             ],
-            "last_modified": "2026-05-10T10:03:10-07:00",
+            "last_modified": "2026-07-13T19:49:39+02:00",
             "markdown_path": "_d/7h-c0.md",
             "outgoing_links": [
                 "/7-habits",
@@ -615,7 +615,7 @@
             "incoming_links": [
                 "/timeoff-2026-07"
             ],
-            "last_modified": "2026-04-14T20:26:12-07:00",
+            "last_modified": "2026-07-19T05:20:21-07:00",
             "markdown_path": "_d/act.md",
             "outgoing_links": [
                 "/addiction",
@@ -677,12 +677,12 @@
         },
         "/adblocker-trojan": {
             "description": "Out of the blue I started seeing ads in my google search. They were especially prominent due to the fact they were white, and I use a black background. It was caused by a trojan running in my chrome extension, which I suspect was installed by a name-jacked NPM plugin.\n\n",
-            "doc_size": 16000,
+            "doc_size": 17000,
             "file_path": "_site/adblocker-trojan.html",
             "incoming_links": [
                 "/timeoff-2021-11"
             ],
-            "last_modified": "2024-10-05T21:35:59-07:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_td/adblocker_trojan.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -958,6 +958,22 @@
             "title": "AI Developer",
             "url": "/ai-developer"
         },
+        "/ai-eval-tools": {
+            "description": "Every time I want to compare models, prompts, or agent harnesses I trip over the same question: which eval tool? This page is a quick survey of the field to get a feel for what exists — not a considered review. I’ve only used two of these in anger, the versions move fast, and most of what follows will be stale by the time you read it.\n\n",
+            "doc_size": 20000,
+            "file_path": "_site/ai-eval-tools.html",
+            "incoming_links": [
+                "/ai-testing"
+            ],
+            "last_modified": "2026-08-02T12:47:16.292502+00:00",
+            "markdown_path": "_d/ai-eval-tools.md",
+            "outgoing_links": [
+                "/ai-testing"
+            ],
+            "redirect_url": "",
+            "title": "AI Eval Tools",
+            "url": "/ai-eval-tools"
+        },
         "/ai-faq": {
             "description": "Questions I keep getting asked about AI, and my current (probably wrong) answers. The ones that don’t resolve cleanly.\n\n",
             "doc_size": 24000,
@@ -1052,7 +1068,7 @@
                 "/ai-art",
                 "/ai-training"
             ],
-            "last_modified": "2026-06-07T10:19:45-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/ai-imagegen.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -1066,7 +1082,7 @@
             "incoming_links": [
                 "/ai-training"
             ],
-            "last_modified": "2026-06-07T10:19:45-07:00",
+            "last_modified": "2026-07-22T07:40:48-07:00",
             "markdown_path": "_d/ai-inference.md",
             "outgoing_links": [
                 "/ai-faq",
@@ -1184,7 +1200,7 @@
         },
         "/ai-native-vocab": {
             "description": "AI is spawning a whole new vocabulary — some of it genuinely useful, some of it pure hype. This is my running glossary of the terms worth knowing, with my take on what each one actually means and why it matters. It’s the companion glossary to The AI Native Engineering Manager.\n\n",
-            "doc_size": 35000,
+            "doc_size": 37000,
             "file_path": "_site/ai-native-vocab.html",
             "incoming_links": [
                 "/ai-native-manager",
@@ -1194,7 +1210,7 @@
                 "/explainers",
                 "/pet-projects"
             ],
-            "last_modified": "2026-06-13T10:34:10-07:00",
+            "last_modified": "2026-07-19T05:42:22-07:00",
             "markdown_path": "_d/ai-native-vocab.md",
             "outgoing_links": [
                 "/agency",
@@ -1325,7 +1341,7 @@
                 "/claw",
                 "/hyper-personal"
             ],
-            "last_modified": "2026-03-14T16:03:56-07:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_d/ai-second-brain.md",
             "outgoing_links": [
                 "/ai-cockpit",
@@ -1363,10 +1379,11 @@
         },
         "/ai-testing": {
             "description": "Testing math is easy, it’s right or wrong. Testing spelling is easy too, but testing if a joke is funny - now that’s tough. Let’s talk about how to test AI.\n\n",
-            "doc_size": 23000,
+            "doc_size": 27000,
             "file_path": "_site/ai-testing.html",
             "incoming_links": [
                 "/ai",
+                "/ai-eval-tools",
                 "/ai-training",
                 "/chop",
                 "/genai-talk",
@@ -1375,9 +1392,10 @@
                 "/testing",
                 "/timeoff-2024-04"
             ],
-            "last_modified": "2026-06-07T10:19:45-07:00",
+            "last_modified": "2026-08-02T12:38:41+00:00",
             "markdown_path": "_d/ai-testing.md",
             "outgoing_links": [
+                "/ai-eval-tools",
                 "/hill-climbing"
             ],
             "redirect_url": "",
@@ -1565,7 +1583,7 @@
             "incoming_links": [
                 "/tools"
             ],
-            "last_modified": "2024-09-22T16:18:28-07:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_td/ast-grep.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -1607,7 +1625,7 @@
                 "/knee-pain",
                 "/physical-pain"
             ],
-            "last_modified": "2026-01-01T17:03:05+00:00",
+            "last_modified": "2026-07-14T06:28:56+02:00",
             "markdown_path": "_d/back-pain.md",
             "outgoing_links": [
                 "/coe",
@@ -1635,7 +1653,7 @@
                 "/slow",
                 "/timeoff-2021-12"
             ],
-            "last_modified": "2025-08-24T10:29:13-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/balance2.md",
             "outgoing_links": [
                 "/7-habits",
@@ -1679,10 +1697,10 @@
         },
         "/bc": {
             "description": "A guide to my favorite spots in British Columbia, focusing on Vancouver and Chilliwack. Whether you’re planning a quick weekend getaway or a longer adventure, here’s what you need to know. These recommendations come from my personal experiences over multiple trips - you can read about some of them in my summer 2024 adventures, Yellow Deli expedition, and various time off adventures:\n\n",
-            "doc_size": 22000,
+            "doc_size": 23000,
             "file_path": "_site/bc.html",
             "incoming_links": [],
-            "last_modified": "2025-12-07T03:02:44+00:00",
+            "last_modified": "2026-07-19T05:20:21-07:00",
             "markdown_path": "_d/bc-vacation.md",
             "outgoing_links": [
                 "/ig66/718",
@@ -1717,7 +1735,7 @@
                 "/untangled",
                 "/words-we-dont-have"
             ],
-            "last_modified": "2026-05-11T07:16:52-07:00",
+            "last_modified": "2026-07-13T19:49:39+02:00",
             "markdown_path": "_d/7h-c1.md",
             "outgoing_links": [
                 "/7-habits",
@@ -1813,7 +1831,7 @@
                 "/sleep",
                 "/timeoff-2024-02"
             ],
-            "last_modified": "2025-12-06T18:03:02-08:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_d/blueprint.md",
             "outgoing_links": [
                 "/ig66/663",
@@ -1830,7 +1848,7 @@
             "incoming_links": [
                 "/job-hunt-stress"
             ],
-            "last_modified": "2025-12-07T02:39:31+00:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_d/bmu.md",
             "outgoing_links": [
                 "/being-a-great-manager",
@@ -1873,7 +1891,7 @@
             "incoming_links": [
                 "/be-proactive"
             ],
-            "last_modified": "2026-03-21T12:32:21-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/breath.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -2030,12 +2048,12 @@
         },
         "/changelog": {
             "description": "A weekly summary of what changed on this blog and across my GitHub projects. Useful for returning readers who want to catch up on new content and updates.\n\n",
-            "doc_size": 256000,
+            "doc_size": 269000,
             "file_path": "_site/changelog.html",
             "incoming_links": [
                 "/timeoff-2026-07"
             ],
-            "last_modified": "2026-07-07T15:13:25+02:00",
+            "last_modified": "2026-07-20T14:52:14+00:00",
             "markdown_path": "_d/changelog.md",
             "outgoing_links": [
                 "/42",
@@ -2095,6 +2113,7 @@
                 "/mortality-software",
                 "/mosh",
                 "/packing",
+                "/performer-playbook",
                 "/physical-pain",
                 "/podcast",
                 "/produce-consume",
@@ -2105,6 +2124,7 @@
                 "/sharpen-the-saw",
                 "/shoulder-pain",
                 "/side-quests",
+                "/sleight-of-mouth",
                 "/spiritual-health",
                 "/synergy",
                 "/taxes",
@@ -2156,7 +2176,7 @@
                 "/gap-year-igor",
                 "/last-year"
             ],
-            "last_modified": "2025-12-07T02:39:31+00:00",
+            "last_modified": "2026-07-19T05:20:21-07:00",
             "markdown_path": "_d/chasing-daylight.md",
             "outgoing_links": [
                 "/death",
@@ -2195,7 +2215,7 @@
                 "/y25",
                 "/y26"
             ],
-            "last_modified": "2026-06-07T10:19:45-07:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_d/ai-coder.md",
             "outgoing_links": [
                 "/ai-journal",
@@ -2348,7 +2368,7 @@
                 "/manager-book",
                 "/work-satisfaction"
             ],
-            "last_modified": "2024-10-05T21:35:59-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_posts/2017-11-16-understandingtechcompensation.md",
             "outgoing_links": [
                 "/job-hunt-stress",
@@ -2491,7 +2511,7 @@
             "doc_size": 18000,
             "file_path": "_site/d/2016-2-15-Seth-Godin-Notes.html",
             "incoming_links": [],
-            "last_modified": "2025-12-07T02:26:29+00:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_d/2016-2-15-Seth-Godin-Notes.md",
             "outgoing_links": [
                 "/dip",
@@ -2545,7 +2565,7 @@
                 "/d/where-have-all-the-bugs-gone",
                 "/how-igor-chops"
             ],
-            "last_modified": "2025-12-07T02:26:29+00:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_d/2017-09-10-software-rot.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -2655,7 +2675,7 @@
             "doc_size": 14000,
             "file_path": "_site/d/where-have-all-the-bugs-gone.html",
             "incoming_links": [],
-            "last_modified": "2022-08-13T08:09:48-07:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_d/where-have-all-the-bugs-gone.md",
             "outgoing_links": [
                 "/d/2017-09-10-software-rot"
@@ -2683,7 +2703,7 @@
         },
         "/day-in-the-life": {
             "description": "A running journal of days that actually worked - the ones where health habits stuck, family time hit different, or I remembered what it feels like to be fully alive. Not every day needs to be Instagram-worthy, but some days deserve a bookmark. This is that bookmark collection.\n\n",
-            "doc_size": 18000,
+            "doc_size": 19000,
             "file_path": "_site/day-in-the-life.html",
             "incoming_links": [],
             "last_modified": "2025-10-04T18:43:51-07:00",
@@ -2710,7 +2730,7 @@
                 "/mortality-software",
                 "/psychic-weight"
             ],
-            "last_modified": "2025-08-22T11:54:12-07:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_d/on-being-mortal.md",
             "outgoing_links": [
                 "/last-year",
@@ -2792,7 +2812,7 @@
                 "/mental-pain",
                 "/mood"
             ],
-            "last_modified": "2025-12-06T18:03:14-08:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_d/depression.md",
             "outgoing_links": [
                 "/7-habits",
@@ -2948,7 +2968,7 @@
                 "/sublime",
                 "/walking-with-god"
             ],
-            "last_modified": "2026-03-21T12:32:21-07:00",
+            "last_modified": "2026-07-14T06:28:56+02:00",
             "markdown_path": "_d/emotional-health-hold.md",
             "outgoing_links": [
                 "/fit-in-my-head",
@@ -2968,7 +2988,7 @@
             "incoming_links": [
                 "/untangled"
             ],
-            "last_modified": "2026-05-16T14:06:25-07:00",
+            "last_modified": "2026-07-19T05:20:21-07:00",
             "markdown_path": "_d/emotional-lives.md",
             "outgoing_links": [
                 "/anxiety",
@@ -3052,7 +3072,7 @@
                 "/siy",
                 "/walking-with-god"
             ],
-            "last_modified": "2026-05-11T07:14:49-07:00",
+            "last_modified": "2026-07-13T19:49:39+02:00",
             "markdown_path": "_d/7h-c2.md",
             "outgoing_links": [
                 "/7-habits",
@@ -3301,7 +3321,7 @@
                 "/frog",
                 "/raccoon-history"
             ],
-            "last_modified": "2026-05-11T07:14:49-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/7h-c3.md",
             "outgoing_links": [
                 "/4dx",
@@ -3339,7 +3359,7 @@
                 "/win-win",
                 "/work-satisfaction"
             ],
-            "last_modified": "2026-05-11T07:14:49-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/7h-c5.md",
             "outgoing_links": [
                 "/7-habits",
@@ -3362,7 +3382,7 @@
             "incoming_links": [
                 "/emotional-health"
             ],
-            "last_modified": "2025-07-20T19:26:41-07:00",
+            "last_modified": "2026-07-14T06:28:56+02:00",
             "markdown_path": "_d/2016-2-14-Health-In-The-Head.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -3443,7 +3463,7 @@
                 "/timeoff",
                 "/timeoff-2020-03"
             ],
-            "last_modified": "2025-04-02T21:53:46-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/frog.md",
             "outgoing_links": [
                 "/Immutable-Laws-Of-Hard",
@@ -3693,7 +3713,7 @@
         },
         "/grammerly": {
             "description": "\n\n",
-            "doc_size": 12000,
+            "doc_size": 13000,
             "file_path": "_site/grammerly.html",
             "incoming_links": [],
             "last_modified": "2025-08-24T09:03:19-07:00",
@@ -3740,7 +3760,7 @@
                 "/raccoon-history",
                 "/religion"
             ],
-            "last_modified": "2026-03-01T14:23:50-08:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_d/greek-orthodox.md",
             "outgoing_links": [
                 "/7h-concepts",
@@ -3896,7 +3916,7 @@
                 "/operating-manual",
                 "/retire"
             ],
-            "last_modified": "2026-05-01T08:03:22-07:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_d/hobby.md",
             "outgoing_links": [
                 "/addiction",
@@ -3931,7 +3951,7 @@
                 "/y25",
                 "/y26"
             ],
-            "last_modified": "2026-04-16T19:46:21-07:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_d/how-igor-chops.md",
             "outgoing_links": [
                 "/40yo",
@@ -4096,7 +4116,7 @@
                 "/physical-health",
                 "/sleep"
             ],
-            "last_modified": "2025-07-20T19:26:41-07:00",
+            "last_modified": "2026-07-14T06:28:56+02:00",
             "markdown_path": "_d/2016-2-11-Insomnia.md",
             "outgoing_links": [
                 "/sleep"
@@ -4112,7 +4132,7 @@
             "incoming_links": [
                 "/job-hunt-stress"
             ],
-            "last_modified": "2023-12-17T18:53:39+00:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_posts/2016-11-26-interviewsarehard.markdown",
             "outgoing_links": [
                 "/the-recruiter-does-not-think-you-are-hot"
@@ -4141,7 +4161,7 @@
                 "/physical-health",
                 "/td/ios-nomad"
             ],
-            "last_modified": "2026-04-05T14:17:43-07:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_td/irl.md",
             "outgoing_links": [
                 "/bike",
@@ -4192,7 +4212,7 @@
                 "/manager-book",
                 "/work-satisfaction"
             ],
-            "last_modified": "2025-08-24T09:03:19-07:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_posts/2017-02-17-job-hunt-stress.md",
             "outgoing_links": [
                 "/bmy",
@@ -4209,7 +4229,7 @@
         },
         "/joy": {
             "description": "If you could have one superpower, what would it be? At 46, you’d think I’d have a quick answer, but the usual ideas—flying, invisibility, stopping time—felt childish. Probably the setting: a circle of 9-17-year-olds, breaking the ice, sharing their wished-for superpowers. As my mind scrambled, a mild panic set in. Nothing surfaced—until a bit of my eulogy came to me: Igor lived to see eyes go wide and mouths gape with wonder. He loved when strangers were drawn in against their objections, when a kid in meltdown, or an adult weighed down by life, forgot their troubles. Relief washed over me, I knew my answer. The super power I wished for:  bringing joy to others.\n\n",
-            "doc_size": 34000,
+            "doc_size": 35000,
             "file_path": "_site/joy.html",
             "incoming_links": [
                 "/affirmations",
@@ -4227,7 +4247,7 @@
                 "/timeoff-2026-07",
                 "/tribe"
             ],
-            "last_modified": "2026-07-09T04:37:41-07:00",
+            "last_modified": "2026-07-20T19:36:53-07:00",
             "markdown_path": "_d/joy.md",
             "outgoing_links": [
                 "/balloon",
@@ -4273,7 +4293,7 @@
                 "/untangled",
                 "/y24"
             ],
-            "last_modified": "2026-01-01T17:07:34+00:00",
+            "last_modified": "2026-07-14T06:28:56+02:00",
             "markdown_path": "_d/bells.md",
             "outgoing_links": [
                 "/shoulder-pain"
@@ -4453,7 +4473,7 @@
             "incoming_links": [
                 "/joy"
             ],
-            "last_modified": "2026-01-03T17:27:23+00:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/the-like-switch.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -4469,7 +4489,7 @@
                 "/build-life-you-want",
                 "/mental-pain"
             ],
-            "last_modified": "2025-12-07T02:40:46+00:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/lonely.md",
             "outgoing_links": [
                 "/chapters"
@@ -4615,7 +4635,7 @@
                 "/energy",
                 "/mood"
             ],
-            "last_modified": "2024-10-05T21:35:59-07:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_d/mania.md",
             "outgoing_links": [
                 "/emotional-health",
@@ -4635,7 +4655,7 @@
                 "/mental-pain",
                 "/timeoff-2026-07"
             ],
-            "last_modified": "2026-07-06T23:30:18-07:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_d/maybe.md",
             "outgoing_links": [
                 "/7h-concepts",
@@ -4673,7 +4693,7 @@
                 "/y24",
                 "/y25"
             ],
-            "last_modified": "2025-12-06T18:03:43-08:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_d/mental-pain.md",
             "outgoing_links": [
                 "/addiction",
@@ -4691,7 +4711,7 @@
         },
         "/mermaid": {
             "description": "Lets try d2\n\n",
-            "doc_size": 14000,
+            "doc_size": 15000,
             "file_path": "_site/mermaid.html",
             "incoming_links": [],
             "last_modified": "2023-12-17T18:49:14+00:00",
@@ -4709,7 +4729,7 @@
                 "/manager-book-appendix",
                 "/timeoff-2026-07"
             ],
-            "last_modified": "2026-05-25T19:31:05-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/facebook.md",
             "outgoing_links": [
                 "/chop",
@@ -4789,7 +4809,7 @@
                 "/negative-mitzvahs",
                 "/positive-mitzvahs"
             ],
-            "last_modified": "2026-01-03T17:27:23+00:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_d/mitzvahs.md",
             "outgoing_links": [
                 "/negative-mitzvahs",
@@ -5028,7 +5048,7 @@
                 "/win-win",
                 "/work-satisfaction"
             ],
-            "last_modified": "2025-12-07T02:46:00+00:00",
+            "last_modified": "2026-07-14T04:50:44+00:00",
             "markdown_path": "_d/gty.md",
             "outgoing_links": [
                 "/curious",
@@ -5162,7 +5182,7 @@
             "incoming_links": [
                 "/tools"
             ],
-            "last_modified": "2026-04-03T15:42:12-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/osx.md",
             "outgoing_links": [
                 "/keyboard",
@@ -5179,7 +5199,7 @@
             "incoming_links": [
                 "/gtd"
             ],
-            "last_modified": "2025-09-13T16:07:47-07:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_d/2015-11-18-Outsourcing.md",
             "outgoing_links": [
                 "/the-recruiter-does-not-think-you-are-hot"
@@ -5323,7 +5343,7 @@
                 "/side-quests",
                 "/y25"
             ],
-            "last_modified": "2026-06-06T11:23:00-07:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_d/pet-projects.md",
             "outgoing_links": [
                 "/ai-native-vocab",
@@ -5358,7 +5378,7 @@
                 "/sharpen-the-saw",
                 "/tech-health-toys"
             ],
-            "last_modified": "2026-03-21T12:32:21-07:00",
+            "last_modified": "2026-07-14T06:28:56+02:00",
             "markdown_path": "_posts/2017-10-07-physical-health.md",
             "outgoing_links": [
                 "/d/habits",
@@ -5388,7 +5408,7 @@
                 "/sleight-of-mouth",
                 "/y25"
             ],
-            "last_modified": "2026-07-12T08:48:30+02:00",
+            "last_modified": "2026-07-14T06:28:56+02:00",
             "markdown_path": "_d/physical-pain.md",
             "outgoing_links": [
                 "/back-pain",
@@ -5412,7 +5432,7 @@
                 "/manager-book",
                 "/y25"
             ],
-            "last_modified": "2026-01-01T14:34:49+00:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/planning.md",
             "outgoing_links": [
                 "/activation",
@@ -5477,7 +5497,7 @@
                 "/mind-monsters",
                 "/psychic-weight"
             ],
-            "last_modified": "2024-10-05T21:35:59-07:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_posts/2018-01-01-fuck-pride.md",
             "outgoing_links": [
                 "/decisive"
@@ -5501,7 +5521,7 @@
                 "/pet-projects",
                 "/y24"
             ],
-            "last_modified": "2026-07-07T05:46:52-07:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_d/process-journal.md",
             "outgoing_links": [
                 "/affirmations",
@@ -5568,7 +5588,7 @@
                 "/energy",
                 "/timeoff-2022-02"
             ],
-            "last_modified": "2025-12-21T15:38:26+00:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_d/productive2.md",
             "outgoing_links": [
                 "/addiction",
@@ -5616,7 +5636,7 @@
                 "/psychic-weight",
                 "/siy"
             ],
-            "last_modified": "2025-08-22T11:54:12-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/psychic-shadows.md",
             "outgoing_links": [
                 "/addiction",
@@ -5870,7 +5890,7 @@
                 "/slow",
                 "/timeoff"
             ],
-            "last_modified": "2024-10-05T21:35:59-07:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_d/resistance.md",
             "outgoing_links": [
                 "/addiction",
@@ -5924,7 +5944,7 @@
             "doc_size": 15000,
             "file_path": "_site/roblox-dev.html",
             "incoming_links": [],
-            "last_modified": "2025-08-22T11:54:12-07:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_td/roblox2.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -5963,7 +5983,7 @@
                 "/content-creation",
                 "/osx"
             ],
-            "last_modified": "2025-01-04T12:24:44-08:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_td/screencast.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -6054,7 +6074,7 @@
                 "/physical-health",
                 "/raccoon-history"
             ],
-            "last_modified": "2026-05-11T07:14:49-07:00",
+            "last_modified": "2026-07-14T04:50:44+00:00",
             "markdown_path": "_d/7h-c7.md",
             "outgoing_links": [
                 "/7-habits",
@@ -6090,7 +6110,7 @@
                 "/y25",
                 "/y26"
             ],
-            "last_modified": "2026-01-25T19:21:14+00:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/shoulder-pain.md",
             "outgoing_links": [
                 "/kettlebell",
@@ -6227,7 +6247,7 @@
                 "/timeoff-2022-02",
                 "/words-we-dont-have"
             ],
-            "last_modified": "2025-12-07T02:26:29+00:00",
+            "last_modified": "2026-07-14T08:26:52+02:00",
             "markdown_path": "_d/2016-3-12-sleight-of-mouth.md",
             "outgoing_links": [
                 "/get-to-yes-with-yourself",
@@ -6272,7 +6292,7 @@
             "incoming_links": [
                 "/joy"
             ],
-            "last_modified": "2023-02-20T13:23:02-08:00",
+            "last_modified": "2026-07-14T04:50:44+00:00",
             "markdown_path": "_td/smilebox.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -6286,7 +6306,7 @@
             "incoming_links": [
                 "/timeoff-2021-11"
             ],
-            "last_modified": "2021-11-25T22:54:03-08:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_d/snjb_.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -6443,7 +6463,7 @@
                 "/siy",
                 "/timeoff-2024-02"
             ],
-            "last_modified": "2026-03-21T12:32:21-07:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_d/sublime.md",
             "outgoing_links": [
                 "/emotional-health",
@@ -6463,7 +6483,7 @@
                 "/depression",
                 "/mania"
             ],
-            "last_modified": "2024-11-09T06:51:11-08:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_d/suicide.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -6485,7 +6505,7 @@
                 "/retire",
                 "/work-satisfaction"
             ],
-            "last_modified": "2025-02-15T10:13:03-08:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_posts/2020-01-04-sustainable-work.md",
             "outgoing_links": [
                 "/moments-at-work"
@@ -6525,7 +6545,7 @@
                 "/7-habits",
                 "/raccoon-history"
             ],
-            "last_modified": "2026-05-11T07:14:49-07:00",
+            "last_modified": "2026-07-13T19:49:39+02:00",
             "markdown_path": "_d/7h-c6.md",
             "outgoing_links": [
                 "/7-habits",
@@ -6604,7 +6624,7 @@
         },
         "/td/back_ref": {
             "description": "This blog is my collection of evergreen notes, a place to have my thinking accrue. The blog is densely linked, in the forward direction, but jekyll does not create back links. I think back links would be great. Here’s my strategy to create them.\n\n",
-            "doc_size": 13000,
+            "doc_size": 14000,
             "file_path": "_site/td/back_ref.html",
             "incoming_links": [],
             "last_modified": "2022-04-16T15:22:43-07:00",
@@ -6666,7 +6686,7 @@
             "doc_size": 16000,
             "file_path": "_site/td/dump_imessage_history.html",
             "incoming_links": [],
-            "last_modified": "2025-08-22T11:54:12-07:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_td/dump_imessage_history.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -6746,7 +6766,7 @@
             "doc_size": 16000,
             "file_path": "_site/td/minecraft.html",
             "incoming_links": [],
-            "last_modified": "2026-01-03T17:27:23+00:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_td/minecraft.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -6860,7 +6880,7 @@
             "incoming_links": [
                 "/viz"
             ],
-            "last_modified": "2020-04-11T16:32:11+00:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_td/visual-vocabulary.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -6922,7 +6942,7 @@
                 "/timeoff-2024-04",
                 "/voices"
             ],
-            "last_modified": "2026-07-07T05:02:30-07:00",
+            "last_modified": "2026-07-14T06:28:56+02:00",
             "markdown_path": "_d/terzepatide.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -7001,7 +7021,7 @@
                 "/job-hunt-stress",
                 "/outsourcing"
             ],
-            "last_modified": "2020-04-12T19:50:58+00:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_posts/2020-01-01-the-recruiter-does-not-think-you-are-hot.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -7051,7 +7071,7 @@
                 "/timeoff-2025-08",
                 "/timeoff-2026-07"
             ],
-            "last_modified": "2026-07-07T05:16:20-07:00",
+            "last_modified": "2026-07-13T23:50:42-07:00",
             "markdown_path": "_d/time_off.md",
             "outgoing_links": [
                 "/addiction",
@@ -7107,7 +7127,7 @@
             "incoming_links": [
                 "/timeoff-2021-12"
             ],
-            "last_modified": "2025-09-13T12:56:01-07:00",
+            "last_modified": "2026-07-14T06:43:37+02:00",
             "markdown_path": "_d/time-off-2020-12.md",
             "outgoing_links": [
                 "/7-habits",
@@ -7127,7 +7147,7 @@
             "incoming_links": [
                 "/timeoff-2021-12"
             ],
-            "last_modified": "2025-12-07T03:17:42+00:00",
+            "last_modified": "2026-07-14T06:43:37+02:00",
             "markdown_path": "_d/time-off-2021-11.md",
             "outgoing_links": [
                 "/adblocker-trojan",
@@ -7147,7 +7167,7 @@
             "incoming_links": [
                 "/timeoff-2022-12"
             ],
-            "last_modified": "2025-09-13T12:56:01-07:00",
+            "last_modified": "2026-07-14T06:43:37+02:00",
             "markdown_path": "_d/time-off-2021-12.md",
             "outgoing_links": [
                 "/activation",
@@ -7166,7 +7186,7 @@
             "doc_size": 20000,
             "file_path": "_site/timeoff-2022-02.html",
             "incoming_links": [],
-            "last_modified": "2025-12-07T03:17:42+00:00",
+            "last_modified": "2026-07-14T06:43:37+02:00",
             "markdown_path": "_d/time-off-2022-02.md",
             "outgoing_links": [
                 "/happy",
@@ -7221,7 +7241,7 @@
             "incoming_links": [
                 "/raccoon-history"
             ],
-            "last_modified": "2026-03-21T12:32:21-07:00",
+            "last_modified": "2026-07-14T06:43:37+02:00",
             "markdown_path": "_d/time-off-2022-12.md",
             "outgoing_links": [
                 "/happy",
@@ -7238,7 +7258,7 @@
             "doc_size": 18000,
             "file_path": "_site/timeoff-2023-04.html",
             "incoming_links": [],
-            "last_modified": "2026-03-21T12:32:21-07:00",
+            "last_modified": "2026-07-14T06:43:37+02:00",
             "markdown_path": "_d/time-off-2023-04.md",
             "outgoing_links": [
                 "/happy",
@@ -7254,7 +7274,7 @@
             "doc_size": 14000,
             "file_path": "_site/timeoff-2023-08.html",
             "incoming_links": [],
-            "last_modified": "2026-03-21T12:32:21-07:00",
+            "last_modified": "2026-07-14T06:43:37+02:00",
             "markdown_path": "_d/time-off-2023-08.md",
             "outgoing_links": [
                 "/happy",
@@ -7289,7 +7309,7 @@
                 "/bc",
                 "/timeoff"
             ],
-            "last_modified": "2025-09-13T12:56:01-07:00",
+            "last_modified": "2026-07-14T06:43:37+02:00",
             "markdown_path": "_d/time-off-2024-02.md",
             "outgoing_links": [
                 "/blueprint",
@@ -7306,7 +7326,7 @@
             "doc_size": 19000,
             "file_path": "_site/timeoff-2024-04.html",
             "incoming_links": [],
-            "last_modified": "2025-12-07T03:17:42+00:00",
+            "last_modified": "2026-07-14T06:43:37+02:00",
             "markdown_path": "_d/time-off-2024-04.md",
             "outgoing_links": [
                 "/ai-testing",
@@ -7365,7 +7385,7 @@
                 "/timeoff",
                 "/y26"
             ],
-            "last_modified": "2026-07-08T09:26:51+02:00",
+            "last_modified": "2026-07-14T13:37:57+02:00",
             "markdown_path": "_d/time-off-2026-07.md",
             "outgoing_links": [
                 "/act",
@@ -7410,7 +7430,7 @@
             "doc_size": 51000,
             "file_path": "_site/tools.html",
             "incoming_links": [],
-            "last_modified": "2025-08-22T11:54:12-07:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_td/tool.md",
             "outgoing_links": [
                 "/ast-grep",
@@ -7499,7 +7519,7 @@
             "incoming_links": [
                 "/taxes"
             ],
-            "last_modified": "2026-06-26T11:58:37-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/trusts.md",
             "outgoing_links": [
                 "/taxes"
@@ -7515,7 +7535,7 @@
             "incoming_links": [
                 "/emotional-lives"
             ],
-            "last_modified": "2026-05-16T14:10:54-07:00",
+            "last_modified": "2026-07-19T05:20:21-07:00",
             "markdown_path": "_d/untangled.md",
             "outgoing_links": [
                 "/be-proactive",
@@ -7535,7 +7555,7 @@
             "incoming_links": [
                 "/first-things-first"
             ],
-            "last_modified": "2025-12-07T03:19:48+00:00",
+            "last_modified": "2026-07-19T05:20:21-07:00",
             "markdown_path": "_d/upstream.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -7613,7 +7633,7 @@
             "doc_size": 14000,
             "file_path": "_site/vlc.html",
             "incoming_links": [],
-            "last_modified": "2025-06-07T09:22:10-07:00",
+            "last_modified": "2026-07-14T06:24:33+02:00",
             "markdown_path": "_d/vlc_player.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -7635,7 +7655,7 @@
                 "/operating-manual",
                 "/sleight-of-mouth"
             ],
-            "last_modified": "2024-04-14T19:24:46-07:00",
+            "last_modified": "2026-07-14T06:41:01+02:00",
             "markdown_path": "_posts/2017-01-01-voices-in-my-head.md",
             "outgoing_links": [
                 "/anxiety",
@@ -7793,7 +7813,7 @@
             "incoming_links": [
                 "/d/2016-2-15-Seth-Godin-Notes"
             ],
-            "last_modified": "2025-08-22T10:48:49-07:00",
+            "last_modified": "2026-07-14T06:26:45+02:00",
             "markdown_path": "_posts/2015-3-13-why-is-no-one-referring.md",
             "outgoing_links": [],
             "redirect_url": "",
@@ -7814,7 +7834,7 @@
                 "/voices",
                 "/work-satisfaction"
             ],
-            "last_modified": "2026-05-11T07:14:49-07:00",
+            "last_modified": "2026-07-14T06:20:26+02:00",
             "markdown_path": "_d/7h-c4.md",
             "outgoing_links": [
                 "/7-habits",


### PR DESCRIPTION
## What

Two pages of eval content, plus a working eval behind them:

**`/ai-testing` — new "Grading the agent with smevals" section**
- Why agent-in-a-workdir evals don't fit the prompt→completion mold, and how smevals' executable-Runner + decoupled-Grader design handles them
- [smevals-blog-edit-evals](https://github.com/idvorkin-ai-tools/smevals-blog-edit-evals): agent must edit a page, keep the TOC byte-identical to `toc.py`'s output, no collateral damage — all deterministic checkers, graders validated by known-good/known-bad mock runners
- Results: Claude Code sonnet/haiku sweep it 100%; a deliberately-dumb Codex config (gpt-5.4-mini, reasoning `none`, pre-approved-command permission envelope) lands 7/10 — every failure a give-up, never a wrong edit. Lesson: the permission envelope is part of the harness under test.

**`/ai-eval-tools` — new survey page (labeled 95% ai-slop)**
- Quick feel-of-the-field survey: smevals, PromptFoo, Pydantic Evals, Inspect AI, DeepEval, Giskard, and the SaaS tier — criteria, limitations, examples, versions as of 2026-08
- Documents the two house benchmark evals (blog page edit — built; raccoon generator — next) and the repo-per-tool naming convention
- Cross-linked with `/ai-testing`; `back-links.json` rebuilt in-PR

## Screenshots

![smevals section](https://gist.githubusercontent.com/idvorkin-ai-tools/6fe39aa098affe86b7b41c279d4a8f02/raw/smevals-section.png)

![eval tools page](https://gist.githubusercontent.com/idvorkin-ai-tools/6fe39aa098affe86b7b41c279d4a8f02/raw/eval-tools-page.png)

## Review checklist

```
Architect: 🟢 headers 🟢 front-matter 🟢 internal-links
Carpenter: 🟢 opening 🟢 voice 🟢 ai-patterns
Judge: 🟢 alerts ⚪ images ⚪ books 🟢 ai-slop
Workflow: 🟢 rebased 🟢 backlinks
```

Note: commits used `SKIP=anchor-checker` because of a pre-existing broken anchor on main (`_d/changelog.md:304` → `/timeoff-2026-07#re-stacking-the-roles`, heading no longer exists — tracked in beads as blog-7et). Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive survey of AI evaluation tools, benchmarks, frameworks, and platform considerations.
  * Expanded AI testing guidance with workflows for grading coding agents, deterministic criteria, test tasks, and validation results.
  * Updated site navigation and backlink metadata to include the new AI evaluation tools page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->