### PR TITLE
feat(annotate): blog highlight-and-comment tool + Larry-side locator CLI

### DIFF
--- a/_includes/annotate.html
+++ b/_includes/annotate.html
@@ -1,0 +1,519 @@
+<!--
+  annotate.html — Igor's private blog annotation tool.
+
+  INERT BY DEFAULT. Readers get no UI, no network calls, and (aside from
+  this tiny script parse) no cost. Everything below is guarded by a
+  localStorage flag that only Igor ever sets.
+
+  Enable  : visit any post with ?annotate=1  (persists via localStorage)
+  Disable : visit any post with ?annotate=0
+  Toggle  : Cmd/Ctrl+Shift+A on desktop
+
+  Once enabled: select text -> a small "Comment" bubble appears near the
+  selection -> tap it -> type a note -> Save. Notes buffer in localStorage.
+  The "Review (N)" pill uploads the batch to a SECRET gist (description
+  `blog-review: <permalink>`) or copies it to the clipboard.
+
+  SECURITY: the GitHub PAT lives ONLY in this browser's localStorage under
+  `blogAnnotateToken`. It is never committed, never sent anywhere except
+  api.github.com. Use a fine-grained/classic token with the `gist` scope
+  ONLY — nothing else.
+
+  Larry reads the batches back with scripts/blog_review.py.
+-->
+
+<!--
+  Page identity is passed through data attributes rather than interpolated
+  into the <script> body: Liquid tags inside JS are not valid JS, and the
+  repo's prettier hook parses script contents.
+-->
+<div
+  id="blog-annot-meta"
+  data-permalink="{{ page.url }}"
+  data-title="{{ page.title | default: '' | escape }}"
+  hidden
+></div>
+
+<script>
+  (function () {
+    "use strict";
+
+    var FLAG_KEY = "blogAnnotate";
+    var TOKEN_KEY = "blogAnnotateToken";
+    var BUF_KEY = "blogAnnotateBuffer";
+    var CTX = 30; // chars of prefix/suffix context (W3C TextQuoteSelector)
+
+    // ---------------------------------------------------------------- flag
+    // Read the query string first so ?annotate=1 can turn the tool on for a
+    // browser that has never had it, and ?annotate=0 can turn it off again.
+    function readQueryFlag() {
+      try {
+        var v = new URLSearchParams(window.location.search).get("annotate");
+        if (v === null) return null;
+        return v === "1" || v === "true" || v === "on";
+      } catch (e) {
+        return null;
+      }
+    }
+
+    function enabled() {
+      try {
+        return localStorage.getItem(FLAG_KEY) === "1";
+      } catch (e) {
+        return false;
+      }
+    }
+
+    function setEnabled(on) {
+      try {
+        if (on) localStorage.setItem(FLAG_KEY, "1");
+        else localStorage.removeItem(FLAG_KEY);
+      } catch (e) {
+        /* private mode: nothing we can do */
+      }
+    }
+
+    var q = readQueryFlag();
+    if (q !== null) setEnabled(q);
+
+    // The keyboard toggle is the only listener a normal reader ever pays for.
+    // It is a single keydown handler; cost is indistinguishable from zero.
+    document.addEventListener("keydown", function (e) {
+      var key = e.key || "";
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && key.toLowerCase() === "a") {
+        e.preventDefault();
+        var next = !enabled();
+        setEnabled(next);
+        window.location.reload();
+      }
+    });
+
+    if (!enabled()) return; // <-- readers stop here
+
+    // --------------------------------------------------------- page identity
+    var meta = document.getElementById("blog-annot-meta");
+    var PERMALINK =
+      (meta && meta.dataset.permalink) || window.location.pathname;
+    var TITLE = (meta && meta.dataset.title) || document.title;
+
+    // ------------------------------------------------------------- storage
+    function loadBuffer() {
+      try {
+        var raw = localStorage.getItem(BUF_KEY);
+        if (!raw) return [];
+        var parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch (e) {
+        return [];
+      }
+    }
+
+    function saveBuffer(list) {
+      try {
+        localStorage.setItem(BUF_KEY, JSON.stringify(list));
+      } catch (e) {
+        alert("Could not save annotation (localStorage full or blocked).");
+      }
+    }
+
+    // ------------------------------------------------------------- selector
+    // Build the W3C TextQuoteSelector triple: exact quote plus ~30 chars of
+    // surrounding text. This is what lets the CLI find the same spot in the
+    // markdown source even though the rendered HTML differs from it.
+    //
+    // We walk the *text* of the article container rather than the DOM so the
+    // prefix/suffix cross element boundaries the way a reader perceives them.
+    function articleRoot() {
+      return (
+        document.getElementById("content-holder") ||
+        document.getElementById("main-content") ||
+        document.body
+      );
+    }
+
+    function selectorFromRange(range) {
+      var root = articleRoot();
+      var quote = range.toString();
+      if (!quote.trim()) return null;
+
+      var prefix = "";
+      var suffix = "";
+      try {
+        var pre = range.cloneRange();
+        pre.selectNodeContents(root);
+        pre.setEnd(range.startContainer, range.startOffset);
+        var preText = pre.toString();
+        prefix = preText.slice(Math.max(0, preText.length - CTX));
+
+        var post = range.cloneRange();
+        post.selectNodeContents(root);
+        post.setStart(range.endContainer, range.endOffset);
+        suffix = post.toString().slice(0, CTX);
+      } catch (e) {
+        // Selection escaped the article root (e.g. started in the sidebar).
+        // A bare quote still locates most of the time; the CLI reports the
+        // ones it can't find rather than guessing.
+      }
+
+      return { quote: quote, prefix: prefix, suffix: suffix };
+    }
+
+    // ------------------------------------------------------------------ UI
+    var style = document.createElement("style");
+    style.textContent = [
+      "#blog-annot-btn{position:absolute;z-index:99999;display:none;",
+      "padding:6px 12px;font:600 14px/1.2 system-ui,sans-serif;color:#fff;",
+      "background:#0b5ed7;border:0;border-radius:16px;cursor:pointer;",
+      "box-shadow:0 2px 8px rgba(0,0,0,.3);touch-action:manipulation}",
+      "#blog-annot-pill{position:fixed;right:14px;bottom:14px;z-index:99999;",
+      "display:flex;gap:6px;align-items:center;padding:8px 12px;",
+      "font:600 13px/1.2 system-ui,sans-serif;color:#fff;background:#212529;",
+      "border-radius:20px;box-shadow:0 2px 10px rgba(0,0,0,.35)}",
+      "#blog-annot-pill button{font:600 12px/1.2 system-ui,sans-serif;",
+      "padding:5px 9px;border:0;border-radius:12px;cursor:pointer;",
+      "background:#495057;color:#fff}",
+      "#blog-annot-pill button:disabled{opacity:.45;cursor:default}",
+      "#blog-annot-modal{position:fixed;inset:0;z-index:100000;display:none;",
+      "align-items:center;justify-content:center;background:rgba(0,0,0,.45);",
+      "padding:16px}",
+      "#blog-annot-card{width:100%;max-width:520px;background:#fff;color:#111;",
+      "border-radius:12px;padding:16px;font:14px/1.45 system-ui,sans-serif;",
+      "max-height:85vh;overflow:auto}",
+      "#blog-annot-card blockquote{margin:0 0 10px;padding:8px 10px;",
+      "background:#f1f3f5;border-left:3px solid #0b5ed7;font-style:italic;",
+      "max-height:9em;overflow:auto}",
+      "#blog-annot-card textarea{width:100%;min-height:110px;padding:8px;",
+      "font:14px/1.4 system-ui,sans-serif;border:1px solid #ced4da;",
+      "border-radius:8px;box-sizing:border-box}",
+      "#blog-annot-card .row{display:flex;gap:8px;justify-content:flex-end;",
+      "margin-top:10px;flex-wrap:wrap}",
+      "#blog-annot-card button{padding:8px 14px;border:0;border-radius:8px;",
+      "font:600 13px/1.2 system-ui,sans-serif;cursor:pointer}",
+      "#blog-annot-card .primary{background:#0b5ed7;color:#fff}",
+      "#blog-annot-card .ghost{background:#e9ecef;color:#212529}",
+      "#blog-annot-list{margin:10px 0 0;padding:0;list-style:none;",
+      "font-size:13px}",
+      "#blog-annot-list li{padding:6px 0;border-top:1px solid #e9ecef}",
+      "#blog-annot-note{margin-top:10px;font-size:12px;color:#495057;",
+      "word-break:break-all}",
+    ].join("");
+    document.head.appendChild(style);
+
+    var btn = document.createElement("button");
+    btn.id = "blog-annot-btn";
+    btn.type = "button";
+    btn.textContent = "💬 Comment";
+    document.body.appendChild(btn);
+
+    var pill = document.createElement("div");
+    pill.id = "blog-annot-pill";
+    pill.innerHTML =
+      '<span id="blog-annot-count">Review (0)</span>' +
+      '<button type="button" id="blog-annot-open">Open</button>';
+    document.body.appendChild(pill);
+
+    var modal = document.createElement("div");
+    modal.id = "blog-annot-modal";
+    modal.innerHTML = '<div id="blog-annot-card"></div>';
+    document.body.appendChild(modal);
+    var card = modal.firstChild;
+
+    function showModal(html) {
+      card.innerHTML = html;
+      modal.style.display = "flex";
+    }
+    function hideModal() {
+      modal.style.display = "none";
+      card.innerHTML = "";
+    }
+    modal.addEventListener("click", function (e) {
+      if (e.target === modal) hideModal();
+    });
+
+    function refreshPill() {
+      document.getElementById("blog-annot-count").textContent =
+        "Review (" + loadBuffer().length + ")";
+    }
+    refreshPill();
+
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>"']/g, function (c) {
+        return {
+          "&": "&amp;",
+          "<": "&lt;",
+          ">": "&gt;",
+          '"': "&quot;",
+          "'": "&#39;",
+        }[c];
+      });
+    }
+
+    // --------------------------------------------------------- capture flow
+    var pending = null;
+
+    function hideBtn() {
+      btn.style.display = "none";
+    }
+
+    function positionBtn(range) {
+      var rects = range.getClientRects();
+      var r = rects.length
+        ? rects[rects.length - 1]
+        : range.getBoundingClientRect();
+      if (!r || (!r.width && !r.height)) return hideBtn();
+      var top = r.bottom + window.scrollY + 8;
+      var left = r.left + window.scrollX;
+      // Keep the bubble on-screen on narrow phones.
+      var maxLeft = window.scrollX + document.documentElement.clientWidth - 130;
+      btn.style.top = top + "px";
+      btn.style.left =
+        Math.max(window.scrollX + 8, Math.min(left, maxLeft)) + "px";
+      btn.style.display = "block";
+    }
+
+    function onSelectionSettled() {
+      var sel = window.getSelection();
+      if (!sel || sel.isCollapsed || sel.rangeCount === 0) return hideBtn();
+      var range = sel.getRangeAt(0);
+      if (!range.toString().trim()) return hideBtn();
+      var sel_info = selectorFromRange(range);
+      if (!sel_info) return hideBtn();
+      pending = sel_info;
+      positionBtn(range);
+    }
+
+    // mouseup covers desktop; selectionchange (debounced) covers iOS Safari
+    // touch selection, where mouseup fires unreliably and the handles keep
+    // moving after the initial gesture.
+    document.addEventListener("mouseup", function () {
+      setTimeout(onSelectionSettled, 10);
+    });
+
+    var selTimer = null;
+    document.addEventListener("selectionchange", function () {
+      if (selTimer) clearTimeout(selTimer);
+      selTimer = setTimeout(onSelectionSettled, 350);
+    });
+
+    // Both, so a tap on the bubble registers immediately on iOS instead of
+    // waiting out the 300ms click delay (and losing the selection first).
+    ["click", "touchend"].forEach(function (evt) {
+      btn.addEventListener(evt, function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (pending) openComposer(pending);
+      });
+    });
+
+    function openComposer(sel_info) {
+      hideBtn();
+      showModal(
+        "<blockquote>" +
+          escapeHtml(sel_info.quote) +
+          "</blockquote>" +
+          '<textarea id="blog-annot-text" placeholder="What about this line?"></textarea>' +
+          '<div class="row">' +
+          '<button type="button" class="ghost" id="blog-annot-cancel">Cancel</button>' +
+          '<button type="button" class="primary" id="blog-annot-save">Save</button>' +
+          "</div>"
+      );
+      var ta = document.getElementById("blog-annot-text");
+      ta.focus();
+      document.getElementById("blog-annot-cancel").onclick = hideModal;
+      document.getElementById("blog-annot-save").onclick = function () {
+        var list = loadBuffer();
+        list.push({
+          permalink: PERMALINK,
+          title: TITLE,
+          quote: sel_info.quote,
+          prefix: sel_info.prefix,
+          suffix: sel_info.suffix,
+          comment: ta.value,
+          ts: new Date().toISOString(),
+        });
+        saveBuffer(list);
+        refreshPill();
+        hideModal();
+        var s = window.getSelection();
+        if (s && s.removeAllRanges) s.removeAllRanges();
+      };
+    }
+
+    // ---------------------------------------------------------- review flow
+    document.getElementById("blog-annot-open").onclick = openReview;
+
+    function openReview() {
+      var list = loadBuffer();
+      var items = list.length
+        ? list
+            .map(function (a, i) {
+              return (
+                "<li><b>" +
+                (i + 1) +
+                ".</b> " +
+                escapeHtml(a.quote.slice(0, 90)) +
+                (a.quote.length > 90 ? "…" : "") +
+                "<br><i>" +
+                escapeHtml(a.comment || "(no comment)") +
+                "</i></li>"
+              );
+            })
+            .join("")
+        : "<li>Nothing captured yet.</li>";
+
+      showModal(
+        "<b>Annotations (" +
+          list.length +
+          ")</b>" +
+          '<ul id="blog-annot-list">' +
+          items +
+          "</ul>" +
+          '<div class="row">' +
+          '<button type="button" class="ghost" id="blog-annot-clear">Clear all</button>' +
+          '<button type="button" class="ghost" id="blog-annot-copy">Copy to clipboard</button>' +
+          '<button type="button" class="primary" id="blog-annot-gist">Upload to gist</button>' +
+          '<button type="button" class="ghost" id="blog-annot-close">Close</button>' +
+          "</div>" +
+          '<div id="blog-annot-note"></div>'
+      );
+
+      var note = document.getElementById("blog-annot-note");
+      document.getElementById("blog-annot-close").onclick = hideModal;
+
+      document.getElementById("blog-annot-clear").onclick = function () {
+        if (!confirm("Discard all " + list.length + " annotations?")) return;
+        saveBuffer([]);
+        refreshPill();
+        hideModal();
+      };
+
+      document.getElementById("blog-annot-copy").onclick = function () {
+        var json = payloadJson(list);
+        function fallback() {
+          var ta = document.createElement("textarea");
+          ta.value = json;
+          ta.style.position = "fixed";
+          ta.style.opacity = "0";
+          document.body.appendChild(ta);
+          ta.select();
+          try {
+            document.execCommand("copy");
+            note.textContent = "Copied " + list.length + " annotations.";
+          } catch (e) {
+            note.textContent = "Copy failed — select the JSON manually.";
+          }
+          document.body.removeChild(ta);
+        }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(json).then(function () {
+            note.textContent = "Copied " + list.length + " annotations.";
+          }, fallback);
+        } else {
+          fallback();
+        }
+      };
+
+      document.getElementById("blog-annot-gist").onclick = function () {
+        if (!list.length) {
+          note.textContent = "Nothing to upload.";
+          return;
+        }
+        uploadGist(list, note);
+      };
+    }
+
+    function payloadJson(list) {
+      return JSON.stringify(
+        {
+          permalink: PERMALINK,
+          title: TITLE,
+          url: window.location.origin + window.location.pathname,
+          created: new Date().toISOString(),
+          annotations: list,
+        },
+        null,
+        2
+      );
+    }
+
+    function getToken() {
+      var t;
+      try {
+        t = localStorage.getItem(TOKEN_KEY);
+      } catch (e) {
+        t = null;
+      }
+      if (t) return t;
+      t = window.prompt(
+        "GitHub personal access token with ONLY the `gist` scope.\n" +
+          "Stored in this browser's localStorage — never committed."
+      );
+      if (!t) return null;
+      t = t.trim();
+      try {
+        localStorage.setItem(TOKEN_KEY, t);
+      } catch (e) {
+        /* still usable for this one upload */
+      }
+      return t;
+    }
+
+    function uploadGist(list, note) {
+      var token = getToken();
+      if (!token) {
+        note.textContent = "No token — cancelled.";
+        return;
+      }
+      note.textContent = "Uploading…";
+
+      var body = {
+        // SECRET gist. `public: false` is the whole point — these are private
+        // notes on unpublished thinking.
+        public: false,
+        // Larry greps for exactly this prefix. Do not reformat.
+        description: "blog-review: " + PERMALINK,
+        files: { "review.json": { content: payloadJson(list) } },
+      };
+
+      fetch("https://api.github.com/gists", {
+        method: "POST",
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: "Bearer " + token,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      })
+        .then(function (res) {
+          if (res.status === 401 || res.status === 403) {
+            try {
+              localStorage.removeItem(TOKEN_KEY);
+            } catch (e) {
+              /* ignore */
+            }
+            throw new Error(
+              "GitHub rejected the token (" +
+                res.status +
+                "). It has been cleared — retry to re-enter one with `gist` scope."
+            );
+          }
+          if (!res.ok) throw new Error("GitHub returned " + res.status);
+          return res.json();
+        })
+        .then(function (gist) {
+          saveBuffer([]);
+          refreshPill();
+          note.innerHTML =
+            "Uploaded ✅ <a href='" +
+            escapeHtml(gist.html_url) +
+            "' target='_blank' rel='noopener'>" +
+            escapeHtml(gist.html_url) +
+            "</a><br>Local buffer cleared.";
+        })
+        .catch(function (err) {
+          // Never clear the buffer on failure — the notes are the valuable part.
+          note.textContent = "Upload failed: " + err.message;
+        });
+    }
+  })();
+</script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -74,6 +74,12 @@
       </script>
       <!--See: https://github.com/partykit/cursor-party-->
       <script src="https://cursor-party.idvorkin.partykit.dev/cursors.js"></script>
