### PR TITLE
fix(annotate): escape rich markup, resolve permalinks properly, add intent + version capture

### DIFF
--- a/_includes/annotate.html
+++ b/_includes/annotate.html
@@ -10,9 +10,34 @@
   Toggle  : Cmd/Ctrl+Shift+A on desktop
 
   Once enabled: select text -> a small "Comment" bubble appears near the
-  selection -> tap it -> type a note -> Save. Notes buffer in localStorage.
+  selection -> tap it -> type a note -> pick an intent -> Save
+  (or Cmd/Ctrl+Enter; Escape cancels). Notes buffer in localStorage.
   The "Review (N)" pill uploads the batch to a SECRET gist (description
   `blog-review: <permalink>`) or copies it to the clipboard.
+
+  INTENT: one tap, seven choices (fix / cut / rewrite / expand / check /
+  question / note), default `note`. Phone annotation produces terse comments
+  and "this is wordy" is ambiguous between cut, rewrite, and idle observation.
+  One tap is the right cost; freeform per-note agent instructions are
+  deliberately NOT offered, because prose turns annotating into prompt-writing.
+
+  PAGE VERSION: recorded per annotation so a stale anchor is detectable later.
+  What this site actually exposes was checked before writing this (2026-08):
+
+    * No `last_modified_at` in any `_d/*.md` frontmatter (0 of 266).
+    * `_config.yml` loads only jekyll-redirect-from + jekyll-paginate; nothing
+      in _layouts/_includes references `site.github.*`, so there is NO
+      `site.github.build_revision` and no git SHA in the built page.
+    * The served HTML carries no generator / revision / version meta tag.
+    * GitHub Pages DOES send a real `Last-Modified` header, which the browser
+      surfaces as `document.lastModified` — but it is the SITE DEPLOY time,
+      byte-identical across every page (verified: /timeoff-2026-07, /22 and
+      /40yo all returned the same value). It identifies the build, not the post.
+
+  So the marker below is: the deploy stamp (real, coarse) plus a length and an
+  FNV-1a digest of the rendered article text (exact, per-post, derived from the
+  bytes actually annotated). blog_review.py adds the per-post signal git
+  already knows: whether the markdown was committed after the note was written.
 
   SECURITY: the GitHub PAT lives ONLY in this browser's localStorage under
   `blogAnnotateToken`. It is never committed, never sent anywhere except
@@ -158,6 +183,35 @@
       return { quote: quote, prefix: prefix, suffix: suffix };
     }
 
+    // ------------------------------------------------------- page versioning
+    // FNV-1a, 32-bit. Not a security hash — a cheap, synchronous, stable
+    // fingerprint so "did this page change since I annotated it?" is answerable
+    // without refetching. crypto.subtle would work too but is async for no gain.
+    function fnv1a(str) {
+      var h = 0x811c9dc5;
+      for (var i = 0; i < str.length; i++) {
+        h ^= str.charCodeAt(i);
+        h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+      }
+      return ("0000000" + h.toString(16)).slice(-8);
+    }
+
+    function pageVersion() {
+      var root = articleRoot();
+      var text = (root.innerText || root.textContent || "")
+        .replace(/\s+/g, " ")
+        .trim();
+      return {
+        url: window.location.origin + window.location.pathname,
+        capturedAt: new Date().toISOString(),
+        // Site deploy time, from GitHub Pages' Last-Modified header. Coarse
+        // (same for every page on the site) but genuine — see the header note.
+        lastModified: document.lastModified || "",
+        contentLength: text.length,
+        contentDigest: fnv1a(text),
+      };
+    }
+
     // ------------------------------------------------------------------ UI
     var style = document.createElement("style");
     style.textContent = [
@@ -185,8 +239,16 @@
       "#blog-annot-card textarea{width:100%;min-height:110px;padding:8px;",
       "font:14px/1.4 system-ui,sans-serif;border:1px solid #ced4da;",
       "border-radius:8px;box-sizing:border-box}",
+      "#blog-annot-intents{display:flex;gap:6px;flex-wrap:wrap;margin-top:10px}",
+      "#blog-annot-intents button{padding:7px 12px;border:1px solid #ced4da;",
+      "border-radius:14px;background:#f8f9fa;color:#495057;",
+      "font:600 13px/1.2 system-ui,sans-serif;cursor:pointer;",
+      "touch-action:manipulation}",
+      "#blog-annot-intents button[aria-pressed='true']{background:#0b5ed7;",
+      "border-color:#0b5ed7;color:#fff}",
       "#blog-annot-card .row{display:flex;gap:8px;justify-content:flex-end;",
-      "margin-top:10px;flex-wrap:wrap}",
+      "margin-top:10px;flex-wrap:wrap;align-items:center}",
+      "#blog-annot-card .hint{margin-right:auto;font-size:12px;color:#868e96}",
       "#blog-annot-card button{padding:8px 14px;border:0;border-radius:8px;",
       "font:600 13px/1.2 system-ui,sans-serif;cursor:pointer}",
       "#blog-annot-card .primary{background:#0b5ed7;color:#fff}",
@@ -225,9 +287,32 @@
     function hideModal() {
       modal.style.display = "none";
       card.innerHTML = "";
+      composerKeys = null;
     }
     modal.addEventListener("click", function (e) {
       if (e.target === modal) hideModal();
+    });
+
+    // Keyboard submit/cancel for the composer. Registered once on document so
+    // it fires no matter which control has focus (textarea, an intent chip, or
+    // nothing); `composerKeys` is non-null only while the composer is open, so
+    // this is inert the rest of the time.
+    var composerKeys = null;
+    var IS_MAC = /Mac|iPhone|iPad|iPod/.test(navigator.platform || "");
+    document.addEventListener("keydown", function (e) {
+      if (!composerKeys) return;
+      if (e.key === "Escape" || e.key === "Esc") {
+        e.preventDefault();
+        composerKeys.cancel();
+        return;
+      }
+      var isEnter = e.key === "Enter" || e.keyCode === 13;
+      // Cmd+Enter on mac, Ctrl+Enter elsewhere. Accept either on both — a
+      // Bluetooth keyboard on an iPad can report whichever it likes.
+      if (isEnter && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        composerKeys.save();
+      }
     });
 
     function refreshPill() {
@@ -305,22 +390,73 @@
       });
     });
 
