### PR TITLE
Apply review feedback to /timeoff-2026-07

### DIFF
--- a/_d/time-off-2026-07.md
+++ b/_d/time-off-2026-07.md
@@ -32,7 +32,7 @@ INSTRUCTIONS FOR CLAUDE — recap status (2026-08-03, rev 3)
 
 > 🗺️ **Trip map & city guide:** [Scandinavian Whirlwind 2026 →](https://idvorkin-ai-tools.github.io/scandinavia-2026/) — one page per stop (Iceland → Copenhagen → Stockholm → Oslo → fjords → Amsterdam), with things to do, hours, and a live weather table.
 
-For context on why I take time off: [/time-off](/time-off).
+For context on why I take time off: [time off is a skill](/time-off) — vegetating _feels_ like rest while it quietly starves the roles that make you _you_, so I keep the habits and re-stack the roles work leaves hungry.
 
 ## Why I'm taking this time off — ranked
 
@@ -42,9 +42,7 @@ I wrote down what I'm actually here for, in order — and then the trip rearrang
 
 1. **Deepen my relationship with Amelia and Tori** — quality time over mere presence.
 2. **Really meet whoever we're traveling with** — I put reasonable odds our kids end up woven into each other's lives for a long while. Good chance to say hello.
-3. **Escape.**
-
-**But it turns out** — on #3, I had nothing to escape from. Amazingly, no work stress and no PSC stress: for once my [body was home and my mind stayed home too](/mind-at-work). Work boxed itself this time — I'd just moved to an IC role at [Meta's AI Lab](/meta#moving-to-metas-ai-lab-2026), so there were no calibrations to sweat and the old [Calibration Collapse](/y26) trap never fired. Take away the consuming and there was simply nothing left to run from.
+3. **Escape** — except it turned out I had nothing to escape from. Amazingly, no work stress and no PSC stress: for once my [body was home and my mind stayed home too](/mind-at-work). Work boxed itself this time — I'd just moved to an IC role at [Meta's AI Lab](/meta#moving-to-metas-ai-lab-2026), so there were no calibrations to sweat and the old [Calibration Collapse](/y26) trap never fired. Take away the consuming and there was simply nothing left to run from.
 
 **What I didn't expect:**
 
@@ -57,6 +55,16 @@ I wrote down what I'm actually here for, in order — and then the trip rearrang
 <!-- prettier-ignore-end -->
 
 4 and 5 are the interesting ones, and they're linked: the one real sacrifice I've made to AI is that the [Dealer of Smiles and Wonder](/joy) just stopped showing up. Out here, with the screens quiet, he walked right back in — the guy underneath was someone I'd been missing.
+
+## How I tried to do this trip
+
+One rule underneath all of it: [be where my feet are](/awareness). Three tests kept me honest —
+
+1. **Whose role does it grow?** Drift on a trip flows toward what you're already good at — work, optimizing, the phone. Spend the days on the open rooms: the kids, wonder, Tori. Not the finished ones.
+2. **Build vs. use?** Researching the perfect restaurant isn't eating the meal. Optimizing the trip isn't living it.
+3. **When?** Anything that pulls me out of the moment — phone, work email, even shooting everything through a camera — lives in the margins. The awake hours belong to the people I'm with.
+
+The sharpest test was how I used AI on the road. I wrote that one up on its own: [my AI policy](/ai-policy). And when I did reach back to the dev box, physics sent a bill: [the speed of light shows up as a number](/life-journal#speed-of-light-from-sweden) — ~170 ms across the Atlantic.
 
 ## How it actually went
 
@@ -215,19 +223,5 @@ _From the plan — the Timeline doesn't show these:_ renting bikes, the Anne Fra
 {% include repo_image.html src="timeline-2026-07-19-flight-home.webp" %}
 
 _And the Timeline for Sun Jul 19 — the long hop home._
-
-## How I tried to do this trip
-
-One rule underneath all of it: [be where my feet are](/awareness). Three tests kept me honest —
-
-1. **Whose role does it grow?** Drift on a trip flows toward what you're already good at — work, optimizing, the phone. Spend the days on the open rooms: the kids, wonder, Tori. Not the finished ones.
-2. **Build vs. use?** Researching the perfect restaurant isn't eating the meal. Optimizing the trip isn't living it.
-3. **When?** Anything that pulls me out of the moment — phone, work email, even shooting everything through a camera — lives in the margins. The awake hours belong to the people I'm with.
-
-The sharpest test was how I used AI on the road. I wrote that one up on its own: [my AI policy](/ai-policy). And when I did reach back to the dev box, physics sent a bill: [the speed of light shows up as a number](/life-journal#speed-of-light-from-sweden) — ~170 ms across the Atlantic.
-
-## Related
-
-{% include summarize-page.html src="/time-off" %}
 
 _Started ~6 weeks pre-trip; the recap sections were written on the road, and the place lists were trued up afterward against my Google Maps Timeline. Back home Jul 19._


### PR DESCRIPTION
Applies your six annotations from the review gist to `_d/time-off-2026-07.md`. **Four were actionable; two were questions I answered without editing.** Net **-6 lines**.

### Edited

**1. "make this summarize"** (top-of-post `/time-off` pointer)
Replaced the bare pointer with a one-line summary of what `/time-off` actually argues, keeping the link:

> For context on why I take time off: [time off is a skill](/time-off) — vegetating _feels_ like rest while it quietly starves the roles that make you _you_, so I keep the habits and re-stack the roles work leaves hungry.

Drawn from that post's own thesis (time off as a skill; the produce/consume trap; "Re-stack your roles"). It also foreshadows this post's #4/#5 — the starved Joy Giver coming back.

**2. "Merge this into point3, look in a render to see how it currently looks weird"**
Looked at the render first. The weirdness: item 3 was a one-word `<li>` — **Escape.** — with all its meaning stranded in a separate `<p>` *outside* the `<ol>`, which then had to say "on #3" to point back:

```html
<li><strong>Escape.</strong></li>
</ol>
<p><strong>But it turns out</strong> — on #3, I had nothing to escape from…</p>
```

Folded the paragraph into item 3 so it carries its own payload and matches the em-dash shape of items 1 and 2. The "#3" back-reference is gone, and the list now reads as a clean 1-2-3 / 4-5 pair.

**3. "What the heck is this - wrong spot, should it be anywhere"** (`## How I tried to do this trip`)
Wrong spot: yes. Should it exist: yes — it's the only place the three tests, `/awareness`, `/ai-policy`, and the speed-of-light link live. It was stranded at the very end, after ~100 lines of place lists and Timeline screenshots. **Moved it up to sit directly after "Why I'm taking this time off"**, so the arc is why → how I tried → how it actually went. Text unchanged; the `#how-i-tried-to-do-this-trip` anchor is unchanged and nothing linked to it.

**4. "Don't I already have this linked at the top?"** (`## Related`)
Yes — genuine duplicate. `/time-off` appeared exactly twice in the post: the top pointer and this section, whose only content was a `summarize-page` card for that same page. Since the top line now *is* a summary of `/time-off`, the section was pure redundancy. **Removed.** The auto "Mentioned in" backlinks widget is separate and untouched.

### Answered, no change

**5. "What is diff between this and the where we went section? Should they merge?"**
**Not merged — they're doing different jobs:**

- `## How it actually went` is the **narrative** — five selected moments with reflection and outbound links (the pools, Skansen + the Frankl beat, the train tech-bender, the fjord, the LinkedIn habit loop).
- `## Where we went (by leg)` is the **ledger** — the complete, evidence-checked record of all 8 legs, cross-checked against Google Maps Timeline, with unresolved *From the plan* lines and per-leg Timeline strips.

They're already de-duplicated by design: the ledger bullets say "(full story above)" rather than retelling. The `INSTRUCTIONS FOR CLAUDE` block at the top of the file also defines the ledger as a maintained artifact with its own rules about not promoting/deleting *From the plan* lines. Merging would either flatten the narrative or bloat the ledger.

That said — the reason the question came up is probably that **the two headings sound alike**. If you want, a one-word sharpening ("How it actually went" → "The moments that stuck", or "Where we went (by leg)" → "The full record (by leg)") would fix the ambiguity without restructuring. I left the headings alone since you didn't ask for a rename and they carry live anchors from `/changelog`.

**6. "make C-Enter/Command-Enter complete a comment"**
Not a post edit — this is a feature request for the annotation tool that got captured as a post annotation. Already shipped in #787. No action here.

### Notes

- Body-only edit with no link-set change, so `back-links.json` was deliberately not rebuilt (the pre-commit hook's rewrite was reverted).
- `anchor-checker` flags one broken anchor, `_d/changelog.md:186` → `/ai-inference#the-model-itself` — pre-existing on `main`, unrelated to this change.
- A repo-wide `js-test`/`fast-test` vitest recipe fails on this branch; no JS/TS files were touched here, so it's independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ADTbzjC1eLz8tuTY9vQRi