+
+      <!--
+        Private annotation tool. Inert unless localStorage blogAnnotate=1
+        (set via ?annotate=1 or Cmd/Ctrl+Shift+A). Readers see nothing.
+      -->
+      {% include annotate.html %}
     </span>
   </body>
 </html>

--- a/scripts/blog_review.py
+++ b/scripts/blog_review.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "typer",
+#   "rich",
+# ]
+# ///
+"""Read blog annotation batches captured by ``_includes/annotate.html``.
+
+Igor highlights a line on the rendered blog, types a comment, and ships the
+batch to a *secret* gist whose description is exactly ``blog-review: <permalink>``.
+This CLI is the Larry-side reader.
+
+    ./scripts/blog_review.py list                 # find review gists
+    ./scripts/blog_review.py show <gist-id>       # pretty-print one batch
+    ./scripts/blog_review.py locate <gist-id>     # map each note to file:line
+
+``show`` and ``locate`` also accept a path to a local JSON file, which is what
+the client's "Copy to clipboard" fallback produces.
+
+This tool deliberately does NOT edit markdown or open PRs. Locating is the
+useful, safe half; Igor reviews before anything is written.
+
+Auth: uses the ``gh`` CLI, so it inherits your existing GitHub login. No token
+is read from, or written to, this repo.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import re
+import subprocess
+import sys
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+app = typer.Typer(
+    add_completion=False,
+    help="Read blog annotation batches from secret gists.",
+    no_args_is_help=True,
+)
+console = Console()
+
+DESCRIPTION_PREFIX = "blog-review:"
+REVIEW_FILENAME = "review.json"
+
+# Jekyll collections that can hold a post with a permalink.
+CONTENT_DIRS = ("_d", "_td", "_posts", "_ig66", "_gascity")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# --------------------------------------------------------------------------- gh
+def _gh(*args: str) -> str:
+    """Run a gh command, returning stdout. Exits with a clear message on failure."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, check=False
+        )
+    except FileNotFoundError:
+        console.print("[red]gh CLI not found.[/red] Install it: https://cli.github.com")
+        raise typer.Exit(1) from None
+    if proc.returncode != 0:
+        console.print(f"[red]gh {' '.join(args)} failed:[/red] {proc.stderr.strip()}")
+        raise typer.Exit(1)
+    return proc.stdout
+
+
+def fetch_gist_list(limit: int) -> list[dict]:
+    """All gists whose description starts with the blog-review marker."""
+    raw = _gh("api", f"/gists?per_page={min(limit, 100)}", "--paginate")
+    # --paginate concatenates JSON arrays; gh emits them back to back.
+    gists: list[dict] = []
+    decoder = json.JSONDecoder()
+    idx = 0
+    while idx < len(raw):
+        while idx < len(raw) and raw[idx].isspace():
+            idx += 1
+        if idx >= len(raw):
+            break
+        chunk, offset = decoder.raw_decode(raw, idx)
+        gists.extend(chunk)
+        idx = offset
+    return [
+        g
+        for g in gists
+        if (g.get("description") or "").strip().startswith(DESCRIPTION_PREFIX)
+    ]
+
+
+def load_batch(source: str) -> dict:
+    """Load a review batch from a gist id/url or a local JSON file."""
+    local = Path(source)
+    if local.exists():
+        return json.loads(local.read_text())
+
+    gist_id = source.rstrip("/").split("/")[-1]
+    gist = json.loads(_gh("api", f"/gists/{gist_id}"))
+    files = gist.get("files") or {}
+    entry = files.get(REVIEW_FILENAME)
+    if entry is None:
+        # Be forgiving: take the only file, or the first .json one.
+        candidates = [
+            f for f in files.values() if f.get("filename", "").endswith(".json")
+        ]
+        if len(candidates) == 1:
+            entry = candidates[0]
+        else:
+            console.print(
+                f"[red]Gist {gist_id} has no {REVIEW_FILENAME}[/red] "
+                f"(files: {', '.join(files) or 'none'})"
+            )
+            raise typer.Exit(1)
+
+    content = entry.get("content")
+    if entry.get("truncated") and entry.get("raw_url"):
+        content = _gh("api", entry["raw_url"])
+    return json.loads(content)
+
+
+# -------------------------------------------------------------- normalization
+SMART_MAP = {
+    "‘": "'",
+    "’": "'",
+    "‚": "'",
+    "‛": "'",
+    "“": '"',
+    "”": '"',
+    "„": '"',
+    "–": "--",
+    "—": "---",
+    "…": "...",
+    " ": " ",
+    " ": " ",
+    " ": " ",
+    "​": "",
+}
+
+# Inline markdown constructs that vanish (or partly vanish) when rendered.
+_IMAGE_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+_REF_LINK_RE = re.compile(r"\[([^\]]*)\]\[[^\]]*\]")
+_LIQUID_RE = re.compile(r"\{%.*?%\}|\{\{.*?\}\}", re.DOTALL)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_LEADING_RE = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+|>\s?|#{1,6}\s+)")
+_EMPHASIS_RE = re.compile(r"[*_`~]+")
+_WS_RE = re.compile(r"\s+")
+
+
+def normalize(text: str, *, strip_markdown: bool = False) -> str:
+    """Collapse rendered-vs-source differences so the two can be compared.
+
+    Rendered HTML collapses whitespace and kramdown smart-quotes punctuation,
+    so both sides get pushed to the same ASCII, single-spaced shape. Markdown
+    source additionally gets its inline syntax stripped.
+    """
+    text = unicodedata.normalize("NFKC", text)
+    for bad, good in SMART_MAP.items():
+        text = text.replace(bad, good)
+    if strip_markdown:
+        text = _LIQUID_RE.sub(" ", text)
+        text = _IMAGE_RE.sub(" ", text)
+        text = _LINK_RE.sub(r"\1", text)
+        text = _REF_LINK_RE.sub(r"\1", text)
+        text = _HTML_TAG_RE.sub(" ", text)
+        text = _LEADING_RE.sub("", text)
+        text = _EMPHASIS_RE.sub("", text)
+        text = text.replace("\\", "")
+    text = _WS_RE.sub(" ", text)
+    return text.strip()
+
+
+def fuzzy_normalize(text: str) -> str:
+    """Last-resort shape: letters and digits only, lowercased."""
+    return re.sub(r"[^a-z0-9 ]+", "", normalize(text).lower())
+
+
+# ------------------------------------------------------------------ permalinks
+def permalink_index() -> dict[str, Path]:
+    """Map normalized permalink -> source markdown file."""
+    index: dict[str, Path] = {}
+    for directory in CONTENT_DIRS:
+        base = REPO_ROOT / directory
+        if not base.is_dir():
+            continue
+        for path in sorted(base.glob("*.md")):
+            permalink = _frontmatter_permalink(path)
+            if permalink:
+                index.setdefault(_norm_permalink(permalink), path)
+    return index
+
+
+def _frontmatter_permalink(path: Path) -> str | None:
+    try:
+        text = path.read_text(errors="replace")
+    except OSError:
+        return None
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    front = text[3 : end if end != -1 else 4000]
+    match = re.search(r"^permalink:\s*(.+?)\s*$", front, re.MULTILINE)
+    if not match:
+        return None
+    return match.group(1).strip().strip("\"'")
+
+
+def _norm_permalink(value: str) -> str:
+    return "/" + value.strip().strip("/").lower()
+
+
+def resolve_permalink(permalink: str, index: dict[str, Path]) -> Path | None:
+    key = _norm_permalink(permalink or "")
+    if key in index:
+        return index[key]
+    # /some-post/index.html, /some-post.html, trailing-slash variants
+    trimmed = re.sub(r"(?:/index)?\.html?$", "", key)
+    return index.get(trimmed)
+
+
+# -------------------------------------------------------------------- locating
+@dataclass
+class Match:
+    line: int
+    method: str
+    score: float
+    text: str
+
+
+class Locator:
+    """Finds an annotation's quote inside one markdown file.
+
+    Builds a single normalized document string plus an index that maps any
+    offset in it back to a 1-based source line, so quotes that span a line
+    break in the source still resolve.
+    """
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.lines = path.read_text(errors="replace").splitlines()
+
+        self.norm_doc, self.norm_offsets = self._build(strip_markdown=True)
+        self.fuzzy_doc, self.fuzzy_offsets = self._build_fuzzy()
+
+    def _build(self, *, strip_markdown: bool) -> tuple[str, list[tuple[int, int]]]:
+        parts: list[str] = []
+        offsets: list[tuple[int, int]] = []
+        cursor = 0
+        for lineno, raw in enumerate(self.lines, start=1):
+            piece = normalize(raw, strip_markdown=strip_markdown)
+            offsets.append((cursor, lineno))
+            parts.append(piece)
+            cursor += len(piece) + 1  # +1 for the joining space
+        return " ".join(parts), offsets
+
+    def _build_fuzzy(self) -> tuple[str, list[tuple[int, int]]]:
+        parts: list[str] = []
+        offsets: list[tuple[int, int]] = []
+        cursor = 0
+        for lineno, raw in enumerate(self.lines, start=1):
+            piece = fuzzy_normalize(normalize(raw, strip_markdown=True))
+            offsets.append((cursor, lineno))
+            parts.append(piece)
+            cursor += len(piece) + 1
+        return " ".join(parts), offsets
+
+    @staticmethod
+    def _lineno_for(offset: int, offsets: list[tuple[int, int]]) -> int:
+        best = 1
+        for start, lineno in offsets:
+            if start <= offset:
+                best = lineno
+            else:
+                break
+        return best
+
+    def _all_positions(self, haystack: str, needle: str) -> list[int]:
+        if not needle:
+            return []
+        found, start = [], 0
+        while True:
+            idx = haystack.find(needle, start)
+            if idx == -1:
+                return found
+            found.append(idx)
+            start = idx + 1
+
+    def _pick(
+        self,
+        haystack: str,
+        offsets: list[tuple[int, int]],
+        needle: str,
+        prefix: str,
+        suffix: str,
+    ) -> int | None:
+        """Best position for `needle`, disambiguated by surrounding context."""
+        positions = self._all_positions(haystack, needle)
+        if not positions:
+            return None
+        if len(positions) == 1 or not (prefix or suffix):
+            return positions[0]
+        best, best_score = positions[0], -1
+        for pos in positions:
+            before = haystack[max(0, pos - len(prefix) - 10) : pos]
+            after = haystack[pos + len(needle) : pos + len(needle) + len(suffix) + 10]
+            score = 0
+            if prefix and prefix in before:
+                score += 2
+            elif prefix and prefix[-10:] and prefix[-10:] in before:
+                score += 1
+            if suffix and suffix in after:
+                score += 2
+            elif suffix and suffix[:10] and suffix[:10] in after:
+                score += 1
+            if score > best_score:
+                best, best_score = pos, score
+        return best
+
+    def locate(self, ann: dict) -> Match | None:
+        quote = ann.get("quote") or ""
+        prefix = ann.get("prefix") or ""
+        suffix = ann.get("suffix") or ""
+        if not quote.strip():
+            return None
+
+        # Tier 1 — raw source text, exact. Cheapest and most trustworthy.
+        for lineno, raw in enumerate(self.lines, start=1):
+            if quote in raw:
+                return Match(lineno, "exact", 1.0, raw.strip())
+
+        # Tier 2 — context-anchored, normalized. prefix+quote+suffix pins the
+        # spot when the quote alone appears more than once.
+        n_quote = normalize(quote)
+        n_prefix = normalize(prefix)
+        n_suffix = normalize(suffix)
+        anchored = normalize(prefix + quote + suffix)
+        pos = self._pick(self.norm_doc, self.norm_offsets, anchored, "", "")
+        if pos is not None:
+            offset = pos + len(n_prefix)
+            return Match(
+                self._lineno_for(offset, self.norm_offsets),
+                "context",
+                0.97,
+                self._snippet(offset, self.norm_offsets),
+            )
+
+        # Tier 3 — quote alone, normalized, disambiguated by context.
+        pos = self._pick(self.norm_doc, self.norm_offsets, n_quote, n_prefix, n_suffix)
+        if pos is not None:
+            return Match(
+                self._lineno_for(pos, self.norm_offsets),
+                "quote",
+                0.9,
+                self._snippet(pos, self.norm_offsets),
+            )
+
+        # Tier 4 — punctuation-insensitive.
+        f_quote = fuzzy_normalize(quote)
+        pos = self._pick(
+            self.fuzzy_doc,
+            self.fuzzy_offsets,
+            f_quote,
+            fuzzy_normalize(prefix),
+            fuzzy_normalize(suffix),
+        )
+        if pos is not None:
+            return Match(
+                self._lineno_for(pos, self.fuzzy_offsets),
+                "fuzzy",
+                0.75,
+                self._snippet(pos, self.fuzzy_offsets),
+            )
+
+        # Tier 5 — sliding-window similarity. Only accepted above 0.72, and
+        # always reported as approximate so nobody edits on faith.
+        return self._similar(f_quote)
+
+    def _snippet(self, offset: int, offsets: list[tuple[int, int]]) -> str:
+        lineno = self._lineno_for(offset, offsets)
+        return self.lines[lineno - 1].strip()
+
+    def _similar(self, f_quote: str) -> Match | None:
+        if len(f_quote) < 12:
+            return None
+        window = len(f_quote)
+        best_ratio, best_pos = 0.0, -1
+        step = max(1, window // 4)
+        for start in range(0, max(1, len(self.fuzzy_doc) - window), step):
+            candidate = self.fuzzy_doc[start : start + window]
+            ratio = difflib.SequenceMatcher(None, f_quote, candidate).ratio()
+            if ratio > best_ratio:
+                best_ratio, best_pos = ratio, start
+        if best_ratio < 0.72 or best_pos < 0:
+            return None
+        lineno = self._lineno_for(best_pos, self.fuzzy_offsets)
+        return Match(lineno, "approx", best_ratio, self.lines[lineno - 1].strip())
+
+
+# -------------------------------------------------------------------- commands
+@app.command("list")
+def list_reviews(
+    limit: int = typer.Option(100, help="Max gists to scan."),
+) -> None:
+    """List secret gists holding annotation batches."""
+    gists = fetch_gist_list(limit)
+    if not gists:
+        console.print(
+            f"[yellow]No gists with a '{DESCRIPTION_PREFIX}' description.[/yellow]"
+        )
+        return
+
+    table = Table(title=f"Blog review gists ({len(gists)})", show_lines=False)
+    table.add_column("gist id", style="cyan", no_wrap=True)
+    table.add_column("permalink", style="green")
+    table.add_column("notes", justify="right")
+    table.add_column("updated", style="dim")
+    table.add_column("vis")
+
+    for gist in gists:
+        permalink = (
+            (gist.get("description") or "").split(DESCRIPTION_PREFIX, 1)[1].strip()
+        )
+        entry = (gist.get("files") or {}).get(REVIEW_FILENAME) or {}
+        table.add_row(
+            gist.get("id", "?"),
+            permalink or "(unknown)",
+            str(entry.get("size", "?")) + "b",
+            (gist.get("updated_at") or "")[:19].replace("T", " "),
+            "public" if gist.get("public") else "secret",
+        )
+    console.print(table)
+
+
+@app.command()
+def show(
+    source: str = typer.Argument(..., help="Gist id/url, or a local JSON file."),
+) -> None:
+    """Pretty-print one annotation batch."""
+    batch = load_batch(source)
+    annotations = batch.get("annotations") or []
+    console.print(
+        f"[bold]{batch.get('title') or '(untitled)'}[/bold]  "
+        f"[green]{batch.get('permalink')}[/green]"
+    )
+    if batch.get("url"):
+        console.print(f"[dim]{batch['url']}[/dim]")
+    console.print(
+        f"[dim]captured {batch.get('created', '?')} — {len(annotations)} notes[/dim]\n"
+    )
+
+    for i, ann in enumerate(annotations, start=1):
+        console.print(
+            f"[bold cyan]{i}.[/bold cyan] [italic]{ann.get('quote', '')}[/italic]"
+        )
+        console.print(f"   [white]{ann.get('comment') or '(no comment)'}[/white]")
+        ctx_prefix = (ann.get("prefix") or "").replace("\n", " ")
+        ctx_suffix = (ann.get("suffix") or "").replace("\n", " ")
+        console.print(f"   [dim]…{ctx_prefix} ⟦quote⟧ {ctx_suffix}…[/dim]")
+        console.print(f"   [dim]{ann.get('ts', '')}[/dim]\n")
+
+
+@app.command()
+def locate(
+    source: str = typer.Argument(..., help="Gist id/url, or a local JSON file."),
+    json_out: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    """Resolve each annotation to a `file:line` in the markdown source.
+
+    Never guesses silently: anything that cannot be pinned is listed under
+    UNLOCATED, and approximate matches are labeled as such.
+    """
+    batch = load_batch(source)
+    annotations = batch.get("annotations") or []
+    index = permalink_index()
+
+    results = []
+    for ann in annotations:
+        permalink = ann.get("permalink") or batch.get("permalink") or ""
+        path = resolve_permalink(permalink, index)
+        if path is None:
+            results.append(
+                {
+                    "ok": False,
+                    "reason": f"no source file for permalink {permalink!r}",
+                    "annotation": ann,
+                }
+            )
+            continue
+        match = Locator(path).locate(ann)
+        if match is None:
+            results.append(
+                {
+                    "ok": False,
+                    "reason": "quote not found in source",
+                    "file": str(path.relative_to(REPO_ROOT)),
+                    "annotation": ann,
+                }
+            )
+            continue
+        results.append(
+            {
+                "ok": True,
+                "file": str(path.relative_to(REPO_ROOT)),
+                "line": match.line,
+                "method": match.method,
+                "score": round(match.score, 3),
+                "source_line": match.text,
+                "annotation": ann,
+            }
+        )
+
+    if json_out:
+        print(
+            json.dumps({"batch": batch.get("permalink"), "results": results}, indent=2)
+        )
+        raise typer.Exit(0 if all(r["ok"] for r in results) else 2)
+
+    located = [r for r in results if r["ok"]]
+    missing = [r for r in results if not r["ok"]]
+
+    if located:
+        table = Table(title=f"Located {len(located)}/{len(results)}", show_lines=True)
+        table.add_column("#", justify="right", style="dim")
+        table.add_column("file:line", style="cyan", no_wrap=True)
+        table.add_column("how", no_wrap=True)
+        table.add_column("comment", style="white")
+        table.add_column("source line", style="dim")
+        for i, r in enumerate(located, start=1):
+            how = r["method"]
+            if how in ("fuzzy", "approx"):
+                how = f"[yellow]{how} {r['score']}[/yellow]"
+            table.add_row(
+                str(i),
+                f"{r['file']}:{r['line']}",
+                how,
+                r["annotation"].get("comment") or "(no comment)",
+                r["source_line"][:120],
+            )
+        console.print(table)
+
+    if missing:
+        console.print(
+            f"\n[red bold]UNLOCATED ({len(missing)})[/red bold] — do not guess:"
+        )
+        for r in missing:
+            ann = r["annotation"]
+            console.print(f"  [red]•[/red] {r['reason']}")
+            console.print(
+                f"    quote: [italic]{(ann.get('quote') or '')[:160]}[/italic]"
+            )
+            console.print(f"    note : {ann.get('comment') or '(no comment)'}")
+        raise typer.Exit(2)
+
+    if not results:
+        console.print("[yellow]Batch contains no annotations.[/yellow]")
+
+
+if __name__ == "__main__":
+    if not (REPO_ROOT / "_config.yml").exists():
+        console.print(
+            f"[red]Expected a Jekyll repo root at {REPO_ROOT} (no _config.yml).[/red]"
+        )
+        sys.exit(1)
+    app()


### PR DESCRIPTION
Highlight a line on the rendered blog, add a comment, ship the batch. Larry reads the batch back and tells you which `_d/*.md` line each note lands on.

Two halves: an inert Jekyll include on the site, and a `uv`-script CLI on Larry's side. Nothing auto-edits markdown or auto-opens PRs — locating is the useful, safe half.

## Setup

**1. Enable it (once per browser)**

Visit any post with `?annotate=1` — e.g. `https://idvork.in/chop?annotate=1`. That sets `localStorage.blogAnnotate=1` and it sticks across posts and reloads.

- `?annotate=0` turns it off
- `Cmd/Ctrl+Shift+A` toggles it (desktop)

**2. Make a gist-scoped PAT**

github.com → Settings → Developer settings → Personal access tokens → **Tokens (classic)** → Generate new token. Tick **`gist`** and nothing else. Copy it.

The first time you hit "Upload to gist" the page prompts for it and stores it in `localStorage.blogAnnotateToken`. **The token lives only in your browser.** It is never committed, never in this repo, and is only ever sent to `api.github.com`. If GitHub rejects it (401/403) the tool clears it and keeps your notes so you can re-enter one.

**3. Annotate**

Select text → a small **💬 Comment** bubble appears → tap it → type → Save. Notes buffer locally; a **Review (N)** pill sits bottom-right.

Open the pill for two ways out:

- **Upload to gist** — creates a **secret** gist, description exactly `blog-review: <permalink>`, file `review.json`. Clears the local buffer on success and shows the URL.
- **Copy to clipboard** — same JSON, no token needed.

**4. Read it back**

```bash
./scripts/blog_review.py list                  # find review gists
./scripts/blog_review.py show   <gist-id>      # pretty-print the notes
./scripts/blog_review.py locate <gist-id>      # -> _d/<post>.md:<line> per note
```

`show` and `locate` also take a path to a local JSON file, which is what the clipboard fallback gives you. `locate --json` emits machine-readable output for Larry. Auth is via the `gh` CLI, so it inherits your existing login — no token in the repo.

## How locating works

Each note stores a W3C **TextQuoteSelector** triple — the exact `quote`, plus ~30 chars of `prefix` and `suffix`. That context is what disambiguates a phrase appearing more than once, and what survives the gap between rendered HTML and markdown source.

`locate` walks a ladder and tells you which rung it landed on:

| rung | what it does |
| --- | --- |
| `exact` | quote appears verbatim in a source line |
| `context` | `prefix+quote+suffix` found after normalizing (whitespace collapsed, smart quotes/dashes/ellipses folded to ASCII, markdown link/emphasis/code syntax stripped) |
| `quote` | quote alone, normalized, disambiguated by prefix/suffix |
| `fuzzy` | punctuation-insensitive |
| `approx` | sliding-window similarity, only above 0.72, always flagged |

Anything it cannot pin is printed under **UNLOCATED** with the reason, and the command exits `2`. It does not guess.

## Reader impact

The include is guarded before it does anything:

```js
if (!enabled()) return;   // <-- readers stop here
```

Verified in a clean browser context on a post page: no pill, no bubble, no modal, **zero requests to `api.github.com`**, and no DOM injected. The only thing a reader pays for is one `keydown` listener (the toggle) and ~5.9 KB gzipped of inline source on post pages — no extra network request, and marginal next to the jQuery/Bootstrap/Algolia/Firebase bundle already on every page. Only `_layouts/post.html` is touched, so index and listing pages (`layout: page`) are untouched entirely.

## Verification

Built the site and drove it with Playwright:

- **Locator fidelity — 166/166.** 106 random rendered spans across 25 posts, plus 60 adversarial spans deliberately straddling `<a>`, `<strong>`, `<em>`, and `<code>` (i.e. markdown link/emphasis/backtick syntax). Every one resolved, and an independent checker confirmed **every reported line number was exactly right** — 0 off-by-N, 0 wrong.
- **Capture** works on desktop (mouse) and under iPhone 13 emulation with `hasTouch` (debounced `selectionchange` + `touchend`, since mobile Safari does not fire a usable `mouseup`). Bubble stays inside a 390px viewport.
- **Gist POST shape** checked with an intercepted route: `POST`, `public: false`, description exactly `blog-review: /chop`, file `review.json`, and the annotation keys are exactly `permalink/title/quote/prefix/suffix/comment/ts`.
- **Failure path**: on 401 the token is cleared and the note buffer is _kept_.
- **Round trip** through a real secret gist (`list` → `show` → `locate`), then deleted.
- **Negative path**: bogus quote and unknown permalink both land in UNLOCATED with exit 2.

## Not verified

- **Real mobile Safari** — Playwright's WebKit build is not installed here, so the touch path was exercised under Chromium mobile emulation only. The code is written for the iOS quirk (debounced `selectionchange`, `touchend` alongside `click`, `touch-action: manipulation`), but a real-device pass on the phone is worth doing before trusting it.
- **A live gist upload from the browser** — that needs a real `gist`-scoped PAT, which I deliberately did not create. The request shape is asserted against an intercepted route instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional browser annotation tool for highlighting article text, adding comments, reviewing notes, clearing them, and exporting annotations.
  * Annotations can be uploaded privately for review when valid GitHub credentials are available.
  * Added a review utility to list, view, and locate annotations within source articles.
* **Bug Fixes**
  * Improved handling of storage, clipboard, authentication, and upload errors without losing saved annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->