+    // One tap, seven choices. Keep in sync with INTENTS in scripts/blog_review.py.
+    var INTENTS = [
+      "fix",
+      "cut",
+      "rewrite",
+      "expand",
+      "check",
+      "question",
+      "note",
+    ];
+    var DEFAULT_INTENT = "note";
+
     function openComposer(sel_info) {
       hideBtn();
+      var chips = INTENTS.map(function (name) {
+        return (
+          '<button type="button" data-intent="' +
+          name +
+          '" aria-pressed="' +
+          (name === DEFAULT_INTENT ? "true" : "false") +
+          '">' +
+          name +
+          "</button>"
+        );
+      }).join("");
+
       showModal(
         "<blockquote>" +
           escapeHtml(sel_info.quote) +
           "</blockquote>" +
           '<textarea id="blog-annot-text" placeholder="What about this line?"></textarea>' +
+          '<div id="blog-annot-intents">' +
+          chips +
+          "</div>" +
           '<div class="row">' +
+          '<span class="hint">' +
+          (IS_MAC ? "⌘" : "Ctrl") +
+          "+Enter saves · Esc cancels</span>" +
           '<button type="button" class="ghost" id="blog-annot-cancel">Cancel</button>' +
           '<button type="button" class="primary" id="blog-annot-save">Save</button>' +
           "</div>"
       );
+
       var ta = document.getElementById("blog-annot-text");
       ta.focus();
-      document.getElementById("blog-annot-cancel").onclick = hideModal;
-      document.getElementById("blog-annot-save").onclick = function () {
+
+      var intent = DEFAULT_INTENT;
+      var chipBox = document.getElementById("blog-annot-intents");
+      chipBox.addEventListener("click", function (e) {
+        var hit = e.target.closest
+          ? e.target.closest("button[data-intent]")
+          : null;
+        if (!hit) return;
+        e.preventDefault();
+        intent = hit.getAttribute("data-intent");
+        var all = chipBox.querySelectorAll("button[data-intent]");
+        for (var i = 0; i < all.length; i++) {
+          all[i].setAttribute(
+            "aria-pressed",
+            all[i] === hit ? "true" : "false"
+          );
+        }
+        // Keep typing where the thumb left off.
+        ta.focus();
+      });
+
+      function save() {
         var list = loadBuffer();
         list.push({
           permalink: PERMALINK,
@@ -329,14 +465,20 @@
           prefix: sel_info.prefix,
           suffix: sel_info.suffix,
           comment: ta.value,
+          intent: intent,
           ts: new Date().toISOString(),
+          version: pageVersion(),
         });
         saveBuffer(list);
         refreshPill();
         hideModal();
         var s = window.getSelection();
         if (s && s.removeAllRanges) s.removeAllRanges();
-      };
+      }
+
+      document.getElementById("blog-annot-cancel").onclick = hideModal;
+      document.getElementById("blog-annot-save").onclick = save;
+      composerKeys = { save: save, cancel: hideModal };
     }
 
     // ---------------------------------------------------------- review flow
@@ -350,7 +492,9 @@
               return (
                 "<li><b>" +
                 (i + 1) +
-                ".</b> " +
+                ".</b> [" +
+                escapeHtml(a.intent || DEFAULT_INTENT) +
+                "] " +
                 escapeHtml(a.quote.slice(0, 90)) +
                 (a.quote.length > 90 ? "…" : "") +
                 "<br><i>" +
@@ -429,6 +573,10 @@
           title: TITLE,
           url: window.location.origin + window.location.pathname,
           created: new Date().toISOString(),
+          // Version of the page you happen to be on when you export. Each
+          // annotation carries its own `version` too — that is the one that
+          // matters, since the buffer can span posts and page loads.
+          version: pageVersion(),
           annotations: list,
         },
         null,

--- a/scripts/blog_review.py
+++ b/scripts/blog_review.py
@@ -24,6 +24,11 @@ useful, safe half; Igor reviews before anything is written.
 
 Auth: uses the ``gh`` CLI, so it inherits your existing GitHub login. No token
 is read from, or written to, this repo.
+
+Everything printed here is *untrusted text* — quotes and comments come from a
+web page and routinely contain ``[...]`` (markdown links, bracketed asides).
+Rich would parse those as console markup and raise ``MarkupError``, so every
+data-derived string goes through :func:`esc` before it reaches a console.
 """
 
 from __future__ import annotations
@@ -34,11 +39,13 @@ import re
 import subprocess
 import sys
 import unicodedata
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.markup import escape as esc
 from rich.table import Table
 
 app = typer.Typer(
@@ -56,6 +63,19 @@ CONTENT_DIRS = ("_d", "_td", "_posts", "_ig66", "_gascity")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+# One tap at annotation time; keep this list in sync with _includes/annotate.html.
+INTENTS = ("fix", "cut", "rewrite", "expand", "check", "question", "note")
+DEFAULT_INTENT = "note"
+INTENT_STYLE = {
+    "fix": "bold red",
+    "cut": "bold magenta",
+    "rewrite": "bold yellow",
+    "expand": "bold green",
+    "check": "bold blue",
+    "question": "bold cyan",
+    "note": "dim",
+}
+
 
 # --------------------------------------------------------------------------- gh
 def _gh(*args: str) -> str:
@@ -68,7 +88,9 @@ def _gh(*args: str) -> str:
         console.print("[red]gh CLI not found.[/red] Install it: https://cli.github.com")
         raise typer.Exit(1) from None
     if proc.returncode != 0:
-        console.print(f"[red]gh {' '.join(args)} failed:[/red] {proc.stderr.strip()}")
+        console.print(
+            f"[red]gh {esc(' '.join(args))} failed:[/red] {esc(proc.stderr.strip())}"
+        )
         raise typer.Exit(1)
     return proc.stdout
 
@@ -114,8 +136,8 @@ def load_batch(source: str) -> dict:
             entry = candidates[0]
         else:
             console.print(
-                f"[red]Gist {gist_id} has no {REVIEW_FILENAME}[/red] "
-                f"(files: {', '.join(files) or 'none'})"
+                f"[red]Gist {esc(gist_id)} has no {REVIEW_FILENAME}[/red] "
+                f"(files: {esc(', '.join(files)) or 'none'})"
             )
             raise typer.Exit(1)
 
@@ -183,21 +205,34 @@ def fuzzy_normalize(text: str) -> str:
 
 
 # ------------------------------------------------------------------ permalinks
-def permalink_index() -> dict[str, Path]:
-    """Map normalized permalink -> source markdown file."""
-    index: dict[str, Path] = {}
-    for directory in CONTENT_DIRS:
-        base = REPO_ROOT / directory
-        if not base.is_dir():
-            continue
-        for path in sorted(base.glob("*.md")):
-            permalink = _frontmatter_permalink(path)
-            if permalink:
-                index.setdefault(_norm_permalink(permalink), path)
-    return index
+#
+# A permalink is NOT the filename. `/timeoff-2026-07` lives in
+# `_d/time-off-2026-07.md`; `/23` lives in `_d/2023-year-in-review.md`. The only
+# authoritative mapping is the `permalink:` line in each post's frontmatter, so
+# that is what we index. Filename derivation is a *fallback*, used for the ~16
+# posts in `_d` that carry no explicit permalink and inherit `_config.yml`'s
+# `permalink: /:title` (Jekyll's `:title` is the filename slug, with any
+# `YYYY-MM-DD-` prefix stripped).
+
+_DATE_PREFIX_RE = re.compile(r"^\d{4}-\d{1,2}-\d{1,2}-")
 
 
-def _frontmatter_permalink(path: Path) -> str | None:
+def _norm_permalink(value: str) -> str:
+    return "/" + value.strip().strip("/").lower()
+
+
+def _squash(value: str) -> str:
+    """Loosened key: alphanumerics only.
+
+    Bridges the hyphenation gap between a permalink and its filename —
+    `/timeoff-2026-07` and `time-off-2026-07.md` both squash to
+    `timeoff202607`. Only ever consulted after the frontmatter index misses.
+    """
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _split_frontmatter(path: Path) -> str | None:
+    """Return the raw frontmatter block, or None if the file has none."""
     try:
         text = path.read_text(errors="replace")
     except OSError:
@@ -205,24 +240,211 @@ def _frontmatter_permalink(path: Path) -> str | None:
     if not text.startswith("---"):
         return None
     end = text.find("\n---", 3)
-    front = text[3 : end if end != -1 else 4000]
-    match = re.search(r"^permalink:\s*(.+?)\s*$", front, re.MULTILINE)
+    if end == -1:
+        # Unterminated frontmatter: cap the window so a stray `permalink:` deep
+        # in the body cannot masquerade as metadata.
+        return text[3:4000]
+    return text[3:end]
+
+
+def _frontmatter_permalink(front: str) -> str | None:
+    # `[ \t]*`, never `\s*`: `\s` matches newlines, so a greedy `\s*` on a
+    # valueless key silently swallows the line break and captures the NEXT
+    # key's text as this key's value.
+    match = re.search(r"^permalink:[ \t]*(.*?)[ \t]*$", front, re.MULTILINE)
     if not match:
         return None
-    return match.group(1).strip().strip("\"'")
+    value = match.group(1).strip().strip("\"'")
+    return value or None
 
 
-def _norm_permalink(value: str) -> str:
-    return "/" + value.strip().strip("/").lower()
+def _frontmatter_redirects(front: str) -> list[str]:
+    """`redirect_from:` as a scalar, a flow list, or a YAML block list.
+
+    Line-based on purpose: a regex over the whole block has to reason about
+    where the key's line ends, and getting that subtly wrong is how the first
+    cut of this function indexed 187 keys named ``/- /eu-2026``.
+    """
+    lines = front.splitlines()
+    for idx, line in enumerate(lines):
+        head = re.match(r"^redirect_from:[ \t]*(.*?)[ \t]*$", line)
+        if head:
+            break
+    else:
+        return []
+
+    inline = head.group(1).strip()
+    if inline and not inline.startswith("#"):
+        if inline.startswith("["):
+            body = inline.strip("[]")
+            return [v.strip().strip("\"'") for v in body.split(",") if v.strip()]
+        return [inline.strip("\"'")]
+
+    values: list[str] = []
+    for line in lines[idx + 1 :]:
+        if not line.strip():
+            break  # blank line ends the block
+        item = re.match(r"^\s*-[ \t]*(.*?)[ \t]*$", line)
+        if not item:
+            break  # a sibling key: the list is over
+        values.append(item.group(1).strip("\"'"))
+    return [v for v in values if v]
 
 
-def resolve_permalink(permalink: str, index: dict[str, Path]) -> Path | None:
-    key = _norm_permalink(permalink or "")
-    if key in index:
-        return index[key]
-    # /some-post/index.html, /some-post.html, trailing-slash variants
-    trimmed = re.sub(r"(?:/index)?\.html?$", "", key)
-    return index.get(trimmed)
+@dataclass
+class Resolution:
+    """Outcome of mapping one permalink onto a source file."""
+
+    path: Path | None
+    how: str = ""
+    reason: str = ""
+    suggestions: list[str] = field(default_factory=list)
+
+
+class PermalinkIndex:
+    """permalink -> source markdown, built from frontmatter.
+
+    Three layers, most-trusted first:
+
+    1. ``permalink:`` in frontmatter — authoritative.
+    2. ``redirect_from:`` aliases — the old URLs Jekyll still serves.
+    3. filename derivation — only for posts with no explicit permalink.
+    """
+
+    def __init__(self, root: Path = REPO_ROOT):
+        self.root = root
+        self.by_permalink: dict[str, Path] = {}
+        self.by_redirect: dict[str, Path] = {}
+        self.by_squashed: dict[str, Path] = {}
+        self.collisions: dict[str, list[Path]] = {}
+        self.files_scanned = 0
+        self.dirs_searched: list[str] = []
+        self.dirs_missing: list[str] = []
+        self._build()
+
+    def _build(self) -> None:
+        for directory in CONTENT_DIRS:
+            base = self.root / directory
+            if not base.is_dir():
+                self.dirs_missing.append(directory)
+                continue
+            self.dirs_searched.append(directory)
+            for path in sorted(base.glob("*.md")):
+                self.files_scanned += 1
+                front = _split_frontmatter(path)
+                permalink = _frontmatter_permalink(front) if front else None
+
+                if permalink:
+                    key = _norm_permalink(permalink)
+                    if key in self.by_permalink and self.by_permalink[key] != path:
+                        self.collisions.setdefault(
+                            key, [self.by_permalink[key]]
+                        ).append(path)
+                    else:
+                        self.by_permalink[key] = path
+
+                if front:
+                    for alias in _frontmatter_redirects(front):
+                        self.by_redirect.setdefault(_norm_permalink(alias), path)
+
+                # Filename derivation — Jekyll's `permalink: /:title` default.
+                stem = path.stem
+                for candidate in {stem, _DATE_PREFIX_RE.sub("", stem)}:
+                    self.by_squashed.setdefault(_squash(candidate), path)
+
+    # ------------------------------------------------------------------ lookup
+    def resolve(self, permalink: str) -> Resolution:
+        raw = permalink or ""
+        key = _norm_permalink(raw)
+        # /some-post/index.html, /some-post.html, trailing-slash variants
+        variants = [key, re.sub(r"(?:/index)?\.html?$", "", key)]
+
+        for variant in variants:
+            if variant in self.by_permalink:
+                return Resolution(self.by_permalink[variant], "frontmatter permalink")
+        for variant in variants:
+            if variant in self.by_redirect:
+                return Resolution(self.by_redirect[variant], "redirect_from alias")
+        for variant in variants:
+            hit = self.by_squashed.get(_squash(variant))
+            if hit is not None:
+                return Resolution(hit, "filename fallback")
+
+        return Resolution(
+            None,
+            "",
+            reason=f"no source file for permalink {raw!r}",
+            suggestions=self.near(key),
+        )
+
+    def near(self, key: str, n: int = 4) -> list[str]:
+        pool = list(self.by_permalink) + list(self.by_redirect)
+        close = difflib.get_close_matches(key, pool, n=n, cutoff=0.6)
+        if close:
+            return close
+        # Fall back to a squashed-prefix scan: catches `/timeoff-x` vs
+        # `/time-off-x` when SequenceMatcher's cutoff is unkind.
+        squashed = _squash(key)
+        return [p for p in pool if _squash(p).startswith(squashed[:8])][:n]
+
+    def describe(self) -> str:
+        dirs = ", ".join(self.dirs_searched) or "(none)"
+        return (
+            f"{len(self.by_permalink)} permalinks + {len(self.by_redirect)} redirects "
+            f"from {self.files_scanned} files in {dirs}"
+        )
+
+
+# --------------------------------------------------------------- git staleness
+def _git(*args: str) -> str | None:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def current_branch() -> str:
+    return _git("rev-parse", "--abbrev-ref", "HEAD") or "(unknown)"
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def staleness(path: Path, annotated_at: str | None) -> dict:
+    """Did the source file change after the annotation was written?
+
+    This is the honest per-post version signal: the site itself publishes no
+    build revision (see the module notes in ``_includes/annotate.html``), but
+    git knows exactly when this markdown last moved.
+    """
+    rel = str(path.relative_to(REPO_ROOT))
+    info: dict = {"file_last_commit": None, "dirty": False, "stale": False}
+
+    committed = _parse_iso(_git("log", "-1", "--format=%cI", "--", rel))
+    if committed:
+        info["file_last_commit"] = committed.isoformat()
+    porcelain = _git("status", "--porcelain", "--", rel)
+    info["dirty"] = bool(porcelain)
+
+    annotated = _parse_iso(annotated_at)
+    if annotated and committed and committed > annotated:
+        info["stale"] = True
+    return info
 
 
 # -------------------------------------------------------------------- locating
@@ -241,6 +463,16 @@ class Locator:
     offset in it back to a 1-based source line, so quotes that span a line
     break in the source still resolve.
     """
+
+    _cache: dict[Path, Locator] = {}
+
+    @classmethod
+    def for_path(cls, path: Path) -> Locator:
+        """One Locator per file — building the normalized doc is not free."""
+        hit = cls._cache.get(path)
+        if hit is None:
+            hit = cls._cache[path] = cls(path)
+        return hit
 
     def __init__(self, path: Path):
         self.path = path
@@ -403,6 +635,70 @@ class Locator:
         return Match(lineno, "approx", best_ratio, self.lines[lineno - 1].strip())
 
 
+# ---------------------------------------------------------- annotation helpers
+def annotation_intent(ann: dict) -> str:
+    """One-tap disposition. Unknown/absent values degrade to `note`."""
+    raw = str(ann.get("intent") or "").strip().lower()
+    return raw if raw in INTENTS else DEFAULT_INTENT
+
+
+def intent_markup(intent: str) -> str:
+    return f"[{INTENT_STYLE.get(intent, 'dim')}]{esc(intent)}[/]"
+
+
+def annotation_version(ann: dict, batch: dict) -> dict:
+    """What the page looked like when this note was written.
+
+    Newer clients attach a per-annotation `version` block; older batches have
+    only the batch-level `url`/`created`. Merge both so `show`/`locate` always
+    have *something* to print, and never claim a marker the payload lacks.
+    """
+    version = dict(ann.get("version") or {})
+    version.setdefault("url", ann.get("url") or batch.get("url") or "")
+    version.setdefault("capturedAt", ann.get("ts") or batch.get("created") or "")
+    return version
+
+
+def version_line(version: dict) -> str:
+    bits = []
+    if version.get("lastModified"):
+        bits.append(f"site build {esc(str(version['lastModified']))}")
+    if version.get("contentDigest"):
+        bits.append(f"content {esc(str(version['contentDigest']))}")
+    if version.get("contentLength"):
+        bits.append(f"{esc(str(version['contentLength']))} chars")
+    if not bits:
+        # Be explicit rather than silently implying we know the page version.
+        return "no page-version marker recorded (pre-version client)"
+    return " · ".join(bits)
+
+
+def batch_source_url(batch: dict) -> str:
+    url = batch.get("url") or ""
+    if url:
+        return url
+    permalink = batch.get("permalink") or ""
+    return f"https://idvork.in{permalink}" if permalink else ""
+
+
+def print_batch_header(batch: dict, annotations: list[dict]) -> None:
+    console.print(
+        f"[bold]{esc(batch.get('title') or '(untitled)')}[/bold]  "
+        f"[green]{esc(str(batch.get('permalink') or ''))}[/green]"
+    )
+    url = batch_source_url(batch)
+    if url:
+        console.print(f"[bold]source url:[/bold] [blue underline]{esc(url)}[/]")
+    console.print(
+        f"[dim]captured {esc(str(batch.get('created', '?')))} — "
+        f"{len(annotations)} notes[/dim]"
+    )
+    version = batch.get("version") or {}
+    if version:
+        console.print(f"[dim]page version: {version_line(version)}[/dim]")
+    console.print()
+
+
 # -------------------------------------------------------------------- commands
 @app.command("list")
 def list_reviews(
@@ -429,10 +725,10 @@ def list_reviews(
         )
         entry = (gist.get("files") or {}).get(REVIEW_FILENAME) or {}
         table.add_row(
-            gist.get("id", "?"),
-            permalink or "(unknown)",
-            str(entry.get("size", "?")) + "b",
-            (gist.get("updated_at") or "")[:19].replace("T", " "),
+            esc(str(gist.get("id", "?"))),
+            esc(permalink) or "(unknown)",
+            esc(str(entry.get("size", "?"))) + "b",
+            esc((gist.get("updated_at") or "")[:19].replace("T", " ")),
             "public" if gist.get("public") else "secret",
         )
     console.print(table)
@@ -445,25 +741,25 @@ def show(
     """Pretty-print one annotation batch."""
     batch = load_batch(source)
     annotations = batch.get("annotations") or []
-    console.print(
-        f"[bold]{batch.get('title') or '(untitled)'}[/bold]  "
-        f"[green]{batch.get('permalink')}[/green]"
-    )
-    if batch.get("url"):
-        console.print(f"[dim]{batch['url']}[/dim]")
-    console.print(
-        f"[dim]captured {batch.get('created', '?')} — {len(annotations)} notes[/dim]\n"
-    )
+    print_batch_header(batch, annotations)
 
     for i, ann in enumerate(annotations, start=1):
+        intent = annotation_intent(ann)
         console.print(
-            f"[bold cyan]{i}.[/bold cyan] [italic]{ann.get('quote', '')}[/italic]"
+            f"[bold cyan]{i}.[/bold cyan] {intent_markup(intent)}  "
+            f"[italic]{esc(ann.get('quote', ''))}[/italic]"
         )
-        console.print(f"   [white]{ann.get('comment') or '(no comment)'}[/white]")
+        console.print(f"   [white]{esc(ann.get('comment') or '(no comment)')}[/white]")
         ctx_prefix = (ann.get("prefix") or "").replace("\n", " ")
         ctx_suffix = (ann.get("suffix") or "").replace("\n", " ")
-        console.print(f"   [dim]…{ctx_prefix} ⟦quote⟧ {ctx_suffix}…[/dim]")
-        console.print(f"   [dim]{ann.get('ts', '')}[/dim]\n")
+        console.print(f"   [dim]…{esc(ctx_prefix)} ⟦quote⟧ {esc(ctx_suffix)}…[/dim]")
+        version = annotation_version(ann, batch)
+        console.print(
+            f"   [dim]{esc(str(ann.get('ts', '')))} · {version_line(version)}[/dim]"
+        )
+        if version.get("url"):
+            console.print(f"   [dim]{esc(str(version['url']))}[/dim]")
+        console.print()
 
 
 @app.command()
@@ -478,28 +774,48 @@ def locate(
     """
     batch = load_batch(source)
     annotations = batch.get("annotations") or []
-    index = permalink_index()
+    index = PermalinkIndex()
+    branch = current_branch()
 
     results = []
     for ann in annotations:
         permalink = ann.get("permalink") or batch.get("permalink") or ""
-        path = resolve_permalink(permalink, index)
-        if path is None:
+        intent = annotation_intent(ann)
+        version = annotation_version(ann, batch)
+        resolution = index.resolve(permalink)
+        if resolution.path is None:
             results.append(
                 {
                     "ok": False,
-                    "reason": f"no source file for permalink {permalink!r}",
+                    "kind": "unresolved-permalink",
+                    "permalink": permalink,
+                    "reason": resolution.reason,
+                    "searched": index.dirs_searched,
+                    "indexed": index.describe(),
+                    "branch": branch,
+                    "suggestions": resolution.suggestions,
+                    "intent": intent,
+                    "version": version,
                     "annotation": ann,
                 }
             )
             continue
-        match = Locator(path).locate(ann)
+        path = resolution.path
+        match = Locator.for_path(path).locate(ann)
+        stale = staleness(path, ann.get("ts") or batch.get("created"))
         if match is None:
             results.append(
                 {
                     "ok": False,
+                    "kind": "quote-not-found",
+                    "permalink": permalink,
                     "reason": "quote not found in source",
                     "file": str(path.relative_to(REPO_ROOT)),
+                    "resolved_via": resolution.how,
+                    "branch": branch,
+                    "intent": intent,
+                    "version": version,
+                    "staleness": stale,
                     "annotation": ann,
                 }
             )
@@ -507,20 +823,36 @@ def locate(
         results.append(
             {
                 "ok": True,
+                "permalink": permalink,
                 "file": str(path.relative_to(REPO_ROOT)),
                 "line": match.line,
                 "method": match.method,
                 "score": round(match.score, 3),
                 "source_line": match.text,
+                "resolved_via": resolution.how,
+                "intent": intent,
+                "version": version,
+                "staleness": stale,
                 "annotation": ann,
             }
         )
 
     if json_out:
         print(
-            json.dumps({"batch": batch.get("permalink"), "results": results}, indent=2)
+            json.dumps(
+                {
+                    "batch": batch.get("permalink"),
+                    "url": batch_source_url(batch),
+                    "branch": branch,
+                    "version": batch.get("version") or {},
+                    "results": results,
+                },
+                indent=2,
+            )
         )
         raise typer.Exit(0 if all(r["ok"] for r in results) else 2)
+
+    print_batch_header(batch, annotations)
 
     located = [r for r in results if r["ok"]]
     missing = [r for r in results if not r["ok"]]
@@ -529,21 +861,47 @@ def locate(
         table = Table(title=f"Located {len(located)}/{len(results)}", show_lines=True)
         table.add_column("#", justify="right", style="dim")
         table.add_column("file:line", style="cyan", no_wrap=True)
+        table.add_column("intent", no_wrap=True)
         table.add_column("how", no_wrap=True)
         table.add_column("comment", style="white")
         table.add_column("source line", style="dim")
         for i, r in enumerate(located, start=1):
-            how = r["method"]
-            if how in ("fuzzy", "approx"):
+            how = esc(r["method"])
+            if r["method"] in ("fuzzy", "approx"):
                 how = f"[yellow]{how} {r['score']}[/yellow]"
             table.add_row(
                 str(i),
-                f"{r['file']}:{r['line']}",
+                esc(f"{r['file']}:{r['line']}"),
+                intent_markup(r["intent"]),
                 how,
-                r["annotation"].get("comment") or "(no comment)",
-                r["source_line"][:120],
+                esc(r["annotation"].get("comment") or "(no comment)"),
+                esc(r["source_line"][:120]),
             )
         console.print(table)
+
+        vias = sorted({r["resolved_via"] for r in located})
+        console.print(f"[dim]resolved via: {esc(', '.join(vias))}[/dim]")
+
+        drifted = [r for r in located if r["staleness"]["stale"]]
+        dirty = [r for r in located if r["staleness"]["dirty"]]
+        if drifted:
+            console.print(
+                f"[yellow]⚠ {len(drifted)} note(s) predate the source file's last "
+                f"commit — anchors may have drifted:[/yellow]"
+            )
+            for r in drifted:
+                console.print(
+                    f"    [yellow]•[/yellow] {esc(r['file'])} committed "
+                    f"{esc(str(r['staleness']['file_last_commit']))} > annotated "
+                    f"{esc(str(r['annotation'].get('ts', '?')))}"
+                )
+        if dirty:
+            files = sorted({r["file"] for r in dirty})
+            console.print(
+                f"[yellow]⚠ uncommitted local changes in {esc(', '.join(files))} — "
+                f"line numbers reflect the working tree, not any published build."
+                f"[/yellow]"
+            )
 
     if missing:
         console.print(
@@ -551,11 +909,32 @@ def locate(
         )
         for r in missing:
             ann = r["annotation"]
-            console.print(f"  [red]•[/red] {r['reason']}")
+            console.print(f"  [red]•[/red] {esc(r['reason'])}")
+            if r["kind"] == "unresolved-permalink":
+                console.print(
+                    f"    searched : {esc(', '.join(r['searched']))} "
+                    f"({esc(r['indexed'])})"
+                )
+                console.print(f"    branch   : {esc(r['branch'])}")
+                if r["suggestions"]:
+                    console.print(f"    nearest  : {esc(', '.join(r['suggestions']))}")
+                console.print(
+                    "    [dim]No post on this checkout claims that permalink. The "
+                    "post may live on an unmerged branch — fetch it, check it out, "
+                    "and re-run.[/dim]"
+                )
+            else:
+                console.print(f"    file     : {esc(r['file'])}")
+                if r.get("staleness", {}).get("stale"):
+                    console.print(
+                        "    [yellow]the file was committed after this note was "
+                        "written — the quoted text was probably edited away.[/yellow]"
+                    )
+            console.print(f"    intent   : {intent_markup(r['intent'])}")
             console.print(
-                f"    quote: [italic]{(ann.get('quote') or '')[:160]}[/italic]"
+                f"    quote    : [italic]{esc((ann.get('quote') or '')[:160])}[/italic]"
             )
-            console.print(f"    note : {ann.get('comment') or '(no comment)'}")
+            console.print(f"    note     : {esc(ann.get('comment') or '(no comment)')}")
         raise typer.Exit(2)
 
     if not results:
@@ -565,7 +944,8 @@ def locate(
 if __name__ == "__main__":
     if not (REPO_ROOT / "_config.yml").exists():
         console.print(
-            f"[red]Expected a Jekyll repo root at {REPO_ROOT} (no _config.yml).[/red]"
+            f"[red]Expected a Jekyll repo root at {esc(str(REPO_ROOT))} "
+            f"(no _config.yml).[/red]"
         )
         sys.exit(1)
     app()

--- a/test_blog_review.py
+++ b/test_blog_review.py
@@ -1,0 +1,173 @@
+# test_blog_review.py
+"""Regression tests for scripts/blog_review.py.
+
+Run: uv run --with pytest --with typer --with rich pytest test_blog_review.py
+
+The crash these guard against was real: a review batch containing the sentence
+"For context on why I take time off: /time-off." killed the whole CLI with
+``MarkupError: closing tag '[/time-off]' ...`` because the markdown link's
+rendered form still reads as rich console markup.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "blog_review", REPO_ROOT / "scripts" / "blog_review.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["blog_review"] = module  # dataclasses needs the module registered
+    spec.loader.exec_module(module)
+    return module
+
+
+br = _load()
+
+
+# --------------------------------------------------------------- rich markup
+MARKUP_LANDMINES = [
+    "For context on why I take time off: /time-off.",  # the original crash
+    "[/close] with no opening tag",
+    "[red]unbalanced[/blue]",
+    "see [1] and [2]",
+    "[[wiki style]]",
+]
+
+
+@pytest.mark.parametrize("text", MARKUP_LANDMINES)
+def test_every_render_path_escapes_markup(text, capsys):
+    """No console path may hand annotation text to rich unescaped."""
+    batch = {
+        "permalink": "/timeoff-2026-07",
+        "title": text,
+        "url": "https://idvork.in/timeoff-2026-07",
+        "created": "2026-08-04T15:15:15.149Z",
+        "annotations": [
+            {
+                "permalink": "/timeoff-2026-07",
+                "quote": text,
+                "prefix": text,
+                "suffix": text,
+                "comment": text,
+                "intent": "note",
+                "ts": "2026-08-04T15:12:53.429Z",
+            }
+        ],
+    }
+    br.print_batch_header(batch, batch["annotations"])
+    out = capsys.readouterr().out
+    # Rendered literally, not swallowed as a style tag.
+    assert text.split()[0] in out
+
+
+def test_unlocated_report_escapes_markup(capsys):
+    console = br.console
+    console.print(f"  [red]•[/red] {br.esc('[/time-off] [bold]x')}")
+    assert "[/time-off]" in capsys.readouterr().out
+
+
+# ------------------------------------------------------------- frontmatter
+def test_permalink_is_not_derived_from_the_url():
+    """`/timeoff-2026-07` lives in `_d/time-off-2026-07.md` — different string."""
+    index = br.PermalinkIndex(REPO_ROOT)
+    hit = index.resolve("/timeoff-2026-07")
+    assert hit.path is not None
+    assert hit.path.name == "time-off-2026-07.md"
+    assert hit.how == "frontmatter permalink"
+
+
+def test_redirect_from_aliases_resolve():
+    index = br.PermalinkIndex(REPO_ROOT)
+    hit = index.resolve("/eu-2026")
+    assert hit.path is not None and hit.path.name == "time-off-2026-07.md"
+    assert hit.how == "redirect_from alias"
+
+
+def test_unknown_permalink_reports_rather_than_guessing():
+    index = br.PermalinkIndex(REPO_ROOT)
+    hit = index.resolve("/definitely-not-a-post-on-this-branch")
+    assert hit.path is None
+    assert "definitely-not-a-post" in hit.reason
+    assert index.dirs_searched  # the report can say where it looked
+
+
+def test_redirect_block_list_parsing():
+    front = (
+        "\nlayout: post\npermalink: /timeoff-2026-07\n"
+        "redirect_from:\n  - /eu-2026\n  - /europe-2026\ntags:\n  - travel\n"
+    )
+    assert br._frontmatter_permalink(front) == "/timeoff-2026-07"
+    # Must stop at `tags:`, and must not fold the key's newline into the value.
+    assert br._frontmatter_redirects(front) == ["/eu-2026", "/europe-2026"]
+
+
+def test_redirect_scalar_and_flow_forms():
+    assert br._frontmatter_redirects("\nredirect_from: /solo\n") == ["/solo"]
+    assert br._frontmatter_redirects("\nredirect_from: [/a, /b]\n") == ["/a", "/b"]
+    assert br._frontmatter_redirects("\ntitle: x\n") == []
+
+
+def test_valueless_key_does_not_swallow_the_next_line():
+    assert br._frontmatter_permalink("\npermalink:\nlayout: post\n") is None
+
+
+# ------------------------------------------------------------------- intent
+def test_intent_defaults_and_validates():
+    assert br.annotation_intent({}) == "note"
+    assert br.annotation_intent({"intent": "REWRITE"}) == "rewrite"
+    assert br.annotation_intent({"intent": "not-an-intent"}) == "note"
+    for name in br.INTENTS:
+        assert br.annotation_intent({"intent": name}) == name
+
+
+# ------------------------------------------------------------------ version
+def test_version_falls_back_to_batch_url_and_says_when_absent():
+    batch = {
+        "url": "https://idvork.in/timeoff-2026-07",
+        "created": "2026-01-01T00:00:00Z",
+    }
+    version = br.annotation_version({"ts": "2026-02-02T00:00:00Z"}, batch)
+    assert version["url"] == "https://idvork.in/timeoff-2026-07"
+    assert version["capturedAt"] == "2026-02-02T00:00:00Z"
+    # Never imply we know a page version the payload never carried.
+    assert "no page-version marker" in br.version_line(version)
+
+
+def test_version_line_reports_recorded_markers():
+    line = br.version_line(
+        {
+            "lastModified": "08/04/2026 08:10:48",
+            "contentDigest": "1cbb510f",
+            "contentLength": 12854,
+        }
+    )
+    assert "08/04/2026 08:10:48" in line and "1cbb510f" in line and "12854" in line
+
+
+def test_batch_source_url_is_always_echoed():
+    assert br.batch_source_url({"url": "https://idvork.in/x"}) == "https://idvork.in/x"
+    assert br.batch_source_url({"permalink": "/x"}) == "https://idvork.in/x"
+
+
+# ----------------------------------------------------------------- locating
+def test_locates_a_markdown_link_line():
+    index = br.PermalinkIndex(REPO_ROOT)
+    path = index.resolve("/timeoff-2026-07").path
+    match = br.Locator.for_path(path).locate(
+        {
+            "quote": "For context on why I take time off: /time-off.\n\n",
+            "prefix": ", and a live weather table.\n\n\n",
+            "suffix": "Why I’m taking this time off —",
+        }
+    )
+    assert match is not None
+    assert "/time-off" in path.read_text().splitlines()[match.line - 1]


### PR DESCRIPTION
Follow-up to #783 (already merged). Driven by a real review batch you shipped —
gist `227eeea6467d24524549d4ba9536ac07`, 6 notes on `/timeoff-2026-07` — which
crashed the CLI outright.

## The crash

```
MarkupError: closing tag '[/time-off]' at position 36 doesn't match any open tag
```

Your note quoted "For context on why I take time off: /time-off." — the
rendered form of a markdown link. Rich reads `[/time-off]` as a closing style
tag. **Any** annotation quoting a link killed the tool.

## Fixes

**1 — Escape everywhere.** Every console/table path now goes through
`rich.markup.escape`: `list`, `show`, `locate`'s table, the UNLOCATED report,
and the `gh`-failure message. Audited, not just the one that blew up.

**2 — Permalink → file.** `/timeoff-2026-07` is not `timeoff-2026-07.md`; it's
`_d/time-off-2026-07.md`. Resolution is now an explicit three-layer index:

| layer | source | example |
| --- | --- | --- |
| 1 | `permalink:` frontmatter (authoritative) | `/timeoff-2026-07` → `_d/time-off-2026-07.md` |
| 2 | `redirect_from:` aliases | `/eu-2026` → same file |
| 3 | filename derivation (fallback only) | `/software-rot` → `_d/2017-09-10-software-rot.md` |

Layer 3 covers the ~16 `_d` posts with no explicit permalink that inherit
`_config.yml`'s `permalink: /:title`, and squashes punctuation so a hyphenation
mismatch still lands. Current index: **291 permalinks + 376 redirects across 442
files, 0 collisions**.

Frontmatter scanning is line-based now. The old `^key:\s*(.+?)\s*$` pattern let
`\s` eat the newline, so a valueless key captured the *next* line's text — the
first cut of the redirect parser indexed 187 keys literally named `/- /eu-2026`
before this was caught.

**3 — Post not on this branch.** Unresolvable permalinks now say so:

Real output, annotating `/clowns` (which lives on the unmerged `clowns-post`
branch) from a checkout of `main`:

```
UNLOCATED (1) — do not guess:
  • no source file for permalink '/clowns'
    searched : _d, _td, _posts, _ig66, _gascity (291 permalinks + 376 redirects
from 442 files in _d, _td, _posts, _ig66, _gascity)
    branch   : fix/blog-annotate-locator
    nearest  : /claws, /slow, /claw, /chow
    No post on this checkout claims that permalink. The post may live on an
unmerged branch — fetch it, check it out, and re-run.
    intent   : note
    quote    : clowns
    note     : post lives on the clowns-post branch
```

## Features

**4 — Cmd/Ctrl+Enter submits.** You asked for this *in* the review (note 3).
Cmd+Enter on mac, Ctrl+Enter elsewhere; Escape cancels; Save button unchanged.
The handler is document-level and gated on an open composer, so it fires with
focus anywhere (textarea, an intent chip) and is inert the rest of the time.
The composer shows `⌘+Enter saves · Esc cancels`.

**5 — Intent, one tap.** Seven chips: `fix` / `cut` / `rewrite` / `expand` /
`check` / `question` / `note`, default `note`. Persisted as `"intent"` on each
annotation and surfaced as a column in `locate` and a colored tag in `show`.
Rationale is yours: "this is wordy" is ambiguous between cut, rewrite and idle
observation, and phone annotation produces terse comments. Deliberately **no**
freeform per-note agent instructions — prose turns annotating into
prompt-writing.

**6 — Version capture + URL echo.**

`locate` and `show` now print the source URL being parsed.

For the version marker I checked what the site actually emits before writing
anything. **Findings, all negative:**

- **No `last_modified_at` frontmatter** — 0 of 266 `_d/*.md` have it.
- **No `site.github.build_revision`** — `_config.yml` loads only
  `jekyll-redirect-from` and `jekyll-paginate`, and nothing in `_layouts/` or
  `_includes/` references `site.github.*`.
- **No revision/generator/version meta tag** in the served HTML (checked the
  live page, not just the source).
- **GitHub Pages `Last-Modified` is real but site-wide.** The header exists and
  the browser exposes it as `document.lastModified` — but it is the *site deploy*
  time, byte-identical across pages. Verified: `/timeoff-2026-07`, `/22` and
  `/40yo` all returned `Tue, 04 Aug 2026 15:10:48 GMT`. It identifies the build,
  not the post.

**So the site publishes no per-post version marker, and this PR does not invent
one.** What each annotation records instead:

```json
"version": {
  "url": "https://idvork.in/timeoff-2026-07",
  "capturedAt": "2026-08-04T15:12:53.429Z",
  "lastModified": "08/04/2026 08:10:48",
  "contentLength": 12854,
  "contentDigest": "1cbb510f"
}
```

`lastModified` is the genuine deploy stamp (coarse). `contentLength` +
`contentDigest` (FNV-1a over the rendered article text) are exact and per-post,
derived from the bytes you actually annotated. On the CLI side `locate` adds the
per-post signal git already knows — whether the markdown was committed after the
note was written:

```
⚠ 2 note(s) predate the source file's last commit — anchors may have drifted:
    • _d/time-off-2026-07.md committed 2026-08-03T16:16:06+00:00 > annotated 2020-01-01T…
```

**Limitation to state plainly:** for batches captured before this PR there is no
version marker at all, and the output says exactly that rather than implying
otherwise (`no page-version marker recorded (pre-version client)`). And
`lastModified` cannot distinguish two different posts within one deploy — the
digest and the git check are what actually carry per-post staleness.

## Verification

The failing gist, end to end:

```
$ ./scripts/blog_review.py locate 227eeea6467d24524549d4ba9536ac07
Time off July 2026 - Scandinavian Whirlwind Tour  /timeoff-2026-07
source url: https://idvork.in/timeoff-2026-07
captured 2026-08-04T15:15:15.149Z — 6 notes

                            Located 6/6
 # │ file:line                  │ intent │ how   │ comment
───┼────────────────────────────┼────────┼───────┼──────────────────────────────
 1 │ _d/time-off-2026-07.md:61  │ note   │ exact │ What is diff betweent his …
 2 │ _d/time-off-2026-07.md:35  │ note   │ quote │ make this esummarize
 3 │ _d/time-off-2026-07.md:33  │ note   │ quote │ make C-Enter/Command-Enter …
 4 │ _d/time-off-2026-07.md:47  │ note   │ quote │ Merget this into point3 …
 5 │ _d/time-off-2026-07.md:219 │ note   │ exact │ What the heck is this …
 6 │ _d/time-off-2026-07.md:229 │ note   │ exact │ Don't I earlay have this …

resolved via: frontmatter permalink
$ echo $?
0
```

All six lines spot-checked against the source: 33 is the trip-map blockquote, 35
the `/time-off` link, 47 the "But it turns out" paragraph, 61 `## How it actually
went`, 219 `## How I tried to do this trip`, 229 `## Related`.

- **21 browser assertions** — Playwright/Chromium driving the real
  `_includes/annotate.html` (Liquid substituted, script untouched): chips render,
  default is `note`, Ctrl+Enter and Meta+Enter both save, Escape discards from
  textarea *and* from a chip, Save button still works, keys inert when closed,
  `intent`+`version` land in the buffer, and a reader with the flag off still
  sees no UI.
- **17 pytest regressions** in `test_blog_review.py`, including the five markup
  landmines that used to crash.
- `prek` green on all changed files; `just fast-test` 259 passed.

## Notes

- The six notes themselves are editorial asks about `/timeoff-2026-07`; this PR
  is tooling only and changes no post content.
- `_d/` untouched, so no backlinks rebuild and no prettier over `_d/`.
